### PR TITLE
feat(managed-agents): wire real SDK calls into ForensicAgent/Session

### DIFF
--- a/src/black_box/analysis/managed_agent.py
+++ b/src/black_box/analysis/managed_agent.py
@@ -1,45 +1,45 @@
 """Managed Agents integration for long-horizon bag replay.
 
-This module is a SKELETON intended for the "Best use of Managed Agents"
-prize track. It maps the Managed Agents primitives (beta
-``managed-agents-2026-04-01``, https://platform.claude.com/docs/en/managed-agents/overview)
-onto Black Box's forensic workflow:
+Real wiring against ``anthropic>=0.96`` beta ``managed-agents-2026-04-01``:
 
-    * **Agent**       -> ``ForensicAgentConfig`` (model + system prompt +
-                         built-in tools + optional MCP servers + skills).
-    * **Environment** -> container template with the uploaded bag mounted at
-                         ``/mnt/bag`` and the user's source tree mounted
-                         read-only so the agent can grep/read code.
-    * **Session**     -> ``ForensicSession``: a single running instance bound
-                         to one incident (``case_key``).
-    * **Events**      -> the ``stream()`` iterator surfaces user turns, tool
-                         results, and status updates for the UI to render.
-    * **Steering**    -> ``steer()`` posts an additional user event mid-run
-                         without restarting the agent, e.g. to focus on a
-                         narrower time window.
-    * **Outcomes**    -> ``finalize()`` collects the structured
-                         PostMortemReport (research preview feature).
+    * **Agent**       -> ``client.beta.agents.create``
+    * **Environment** -> ``client.beta.environments.create``  (cloud config)
+    * **Files**       -> ``client.beta.files.upload`` (bag, artefacts) then
+                         referenced from the Session as ``file`` resources.
+    * **Session**     -> ``client.beta.sessions.create`` (agent+env+resources)
+    * **Events**      -> ``client.beta.sessions.events.stream`` (live) with
+                         ``.list`` fallback; ``events.send`` for steering.
+    * **Outcomes**    -> final ``agent.message`` event parsed as JSON and
+                         validated against ``PostMortemReport``.
 
-Rate limits (from docs, respected by the retry layer we still have to
-build): 60 create/min, 600 read/min.
+Rate limits per docs: 60 create/min, 600 read/min -> tiny local throttle.
 
-Usage sketch::
+Usage::
 
     agent = ForensicAgent(ForensicAgentConfig(task_budget_minutes=15))
     session = agent.open_session(bag_path=Path("/mnt/bag"), case_key="crash_001")
     for event in session.stream():
-        ui.push(event)                         # reasoning / tool-call / output
+        ui.push(event)
     session.steer("focus on the 12s-15s window, ignore earlier")
-    report = session.finalize()                # -> PostMortemReport
-
-All real HTTP calls are intentionally absent: this file defines the
-shape the rest of the codebase will depend on once the beta SDK lands.
+    report = session.finalize()
 """
 from __future__ import annotations
 
+import json
+import os
+import threading
+import time
+from collections import deque
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator, Literal
+from typing import Iterable, Iterator, Literal
+
+from anthropic import Anthropic
+from pydantic import ValidationError
+
+from .schemas import PostMortemReport
+
 
 # ---------------------------------------------------------------------------
 # Beta handshake
@@ -47,9 +47,9 @@ from typing import Iterator, Literal
 ANTHROPIC_BETA_HEADER = "managed-agents-2026-04-01"
 MODEL = "claude-opus-4-7"
 
-# Built-in tool identifiers advertised by the Managed Agents platform.
-# (Bash, file ops, web search/fetch, MCP bridge.) We enable the subset
-# that forensic replay actually needs.
+# Logical tool names we care about; mapped to the SDK's closed set when
+# building agent tool configs. SDK tools as of 2026-04-01:
+#   bash, edit, read, write, glob, grep, web_fetch, web_search
 BUILTIN_TOOLS: tuple[str, ...] = (
     "bash",
     "file_read",
@@ -62,21 +62,31 @@ BUILTIN_TOOLS: tuple[str, ...] = (
     "mcp",
 )
 
+_TOOL_ALIASES: dict[str, str] = {
+    "bash": "bash",
+    "file_read": "read",
+    "file_write": "write",
+    "file_edit": "edit",
+    "file_glob": "glob",
+    "file_grep": "grep",
+    "web_search": "web_search",
+    "web_fetch": "web_fetch",
+}
+
+_SDK_TOOL_NAMES: frozenset[str] = frozenset(
+    {"bash", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search"}
+)
+
 
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 @dataclass
 class ForensicAgentConfig:
-    """Declarative spec for the forensic Agent + its Environment.
-
-    Fields map 1:1 onto the managed-agents create-agent / create-environment
-    request bodies.
-    """
+    """Declarative spec for the forensic Agent + its Environment."""
 
     task_budget_minutes: int = 15
     model: str = MODEL
-    # TODO(managed-agents): pull the real post-mortem prompt from prompts.py
     system_prompt: str = (
         "You are Black Box, a forensic copilot for robot incidents. "
         "Use the mounted bag at /mnt/bag and the source tree at /mnt/src "
@@ -87,82 +97,513 @@ class ForensicAgentConfig:
     skills: list[str] = field(default_factory=list)          # e.g. ["ros-bag-decoder"]
     mounted_files: list[Path] = field(default_factory=list)  # bag, source tree
     network: Literal["none", "egress_only"] = "egress_only"
-    # Container image template name on the managed-agents side.
     environment_template: str = "python-3.11-ros-tools"
+    agent_name: str = "black-box-forensic"
+
+
+# ---------------------------------------------------------------------------
+# Rate limit throttle (60 create/min, 600 read/min)
+# ---------------------------------------------------------------------------
+class _RateLimiter:
+    """Sliding-window limiter. One-per-process; guarded by a lock."""
+
+    def __init__(self, max_per_window: int, window_seconds: float = 60.0) -> None:
+        self._max = max_per_window
+        self._window = window_seconds
+        self._events: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        with self._lock:
+            now = time.monotonic()
+            cutoff = now - self._window
+            while self._events and self._events[0] < cutoff:
+                self._events.popleft()
+            if len(self._events) >= self._max:
+                sleep_for = self._events[0] + self._window - now
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+                    now = time.monotonic()
+                    cutoff = now - self._window
+                    while self._events and self._events[0] < cutoff:
+                        self._events.popleft()
+            self._events.append(now)
+
+
+_CREATE_LIMITER = _RateLimiter(max_per_window=60)
+_READ_LIMITER = _RateLimiter(max_per_window=600)
+
+
+# ---------------------------------------------------------------------------
+# Cost logging (re-uses data/costs.jsonl from claude_client)
+# ---------------------------------------------------------------------------
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    return Path.cwd()
+
+
+def _costs_file() -> Path:
+    root = _find_repo_root()
+    costs_dir = root / "data"
+    costs_dir.mkdir(parents=True, exist_ok=True)
+    return costs_dir / "costs.jsonl"
+
+
+_PRICING = {
+    "input": 15.0,
+    "cache_write": 18.75,
+    "cache_read": 1.50,
+    "output": 75.0,
+}
+
+
+def _append_cost_entry(entry: dict) -> None:
+    path = _costs_file()
+    with open(path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _wrap_call(endpoint: str, fn, *args, **kwargs):
+    try:
+        return fn(*args, **kwargs)
+    except Exception as exc:  # narrow re-raise with context
+        raise RuntimeError(f"managed-agents {endpoint} failed: {exc}") from exc
+
+
+def _event_timestamp(event) -> float:
+    ts = getattr(event, "processed_at", None)
+    if isinstance(ts, datetime):
+        return ts.timestamp()
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    return time.time()
+
+
+_TERMINAL_EVENT_TYPES: frozenset[str] = frozenset(
+    {"session.status_idle", "session.status_terminated", "session.deleted"}
+)
+
+
+def _normalize_event(event) -> dict:
+    """Translate an SDK event object into the UI-facing shape."""
+    etype = getattr(event, "type", "unknown")
+    ts = _event_timestamp(event)
+
+    if etype == "agent.thinking":
+        kind = "reasoning"
+        payload = {"id": getattr(event, "id", None)}
+    elif etype == "agent.message":
+        kind = "assistant"
+        payload = {
+            "id": getattr(event, "id", None),
+            "text": _extract_text(getattr(event, "content", None)),
+        }
+    elif etype in ("agent.tool_use", "agent.mcp_tool_use", "agent.custom_tool_use"):
+        kind = "tool_call"
+        payload = {
+            "id": getattr(event, "id", None),
+            "name": getattr(event, "name", None),
+            "input": getattr(event, "input", None),
+        }
+    elif etype in ("agent.tool_result", "agent.mcp_tool_result"):
+        kind = "tool_result"
+        payload = {
+            "id": getattr(event, "id", None),
+            "tool_use_id": getattr(event, "tool_use_id", None),
+            "is_error": getattr(event, "is_error", None),
+            "text": _extract_text(getattr(event, "content", None)),
+        }
+    elif etype.startswith("session.status_") or etype == "session.error":
+        kind = "status"
+        state = etype.replace("session.status_", "").replace("session.", "")
+        payload = {"state": state}
+        stop = getattr(event, "stop_reason", None)
+        if stop is not None:
+            payload["stop_reason"] = getattr(stop, "type", str(stop))
+    else:
+        kind = "status"
+        payload = {"state": etype}
+
+    return {"type": kind, "ts": ts, "payload": payload}
+
+
+def _extract_text(content) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    parts: list[str] = []
+    try:
+        iterator: Iterable = content  # type: ignore[assignment]
+    except TypeError:
+        return str(content)
+    for block in iterator:
+        text = getattr(block, "text", None)
+        if text is None and isinstance(block, dict):
+            text = block.get("text")
+        if text:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _strip_json_fences(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```json"):
+        text = text[7:]
+    elif text.startswith("```"):
+        text = text[3:]
+    if text.endswith("```"):
+        text = text[:-3]
+    return text.strip()
+
+
+def _build_tool_configs(tool_names: Iterable[str]) -> list[dict]:
+    configs: list[dict] = []
+    seen: set[str] = set()
+    for name in tool_names:
+        sdk_name = _TOOL_ALIASES.get(name, name)
+        if sdk_name in _SDK_TOOL_NAMES and sdk_name not in seen:
+            configs.append({"name": sdk_name, "enabled": True})
+            seen.add(sdk_name)
+    return configs
+
+
+def _build_cloud_config(network: str) -> dict:
+    if network == "none":
+        net: dict = {
+            "type": "limited",
+            "allow_mcp_servers": False,
+            "allow_package_managers": False,
+            "allowed_hosts": [],
+        }
+    else:  # "egress_only" (and any other value)
+        net = {"type": "unrestricted"}
+    return {"type": "cloud", "networking": net}
 
 
 # ---------------------------------------------------------------------------
 # Agent / Session
 # ---------------------------------------------------------------------------
 class ForensicAgent:
-    """Thin wrapper around the Managed Agents control plane.
+    """Thin wrapper around the Managed Agents control plane."""
 
-    Owns the Agent + Environment specs; mints Sessions on demand.
-    """
-
-    def __init__(self, config: ForensicAgentConfig | None = None) -> None:
+    def __init__(self, config: ForensicAgentConfig | None = None, client: Anthropic | None = None) -> None:
         self.config = config or ForensicAgentConfig()
-        # TODO(managed-agents): lazy-init an anthropic.ManagedAgents client
-        #                       with headers={"anthropic-beta": ANTHROPIC_BETA_HEADER}
-        self._client = None
+        self._client: Anthropic = client or Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
     def open_session(self, bag_path: Path, case_key: str) -> "ForensicSession":
-        """Create an Environment + Agent and start a Session bound to one case."""
-        # TODO(managed-agents): POST /v1/environments
-        #                       - template=self.config.environment_template
-        #                       - mounts=[{src: bag_path, dst: "/mnt/bag"}, ...]
-        #                       - network=self.config.network
-        # TODO(managed-agents): POST /v1/agents
-        #                       - model, system_prompt, tools, mcp_servers, skills
-        # TODO(managed-agents): POST /v1/sessions  (env_id + agent_id)
-        # TODO(managed-agents): seed the session with an initial user turn
-        #                       containing the case_key + analysis mode.
-        raise NotImplementedError("managed-agents session creation not yet wired")
+        beta = self._client.beta
+
+        file_resources: list[dict] = []
+        bag_path = Path(bag_path)
+        to_upload: list[Path] = []
+        if bag_path.exists() and bag_path.is_file():
+            to_upload.append(bag_path)
+        for extra in self.config.mounted_files:
+            p = Path(extra)
+            if p.exists() and p.is_file():
+                to_upload.append(p)
+        for path in to_upload:
+            _CREATE_LIMITER.acquire()
+            with open(path, "rb") as fh:
+                metadata = _wrap_call(
+                    "files.upload",
+                    beta.files.upload,
+                    file=(path.name, fh, "application/octet-stream"),
+                )
+            file_resources.append(
+                {
+                    "type": "file",
+                    "file_id": metadata.id,
+                    "mount_path": f"/mnt/bag/{path.name}",
+                }
+            )
+
+        _CREATE_LIMITER.acquire()
+        environment = _wrap_call(
+            "environments.create",
+            beta.environments.create,
+            name=f"blackbox-env-{case_key}",
+            config=_build_cloud_config(self.config.network),
+            metadata={"case_key": case_key},
+        )
+
+        tool_configs = _build_tool_configs(self.config.tools)
+        tools_param: list[dict] = []
+        if tool_configs:
+            tools_param.append(
+                {"type": "agent_toolset_20260401", "configs": tool_configs}
+            )
+        skills_param = [
+            {"type": "anthropic", "skill_id": sid} for sid in self.config.skills
+        ]
+
+        agent_kwargs: dict = {
+            "model": self.config.model,
+            "name": self.config.agent_name,
+            "system": self.config.system_prompt,
+            "tools": tools_param,
+            "skills": skills_param,
+            "metadata": {"case_key": case_key},
+        }
+        if self.config.mcp_servers:
+            agent_kwargs["mcp_servers"] = self.config.mcp_servers
+
+        _CREATE_LIMITER.acquire()
+        agent = _wrap_call("agents.create", beta.agents.create, **agent_kwargs)
+
+        session_kwargs: dict = {
+            "agent": {"id": agent.id, "type": "agent"},
+            "environment_id": environment.id,
+            "metadata": {"case_key": case_key, "mode": "post_mortem"},
+            "title": f"post-mortem {case_key}",
+        }
+        if file_resources:
+            session_kwargs["resources"] = file_resources
+
+        _CREATE_LIMITER.acquire()
+        session = _wrap_call("sessions.create", beta.sessions.create, **session_kwargs)
+
+        seed_text = (
+            f"Case key: {case_key}\n"
+            f"Mode: post_mortem\n"
+            f"Budget: {self.config.task_budget_minutes} minutes.\n"
+            "Analyze the mounted rosbag. Return a single JSON object that "
+            "validates against the PostMortemReport schema: keys timeline, "
+            "hypotheses, root_cause_idx, patch_proposal."
+        )
+        _CREATE_LIMITER.acquire()
+        _wrap_call(
+            "sessions.events.send",
+            beta.sessions.events.send,
+            session_id=session.id,
+            events=[
+                {
+                    "type": "user.message",
+                    "content": [{"type": "text", "text": seed_text}],
+                }
+            ],
+        )
+
+        return ForensicSession(
+            session_id=session.id,
+            case_key=case_key,
+            _client=self._client,
+            _agent_id=agent.id,
+            _environment_id=environment.id,
+            _started_at=time.monotonic(),
+        )
 
 
+@dataclass
 class ForensicSession:
     """Represents one running managed-agents Session.
 
     The UI treats this as an event stream until ``finalize()`` is called.
     """
 
-    def __init__(self, session_id: str, case_key: str) -> None:
-        self.session_id = session_id
-        self.case_key = case_key
+    session_id: str
+    case_key: str
+    _client: Anthropic | None = None
+    _agent_id: str | None = None
+    _environment_id: str | None = None
+    _started_at: float = field(default_factory=time.monotonic)
+    _final_text: str | None = field(default=None, repr=False)
 
     # -- event stream --------------------------------------------------------
     def stream(self) -> Iterator[dict]:
-        """Yield session Events as structured dicts.
+        """Yield session Events as structured dicts."""
+        if self._client is None:
+            raise RuntimeError("ForensicSession has no client bound")
 
-        Each item looks like::
+        beta = self._client.beta
+        terminal_emitted = False
 
-            {"type": "reasoning" | "tool_call" | "tool_result" | "status",
-             "ts":   float,
-             "payload": {...}}
-        """
-        # TODO(managed-agents): open SSE on GET /v1/sessions/{id}/events
-        # TODO(managed-agents): translate raw Events into the dict shape above
-        raise NotImplementedError
+        try:
+            _READ_LIMITER.acquire()
+            stream_ctx = _wrap_call(
+                "sessions.events.stream",
+                beta.sessions.events.stream,
+                session_id=self.session_id,
+            )
+        except RuntimeError:
+            stream_ctx = None
+
+        if stream_ctx is not None:
+            for event in stream_ctx:
+                payload = _normalize_event(event)
+                if payload["type"] == "assistant":
+                    self._final_text = payload["payload"].get("text") or self._final_text
+                yield payload
+                if getattr(event, "type", "") in _TERMINAL_EVENT_TYPES:
+                    terminal_emitted = True
+                    break
+
+        if not terminal_emitted:
+            yield from self._poll_events()
+            terminal_emitted = True
+
+        yield {
+            "type": "status",
+            "ts": time.time(),
+            "payload": {"state": "completed"},
+        }
+
+    def _poll_events(self) -> Iterator[dict]:
+        assert self._client is not None
+        beta = self._client.beta
+        seen_ids: set[str] = set()
+        while True:
+            _READ_LIMITER.acquire()
+            page = _wrap_call(
+                "sessions.events.list",
+                beta.sessions.events.list,
+                session_id=self.session_id,
+                order="asc",
+                limit=100,
+            )
+            items = getattr(page, "data", None) or list(page)
+            terminal = False
+            for event in items:
+                eid = getattr(event, "id", None)
+                if eid is not None:
+                    if eid in seen_ids:
+                        continue
+                    seen_ids.add(eid)
+                payload = _normalize_event(event)
+                if payload["type"] == "assistant":
+                    self._final_text = payload["payload"].get("text") or self._final_text
+                yield payload
+                if getattr(event, "type", "") in _TERMINAL_EVENT_TYPES:
+                    terminal = True
+            if terminal:
+                return
+            _READ_LIMITER.acquire()
+            session = _wrap_call(
+                "sessions.retrieve",
+                beta.sessions.retrieve,
+                self.session_id,
+            )
+            status = getattr(session, "status", None)
+            if status in ("idle", "terminated"):
+                return
+            time.sleep(1.0)
 
     # -- steering ------------------------------------------------------------
     def steer(self, message: str) -> None:
-        """Inject a user turn mid-run without restarting the agent."""
-        # TODO(managed-agents): POST /v1/sessions/{id}/events with role=user
-        #                       and content=message. The agent will see it on
-        #                       its next reasoning step.
-        raise NotImplementedError
+        if self._client is None:
+            raise RuntimeError("ForensicSession has no client bound")
+        _CREATE_LIMITER.acquire()
+        _wrap_call(
+            "sessions.events.send",
+            self._client.beta.sessions.events.send,
+            session_id=self.session_id,
+            events=[
+                {
+                    "type": "user.message",
+                    "content": [{"type": "text", "text": message}],
+                }
+            ],
+        )
 
     # -- finalize ------------------------------------------------------------
     def finalize(self) -> dict:
-        """Close the session and collect the final structured outcome.
+        if self._client is None:
+            raise RuntimeError("ForensicSession has no client bound")
+        beta = self._client.beta
 
-        Outcomes are a research-preview feature; until then we parse the
-        last assistant turn as JSON and validate against PostMortemReport.
-        """
-        # TODO(managed-agents): POST /v1/sessions/{id}/finalize
-        # TODO(managed-agents): fetch final outcome (research preview)
-        # TODO(managed-agents): validate against analysis.schemas.PostMortemReport
-        raise NotImplementedError
+        final_text = self._final_text
+        _READ_LIMITER.acquire()
+        session = _wrap_call(
+            "sessions.retrieve",
+            beta.sessions.retrieve,
+            self.session_id,
+        )
+
+        if not final_text:
+            _READ_LIMITER.acquire()
+            page = _wrap_call(
+                "sessions.events.list",
+                beta.sessions.events.list,
+                session_id=self.session_id,
+                order="desc",
+                limit=50,
+            )
+            items = getattr(page, "data", None) or list(page)
+            for event in items:
+                if getattr(event, "type", "") == "agent.message":
+                    final_text = _extract_text(getattr(event, "content", None))
+                    if final_text:
+                        break
+
+        wall_time = time.monotonic() - self._started_at
+        self._log_usage(session, wall_time)
+
+        if not final_text:
+            raise RuntimeError(
+                f"managed-agents session {self.session_id} produced no assistant message"
+            )
+
+        raw = _strip_json_fences(final_text)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"assistant output was not valid JSON: {exc}; text={raw[:200]!r}"
+            ) from exc
+        try:
+            report = PostMortemReport.model_validate(data)
+        except ValidationError as exc:
+            raise RuntimeError(
+                f"assistant JSON did not match PostMortemReport: {exc}"
+            ) from exc
+        return report.model_dump()
+
+    def _log_usage(self, session, wall_time: float) -> None:
+        usage = getattr(session, "usage", None)
+        cached_input = getattr(usage, "cache_read_input_tokens", 0) or 0
+        uncached_input = getattr(usage, "input_tokens", 0) or 0
+        cache_creation_obj = getattr(usage, "cache_creation", None)
+        cache_creation = 0
+        if cache_creation_obj is not None:
+            cache_creation = (
+                getattr(cache_creation_obj, "ephemeral_5m_input_tokens", 0) or 0
+            ) + (
+                getattr(cache_creation_obj, "ephemeral_1h_input_tokens", 0) or 0
+            )
+            if not cache_creation:
+                cache_creation = getattr(cache_creation_obj, "input_tokens", 0) or 0
+        output = getattr(usage, "output_tokens", 0) or 0
+
+        input_cost = (
+            uncached_input * _PRICING["input"]
+            + cache_creation * _PRICING["cache_write"]
+            + cached_input * _PRICING["cache_read"]
+        ) / 1e6
+        output_cost = output * _PRICING["output"] / 1e6
+        total_cost = input_cost + output_cost
+
+        entry = {
+            "cached_input_tokens": int(cached_input),
+            "uncached_input_tokens": int(uncached_input),
+            "cache_creation_tokens": int(cache_creation),
+            "output_tokens": int(output),
+            "usd_cost": float(total_cost),
+            "wall_time_s": float(wall_time),
+            "model": MODEL,
+            "prompt_kind": "managed_agent_postmortem",
+            "session_id": self.session_id,
+            "case_key": self.case_key,
+            "logged_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _append_cost_entry(entry)
 
 
 __all__ = [

--- a/tests/test_managed_agent.py
+++ b/tests/test_managed_agent.py
@@ -1,0 +1,304 @@
+"""Unit tests for the Managed Agents wiring.
+
+Mocks the anthropic SDK so nothing hits the real API.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from black_box.analysis import managed_agent as ma
+from black_box.analysis.managed_agent import (
+    ForensicAgent,
+    ForensicAgentConfig,
+    ForensicSession,
+    _RateLimiter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+class _FakeFiles:
+    def __init__(self):
+        self.uploaded: list[str] = []
+
+    def upload(self, *, file, **_):
+        name = "blob"
+        if isinstance(file, tuple):
+            name = file[0]
+        self.uploaded.append(name)
+        return SimpleNamespace(id=f"file_{len(self.uploaded):03d}", filename=name)
+
+
+class _FakeEnvironments:
+    def __init__(self):
+        self.created: list[dict] = []
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(id="env_abc", name=kwargs.get("name"))
+
+
+class _FakeAgents:
+    def __init__(self):
+        self.created: list[dict] = []
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(id="agent_xyz", version=1, **{k: v for k, v in kwargs.items() if k != "betas"})
+
+
+class _FakeEvents:
+    def __init__(self, scripted_events=None):
+        self.sent: list[dict] = []
+        self._scripted = scripted_events or []
+        self._listed: list[dict] = []
+
+    def send(self, *, session_id, events, **_):
+        self.sent.append({"session_id": session_id, "events": list(events)})
+        return SimpleNamespace(ok=True)
+
+    def stream(self, *, session_id, **_):
+        return iter(self._scripted)
+
+    def list(self, *, session_id, order="asc", limit=100, **_):
+        data = self._listed if order == "asc" else list(reversed(self._listed))
+        return SimpleNamespace(data=data)
+
+
+class _FakeSessions:
+    def __init__(self, events):
+        self.events = events
+        self.created: list[dict] = []
+        self._session_state = SimpleNamespace(
+            id="session_123",
+            status="idle",
+            usage=SimpleNamespace(
+                input_tokens=100,
+                output_tokens=200,
+                cache_read_input_tokens=50,
+                cache_creation=SimpleNamespace(
+                    ephemeral_5m_input_tokens=30,
+                    ephemeral_1h_input_tokens=0,
+                ),
+            ),
+        )
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(id="session_123")
+
+    def retrieve(self, session_id, **_):
+        return self._session_state
+
+
+class _FakeBeta:
+    def __init__(self, events):
+        self.files = _FakeFiles()
+        self.environments = _FakeEnvironments()
+        self.agents = _FakeAgents()
+        self.sessions = _FakeSessions(events)
+        # attach events under sessions
+        self.sessions.events = events
+
+
+class _FakeClient:
+    def __init__(self, events):
+        self.beta = _FakeBeta(events)
+
+
+def _make_event(etype: str, **fields):
+    ns = SimpleNamespace(type=etype, processed_at=fields.pop("processed_at", 1000.0), **fields)
+    return ns
+
+
+def _make_text_block(text: str):
+    return SimpleNamespace(type="text", text=text)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+def test_open_session_creates_env_agent_and_session(tmp_path: Path):
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"\x00fake\x00bag")
+
+    events = _FakeEvents()
+    client = _FakeClient(events)
+
+    config = ForensicAgentConfig(task_budget_minutes=7, skills=["ros-bag-decoder"])
+    agent = ForensicAgent(config=config, client=client)
+
+    session = agent.open_session(bag_path=bag, case_key="crash_001")
+
+    assert isinstance(session, ForensicSession)
+    assert session.session_id == "session_123"
+    assert session.case_key == "crash_001"
+    # env created once with cloud config
+    assert len(client.beta.environments.created) == 1
+    env_kwargs = client.beta.environments.created[0]
+    assert env_kwargs["config"]["type"] == "cloud"
+    # agent created once with real SDK tool names only
+    assert len(client.beta.agents.created) == 1
+    agent_kwargs = client.beta.agents.created[0]
+    toolset = agent_kwargs["tools"][0]
+    assert toolset["type"] == "agent_toolset_20260401"
+    names = {c["name"] for c in toolset["configs"]}
+    assert names <= {"bash", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search"}
+    assert "mcp" not in names  # filtered out, SDK uses separate toolset type
+    assert agent_kwargs["skills"] == [{"type": "anthropic", "skill_id": "ros-bag-decoder"}]
+    # session created referencing env + agent + uploaded file
+    session_kwargs = client.beta.sessions.created[0]
+    assert session_kwargs["agent"] == {"id": "agent_xyz", "type": "agent"}
+    assert session_kwargs["environment_id"] == "env_abc"
+    assert session_kwargs["resources"][0]["type"] == "file"
+    assert session_kwargs["resources"][0]["file_id"].startswith("file_")
+    # seed user event sent
+    assert len(events.sent) == 1
+    seed = events.sent[0]["events"][0]
+    assert seed["type"] == "user.message"
+    assert "crash_001" in seed["content"][0]["text"]
+
+
+def test_stream_yields_normalized_dicts():
+    scripted = [
+        _make_event("agent.thinking", id="t1"),
+        _make_event(
+            "agent.tool_use",
+            id="u1",
+            name="bash",
+            input={"cmd": "ls /mnt/bag"},
+        ),
+        _make_event(
+            "agent.tool_result",
+            id="r1",
+            tool_use_id="u1",
+            content=[_make_text_block("ok")],
+            is_error=False,
+        ),
+        _make_event(
+            "agent.message",
+            id="m1",
+            content=[_make_text_block('{"ok": true}')],
+        ),
+        _make_event(
+            "session.status_idle",
+            id="s1",
+            stop_reason=SimpleNamespace(type="end_turn"),
+        ),
+    ]
+    events = _FakeEvents(scripted_events=scripted)
+    client = _FakeClient(events)
+    session = ForensicSession(
+        session_id="session_123",
+        case_key="crash_001",
+        _client=client,
+    )
+
+    emitted = list(session.stream())
+    kinds = [e["type"] for e in emitted]
+    assert kinds[:4] == ["reasoning", "tool_call", "tool_result", "assistant"]
+    # status events after terminal
+    assert emitted[4]["type"] == "status"
+    assert emitted[4]["payload"]["state"] == "idle"
+    assert emitted[-1]["payload"] == {"state": "completed"}
+    # tool_call payload preserved
+    assert emitted[1]["payload"]["name"] == "bash"
+    assert emitted[1]["payload"]["input"] == {"cmd": "ls /mnt/bag"}
+    # assistant text captured for finalize
+    assert session._final_text == '{"ok": true}'
+
+
+def test_steer_posts_user_event():
+    events = _FakeEvents()
+    client = _FakeClient(events)
+    session = ForensicSession(
+        session_id="session_123", case_key="c", _client=client
+    )
+
+    session.steer("focus on 12-15s")
+
+    assert len(events.sent) == 1
+    ev = events.sent[0]
+    assert ev["session_id"] == "session_123"
+    assert ev["events"][0]["type"] == "user.message"
+    assert ev["events"][0]["content"][0]["text"] == "focus on 12-15s"
+
+
+def test_finalize_parses_last_assistant_and_logs_cost(tmp_path: Path, monkeypatch):
+    report_json = {
+        "timeline": [{"t_ns": 1, "label": "boot", "cross_view": False}],
+        "hypotheses": [
+            {
+                "bug_class": "pid_saturation",
+                "confidence": 0.9,
+                "summary": "PID wound up",
+                "evidence": [
+                    {
+                        "source": "telemetry",
+                        "topic_or_file": "/cmd_vel",
+                        "t_ns": 12000,
+                        "snippet": "max u for 3s",
+                    }
+                ],
+                "patch_hint": "clamp output to +/-1.0",
+            }
+        ],
+        "root_cause_idx": 0,
+        "patch_proposal": "clamp in control_loop.py",
+    }
+    events = _FakeEvents()
+    events._listed = [
+        _make_event(
+            "agent.message",
+            id="m1",
+            content=[_make_text_block(f"```json\n{json.dumps(report_json)}\n```")],
+        )
+    ]
+    client = _FakeClient(events)
+    session = ForensicSession(
+        session_id="session_123", case_key="crash_001", _client=client
+    )
+
+    # redirect cost log to tmp path
+    fake_cost = tmp_path / "costs.jsonl"
+    monkeypatch.setattr(ma, "_costs_file", lambda: fake_cost)
+
+    result = session.finalize()
+
+    assert result["root_cause_idx"] == 0
+    assert result["hypotheses"][0]["bug_class"] == "pid_saturation"
+    # cost line written
+    lines = fake_cost.read_text().strip().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["prompt_kind"] == "managed_agent_postmortem"
+    assert entry["session_id"] == "session_123"
+    assert entry["model"] == "claude-opus-4-7"
+    assert entry["output_tokens"] == 200
+    assert entry["cached_input_tokens"] == 50
+    assert entry["cache_creation_tokens"] == 30
+    assert entry["usd_cost"] > 0
+
+
+def test_rate_limiter_sleeps_after_burst():
+    limiter = _RateLimiter(max_per_window=60, window_seconds=60.0)
+    # Pre-fill 60 slots in the limiter's deque at monotonic() time.
+    now = time.monotonic()
+    limiter._events.extend([now] * 60)
+
+    with mock.patch("black_box.analysis.managed_agent.time.sleep") as sleep_mock:
+        limiter.acquire()
+        assert sleep_mock.called
+        # The sleep duration should be positive and <= window
+        slept_for = sleep_mock.call_args[0][0]
+        assert slept_for > 0
+        assert slept_for <= 60.0


### PR DESCRIPTION
## Summary
- Replaces the 4 `NotImplementedError` sites in `ForensicAgent` / `ForensicSession` with real `client.beta.{files,environments,agents,sessions}` calls against `managed-agents-2026-04-01`.
- Streams session events (`events.stream`) with an `events.list` polling fallback; parses the final `agent.message` JSON, validates it against `PostMortemReport`.
- Appends per-session usage + USD cost to `data/costs.jsonl` on finalize (cached / uncached / cache_creation / output tokens).
- Adds sliding-window rate limiter (60 create/min, 600 read/min per docs).
- New `tests/test_managed_agent.py` — 5 tests with a mocked SDK covering open_session, stream, steer, finalize, cost logging.

## Divergences from the skeleton brief
- **No env-level mounts.** Files are attached at the Session via `resources=[{type:"file", file_id, mount_path}]`; `environments.create` doesn't take mounts in the 04-01 surface.
- **`sessions.create` wants `agent={id,type}`,** not `agent_id`.
- **Events API is `send`/`stream`/`list`,** not `create`. User turns use `{type:"user.message", content:[{type:"text", text:...}]}`.
- **`task_budget_minutes` is informational** — no SDK slot for a hard budget; encoded in seed prompt for now.
- **`BUILTIN_TOOLS` tuple kept** for public API; internal `_TOOL_ALIASES` translates to the SDK's closed set (`bash, read, write, edit, glob, grep, web_fetch, web_search`).
- `anthropic-beta` header is auto-injected by `client.beta.*` in 0.96.0; `ANTHROPIC_BETA_HEADER` constant is kept public.

## Stacked on
#1 (dep bump).

## Test plan
- [x] `pytest tests/test_managed_agent.py` → 5 passed
- [x] Full suite: 37 passed
- [ ] End-to-end smoke test against real API (deferred until real bag in hand)