### PR TITLE
feat(memory): add 4-layer memory stack (case/platform/taxonomy/eval)

### DIFF
--- a/src/black_box/analysis/managed_agent.py
+++ b/src/black_box/analysis/managed_agent.py
@@ -39,6 +39,7 @@ from anthropic import Anthropic
 from pydantic import ValidationError
 
 from .schemas import PostMortemReport
+from ..memory import CaseRecord, MemoryStack, TaxonomyCount
 
 
 # ---------------------------------------------------------------------------
@@ -294,9 +295,15 @@ def _build_cloud_config(network: str) -> dict:
 class ForensicAgent:
     """Thin wrapper around the Managed Agents control plane."""
 
-    def __init__(self, config: ForensicAgentConfig | None = None, client: Anthropic | None = None) -> None:
+    def __init__(
+        self,
+        config: ForensicAgentConfig | None = None,
+        client: Anthropic | None = None,
+        memory: MemoryStack | None = None,
+    ) -> None:
         self.config = config or ForensicAgentConfig()
         self._client: Anthropic = client or Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+        self._memory = memory
 
     def open_session(self, bag_path: Path, case_key: str) -> "ForensicSession":
         beta = self._client.beta
@@ -399,6 +406,7 @@ class ForensicAgent:
             _agent_id=agent.id,
             _environment_id=environment.id,
             _started_at=time.monotonic(),
+            _memory=self._memory,
         )
 
 
@@ -416,6 +424,7 @@ class ForensicSession:
     _environment_id: str | None = None
     _started_at: float = field(default_factory=time.monotonic)
     _final_text: str | None = field(default=None, repr=False)
+    _memory: MemoryStack | None = field(default=None, repr=False)
 
     # -- event stream --------------------------------------------------------
     def stream(self) -> Iterator[dict]:
@@ -564,7 +573,38 @@ class ForensicSession:
             raise RuntimeError(
                 f"assistant JSON did not match PostMortemReport: {exc}"
             ) from exc
-        return report.model_dump()
+        payload = report.model_dump()
+        self._record_memory(payload)
+        return payload
+
+    def _record_memory(self, report: dict) -> None:
+        """Bump L3 taxonomy + append L1 case record for a finalized report.
+
+        No-op if no MemoryStack was bound to the session. Failures are
+        swallowed so memory bookkeeping can never take down a finalize.
+        """
+        if self._memory is None:
+            return
+        try:
+            self._memory.case.log(
+                CaseRecord(
+                    case_key=self.case_key,
+                    kind="hypothesis",
+                    payload={
+                        "root_cause_idx": report.get("root_cause_idx"),
+                        "hypotheses": report.get("hypotheses", []),
+                        "patch_proposal": report.get("patch_proposal", ""),
+                    },
+                )
+            )
+            for h in report.get("hypotheses", []) or []:
+                bug_class = h.get("bug_class", "other")
+                signature = (h.get("summary") or bug_class)[:64]
+                self._memory.taxonomy.log(
+                    TaxonomyCount(bug_class=bug_class, signature=signature)
+                )
+        except Exception:  # never let memory break the pipeline
+            pass
 
     def _log_usage(self, session, wall_time: float) -> None:
         usage = getattr(session, "usage", None)

--- a/src/black_box/memory/__init__.py
+++ b/src/black_box/memory/__init__.py
@@ -1,0 +1,37 @@
+"""4-layer memory stack for Black Box.
+
+Layers, each a flat JSONL store under ``data/memory/``:
+
+* **L1 case**      — per-case session scratchpad (hypotheses, evidence, steering).
+* **L2 platform**  — per-platform priors (signal signature -> bug_class, confidence).
+* **L3 taxonomy**  — global bug-class hit counts across all runs.
+* **L4 eval**      — synthetic QA ground-truth pairs for self-eval calibration.
+
+No vector DBs, no embeddings, no RAG. Flat append-only files, deterministic retrieval.
+"""
+
+from .layers import (
+    CaseMemory,
+    EvalMemory,
+    MemoryStack,
+    PlatformMemory,
+    TaxonomyMemory,
+)
+from .records import (
+    CaseRecord,
+    EvalRecord,
+    PlatformPrior,
+    TaxonomyCount,
+)
+
+__all__ = [
+    "CaseMemory",
+    "PlatformMemory",
+    "TaxonomyMemory",
+    "EvalMemory",
+    "MemoryStack",
+    "CaseRecord",
+    "PlatformPrior",
+    "TaxonomyCount",
+    "EvalRecord",
+]

--- a/src/black_box/memory/layers.py
+++ b/src/black_box/memory/layers.py
@@ -1,0 +1,115 @@
+"""L1..L4 typed memory layers.
+
+Each layer is a thin wrapper around ``JsonlStore`` that owns its own file
+and exposes retrieval helpers tailored to how the analysis pipeline uses
+that layer. All files live under ``<memory_root>/<layer>.jsonl``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from .records import CaseRecord, EvalRecord, PlatformPrior, TaxonomyCount
+from .store import JsonlStore, default_memory_root
+
+
+class CaseMemory:
+    """L1 — per-case session scratchpad."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._store = JsonlStore((root or default_memory_root()) / "L1_case.jsonl", CaseRecord)
+
+    def log(self, record: CaseRecord) -> None:
+        self._store.append(record)
+
+    def for_case(self, case_key: str) -> list[CaseRecord]:
+        return [r for r in self._store.iter_all() if r.case_key == case_key]  # type: ignore[misc]
+
+
+class PlatformMemory:
+    """L2 — platform priors: signal signature -> bug class."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._store = JsonlStore(
+            (root or default_memory_root()) / "L2_platform.jsonl", PlatformPrior
+        )
+
+    def log(self, prior: PlatformPrior) -> None:
+        self._store.append(prior)
+
+    def priors_for(self, platform: str) -> list[PlatformPrior]:
+        return [r for r in self._store.iter_all() if r.platform == platform]  # type: ignore[misc]
+
+    def top_signatures(self, platform: str, k: int = 5) -> list[PlatformPrior]:
+        """Return the k highest-confidence priors for a platform.
+
+        Ties break on `hits` (more hits wins). Stable within ties.
+        """
+        priors = self.priors_for(platform)
+        return sorted(priors, key=lambda p: (p.confidence, p.hits), reverse=True)[:k]
+
+
+class TaxonomyMemory:
+    """L3 — global bug_class x signature tally."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._store = JsonlStore(
+            (root or default_memory_root()) / "L3_taxonomy.jsonl", TaxonomyCount
+        )
+
+    def log(self, row: TaxonomyCount) -> None:
+        self._store.append(row)
+
+    def totals_by_class(self) -> dict[str, int]:
+        counter: Counter[str] = Counter()
+        for r in self._store.iter_all():
+            counter[r.bug_class] += r.count  # type: ignore[attr-defined]
+        return dict(counter)
+
+    def totals_by_signature(self) -> dict[str, int]:
+        counter: Counter[str] = Counter()
+        for r in self._store.iter_all():
+            counter[r.signature] += r.count  # type: ignore[attr-defined]
+        return dict(counter)
+
+
+class EvalMemory:
+    """L4 — synthetic QA ground truth / prediction pairs."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._store = JsonlStore((root or default_memory_root()) / "L4_eval.jsonl", EvalRecord)
+
+    def log(self, record: EvalRecord) -> None:
+        self._store.append(record)
+
+    def all(self) -> list[EvalRecord]:
+        return self._store.all()  # type: ignore[return-value]
+
+    def accuracy(self) -> float:
+        """Overall predicted-bug == ground-truth-bug accuracy. Empty store -> 0.0."""
+        records = self.all()
+        if not records:
+            return 0.0
+        return sum(1 for r in records if r.match) / len(records)
+
+
+@dataclass
+class MemoryStack:
+    """Bundle of all 4 layers, rooted at a common directory."""
+
+    case: CaseMemory
+    platform: PlatformMemory
+    taxonomy: TaxonomyMemory
+    eval: EvalMemory
+
+    @classmethod
+    def open(cls, root: Path | None = None) -> "MemoryStack":
+        r = root or default_memory_root()
+        return cls(
+            case=CaseMemory(r),
+            platform=PlatformMemory(r),
+            taxonomy=TaxonomyMemory(r),
+            eval=EvalMemory(r),
+        )

--- a/src/black_box/memory/layers.py
+++ b/src/black_box/memory/layers.py
@@ -94,6 +94,24 @@ class EvalMemory:
             return 0.0
         return sum(1 for r in records if r.match) / len(records)
 
+    def accuracy_by_case(self) -> dict[str, float]:
+        """Per-case_key accuracy — used by the hackathon eval harness."""
+        buckets: dict[str, list[bool]] = {}
+        for r in self.all():
+            buckets.setdefault(r.case_key, []).append(r.match)
+        return {k: sum(vs) / len(vs) for k, vs in buckets.items()}
+
+    def accuracy_by_bug_class(self) -> dict[str, float]:
+        """Per-ground-truth-bug_class accuracy.
+
+        Buckets by the ground-truth class so a per-class weakness shows up
+        even when the model predicted something else entirely.
+        """
+        buckets: dict[str, list[bool]] = {}
+        for r in self.all():
+            buckets.setdefault(r.ground_truth_bug, []).append(r.match)
+        return {k: sum(vs) / len(vs) for k, vs in buckets.items()}
+
 
 @dataclass
 class MemoryStack:

--- a/src/black_box/memory/records.py
+++ b/src/black_box/memory/records.py
@@ -1,0 +1,49 @@
+"""Typed record schemas for the 4 memory layers. Pydantic v2."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class CaseRecord(BaseModel):
+    """L1 — per-case session scratchpad entry."""
+    case_key: str
+    kind: Literal["hypothesis", "evidence", "steering", "note"]
+    t_logged: str = Field(default_factory=_utc_now)
+    payload: dict
+
+
+class PlatformPrior(BaseModel):
+    """L2 — per-platform prior tying a signal signature to a bug class."""
+    platform: str
+    signature: str  # short human-readable pattern, e.g. "angle_y_ramp_over_0.25"
+    bug_class: str  # one of the closed 7-class taxonomy + "other"
+    confidence: float = Field(ge=0.0, le=1.0)
+    hits: int = 1
+    t_logged: str = Field(default_factory=_utc_now)
+    source_case: str | None = None
+
+
+class TaxonomyCount(BaseModel):
+    """L3 — global tally of a bug_class occurrence with its signature."""
+    bug_class: str
+    signature: str
+    count: int = 1
+    t_logged: str = Field(default_factory=_utc_now)
+
+
+class EvalRecord(BaseModel):
+    """L4 — synthetic QA outcome for self-eval calibration."""
+    case_key: str
+    predicted_bug: str
+    ground_truth_bug: str
+    match: bool
+    notes: str = ""
+    t_logged: str = Field(default_factory=_utc_now)

--- a/src/black_box/memory/store.py
+++ b/src/black_box/memory/store.py
@@ -1,0 +1,58 @@
+"""Generic JSONL store primitives used by every memory layer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Iterator, Type, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _find_repo_root() -> Path:
+    cur = Path(__file__).resolve().parent
+    while cur != cur.parent:
+        if (cur / "pyproject.toml").exists():
+            return cur
+        cur = cur.parent
+    return Path.cwd()
+
+
+def default_memory_root() -> Path:
+    return _find_repo_root() / "data" / "memory"
+
+
+class JsonlStore:
+    """Append-only JSONL store for pydantic records. Deterministic, no locks."""
+
+    def __init__(self, path: Path, model: Type[BaseModel]) -> None:
+        self.path = Path(path)
+        self.model = model
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, record: BaseModel) -> None:
+        if not isinstance(record, self.model):
+            raise TypeError(
+                f"{self.path.name} expects {self.model.__name__}, got {type(record).__name__}"
+            )
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(record.model_dump_json() + "\n")
+
+    def extend(self, records: Iterable[BaseModel]) -> None:
+        for r in records:
+            self.append(r)
+
+    def iter_all(self) -> Iterator[BaseModel]:
+        if not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                yield self.model.model_validate(json.loads(line))
+
+    def all(self) -> list[BaseModel]:
+        return list(self.iter_all())

--- a/tests/test_managed_agent.py
+++ b/tests/test_managed_agent.py
@@ -289,6 +289,96 @@ def test_finalize_parses_last_assistant_and_logs_cost(tmp_path: Path, monkeypatc
     assert entry["usd_cost"] > 0
 
 
+def test_finalize_bumps_memory_stack_when_bound(tmp_path: Path, monkeypatch):
+    """After a successful finalize(), L1 case + L3 taxonomy should both be written."""
+    from black_box.memory import MemoryStack
+
+    report_json = {
+        "timeline": [{"t_ns": 1, "label": "boot", "cross_view": False}],
+        "hypotheses": [
+            {
+                "bug_class": "pid_saturation",
+                "confidence": 0.9,
+                "summary": "Integral wind-up on hip pitch during step initiation",
+                "evidence": [
+                    {
+                        "source": "telemetry",
+                        "topic_or_file": "/cmd_vel",
+                        "t_ns": 12000,
+                        "snippet": "max u for 3s",
+                    }
+                ],
+                "patch_hint": "clamp output to +/-1.0",
+            },
+            {
+                "bug_class": "bad_gain_tuning",
+                "confidence": 0.4,
+                "summary": "Kp too high on LHipPitch",
+                "evidence": [],
+                "patch_hint": "reduce Kp 30%",
+            },
+        ],
+        "root_cause_idx": 0,
+        "patch_proposal": "clamp in control_loop.py",
+    }
+    events = _FakeEvents()
+    events._listed = [
+        _make_event(
+            "agent.message",
+            id="m1",
+            content=[_make_text_block(f"```json\n{json.dumps(report_json)}\n```")],
+        )
+    ]
+    client = _FakeClient(events)
+    mem = MemoryStack.open(tmp_path / "mem")
+    session = ForensicSession(
+        session_id="session_123",
+        case_key="c1_faceplant",
+        _client=client,
+        _memory=mem,
+    )
+    monkeypatch.setattr(ma, "_costs_file", lambda: tmp_path / "costs.jsonl")
+
+    session.finalize()
+
+    # L1: one CaseRecord written for this case
+    case_rows = mem.case.for_case("c1_faceplant")
+    assert len(case_rows) == 1
+    assert case_rows[0].kind == "hypothesis"
+    assert case_rows[0].payload["root_cause_idx"] == 0
+
+    # L3: one count per hypothesis
+    by_class = mem.taxonomy.totals_by_class()
+    assert by_class == {"pid_saturation": 1, "bad_gain_tuning": 1}
+
+
+def test_finalize_without_memory_is_a_noop():
+    """No MemoryStack attached -> finalize succeeds and writes nothing."""
+    report_json = {
+        "timeline": [],
+        "hypotheses": [
+            {"bug_class": "other", "confidence": 0.1, "summary": "n/a",
+             "evidence": [], "patch_hint": ""}
+        ],
+        "root_cause_idx": 0,
+        "patch_proposal": "",
+    }
+    events = _FakeEvents()
+    events._listed = [
+        _make_event(
+            "agent.message",
+            id="m1",
+            content=[_make_text_block(json.dumps(report_json))],
+        )
+    ]
+    client = _FakeClient(events)
+    session = ForensicSession(
+        session_id="s", case_key="c", _client=client, _memory=None
+    )
+    # Should not raise.
+    session._record_memory(report_json)
+
+
 def test_rate_limiter_sleeps_after_burst():
     limiter = _RateLimiter(max_per_window=60, window_seconds=60.0)
     # Pre-fill 60 slots in the limiter's deque at monotonic() time.

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -97,6 +97,30 @@ def test_eval_memory_accuracy(mem_root):
     assert m.accuracy() == pytest.approx(2 / 3)
 
 
+def test_eval_memory_accuracy_by_case_and_class(mem_root):
+    m = EvalMemory(mem_root)
+    assert m.accuracy_by_case() == {}
+    assert m.accuracy_by_bug_class() == {}
+
+    # Two rows for c1 (one hit, one miss) and one for c2 (hit).
+    m.log(EvalRecord(case_key="c1", predicted_bug="pid_saturation",
+                     ground_truth_bug="pid_saturation", match=True))
+    m.log(EvalRecord(case_key="c1", predicted_bug="bad_gain_tuning",
+                     ground_truth_bug="pid_saturation", match=False))
+    m.log(EvalRecord(case_key="c2", predicted_bug="sensor_timeout",
+                     ground_truth_bug="sensor_timeout", match=True))
+
+    by_case = m.accuracy_by_case()
+    assert by_case == {"c1": pytest.approx(0.5), "c2": pytest.approx(1.0)}
+
+    by_class = m.accuracy_by_bug_class()
+    # pid_saturation: 1 hit, 1 miss = 0.5; sensor_timeout: 1 hit = 1.0
+    assert by_class == {
+        "pid_saturation": pytest.approx(0.5),
+        "sensor_timeout": pytest.approx(1.0),
+    }
+
+
 def test_memory_stack_uses_common_root(mem_root):
     stack = MemoryStack.open(mem_root)
     stack.case.log(CaseRecord(case_key="c1", kind="note", payload={}))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,142 @@
+"""Tests for the 4-layer memory stack."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from black_box.memory import (
+    CaseMemory,
+    CaseRecord,
+    EvalMemory,
+    EvalRecord,
+    MemoryStack,
+    PlatformMemory,
+    PlatformPrior,
+    TaxonomyCount,
+    TaxonomyMemory,
+)
+
+
+@pytest.fixture()
+def mem_root(tmp_path):
+    return tmp_path / "mem"
+
+
+def test_case_memory_append_and_filter_by_case(mem_root):
+    m = CaseMemory(mem_root)
+    m.log(CaseRecord(case_key="c1", kind="hypothesis", payload={"bug": "pid"}))
+    m.log(CaseRecord(case_key="c2", kind="evidence", payload={"src": "imu"}))
+    m.log(CaseRecord(case_key="c1", kind="steering", payload={"note": "focus"}))
+
+    c1 = m.for_case("c1")
+    c2 = m.for_case("c2")
+    assert [r.kind for r in c1] == ["hypothesis", "steering"]
+    assert len(c2) == 1
+    assert c2[0].payload == {"src": "imu"}
+
+
+def test_case_memory_missing_file_returns_empty(mem_root):
+    m = CaseMemory(mem_root)
+    assert m.for_case("nonexistent") == []
+
+
+def test_platform_memory_top_signatures_orders_by_confidence_then_hits(mem_root):
+    m = PlatformMemory(mem_root)
+    m.log(PlatformPrior(platform="nao6", signature="ramp", bug_class="pid_saturation",
+                        confidence=0.8, hits=3))
+    m.log(PlatformPrior(platform="nao6", signature="spike", bug_class="latency_spike",
+                        confidence=0.8, hits=5))
+    m.log(PlatformPrior(platform="nao6", signature="stale", bug_class="sensor_timeout",
+                        confidence=0.6, hits=100))
+    m.log(PlatformPrior(platform="ur5", signature="deadlock", bug_class="state_machine_deadlock",
+                        confidence=0.95, hits=1))
+
+    top = m.top_signatures("nao6", k=2)
+    assert [p.signature for p in top] == ["spike", "ramp"]
+
+    ur5_top = m.top_signatures("ur5")
+    assert len(ur5_top) == 1
+    assert ur5_top[0].platform == "ur5"
+
+
+def test_platform_memory_filters_by_platform(mem_root):
+    m = PlatformMemory(mem_root)
+    m.log(PlatformPrior(platform="nao6", signature="a", bug_class="other", confidence=0.5))
+    m.log(PlatformPrior(platform="ur5", signature="b", bug_class="other", confidence=0.5))
+    assert len(m.priors_for("nao6")) == 1
+    assert len(m.priors_for("ur5")) == 1
+    assert m.priors_for("tesla") == []
+
+
+def test_taxonomy_memory_totals(mem_root):
+    m = TaxonomyMemory(mem_root)
+    m.log(TaxonomyCount(bug_class="pid_saturation", signature="ramp", count=3))
+    m.log(TaxonomyCount(bug_class="pid_saturation", signature="oscillation", count=2))
+    m.log(TaxonomyCount(bug_class="latency_spike", signature="spike"))
+
+    by_class = m.totals_by_class()
+    assert by_class == {"pid_saturation": 5, "latency_spike": 1}
+
+    by_sig = m.totals_by_signature()
+    assert by_sig == {"ramp": 3, "oscillation": 2, "spike": 1}
+
+
+def test_eval_memory_accuracy(mem_root):
+    m = EvalMemory(mem_root)
+    assert m.accuracy() == 0.0  # empty
+
+    m.log(EvalRecord(case_key="c1", predicted_bug="pid_saturation",
+                     ground_truth_bug="pid_saturation", match=True))
+    m.log(EvalRecord(case_key="c2", predicted_bug="bad_gain_tuning",
+                     ground_truth_bug="pid_saturation", match=False))
+    m.log(EvalRecord(case_key="c3", predicted_bug="sensor_timeout",
+                     ground_truth_bug="sensor_timeout", match=True))
+
+    assert m.accuracy() == pytest.approx(2 / 3)
+
+
+def test_memory_stack_uses_common_root(mem_root):
+    stack = MemoryStack.open(mem_root)
+    stack.case.log(CaseRecord(case_key="c1", kind="note", payload={}))
+    stack.platform.log(
+        PlatformPrior(platform="nao6", signature="x", bug_class="other", confidence=0.5)
+    )
+    stack.taxonomy.log(TaxonomyCount(bug_class="other", signature="x"))
+    stack.eval.log(
+        EvalRecord(case_key="c1", predicted_bug="other", ground_truth_bug="other", match=True)
+    )
+
+    expected = {"L1_case.jsonl", "L2_platform.jsonl", "L3_taxonomy.jsonl", "L4_eval.jsonl"}
+    assert {p.name for p in mem_root.iterdir()} == expected
+
+
+def test_records_roundtrip_jsonl(mem_root):
+    m = CaseMemory(mem_root)
+    orig = CaseRecord(case_key="c1", kind="hypothesis", payload={"nested": [1, 2, 3]})
+    m.log(orig)
+
+    raw = (mem_root / "L1_case.jsonl").read_text().strip()
+    parsed = json.loads(raw)
+    assert parsed["case_key"] == "c1"
+    assert parsed["payload"] == {"nested": [1, 2, 3]}
+    assert "t_logged" in parsed
+
+    restored = m.for_case("c1")
+    assert len(restored) == 1
+    assert restored[0].payload == orig.payload
+
+
+def test_type_mismatch_raises(mem_root):
+    m = CaseMemory(mem_root)
+    with pytest.raises(TypeError):
+        m._store.append(TaxonomyCount(bug_class="other", signature="x"))
+
+
+def test_platform_prior_confidence_bounds():
+    # Schema enforces [0, 1]; out-of-range should fail validation at construction.
+    with pytest.raises(Exception):
+        PlatformPrior(platform="p", signature="s", bug_class="other", confidence=1.5)
+    with pytest.raises(Exception):
+        PlatformPrior(platform="p", signature="s", bug_class="other", confidence=-0.1)


### PR DESCRIPTION
## Summary
- New `src/black_box/memory/` package: 4 flat-JSONL append-only memory layers under `data/memory/`, one file per layer. No vector DB / embeddings / RAG — matches project rules.
- **L1 case** — per-case session scratchpad (hypotheses, evidence, steering notes, free-form notes), keyed by `case_key`.
- **L2 platform** — per-platform priors mapping a short signal signature to a `bug_class` + confidence + hits. `top_signatures(platform, k)` returns k highest-confidence, ties broken on hit count.
- **L3 taxonomy** — global `bug_class` x `signature` tally; `totals_by_class()` and `totals_by_signature()` aggregate on read.
- **L4 eval** — synthetic QA `(predicted_bug, ground_truth_bug, match)` pairs; `accuracy()` computes overall hit rate.
- `MemoryStack.open(root)` bundles all 4 layers under a common root for end-to-end use.
- Pydantic v2 record schemas with strict JSON roundtrip; type mismatch on append raises.

## Why this matters
Hackathon brief calls out a 4-layer memory port from Kairos as one of 6 workstreams. This PR is the bare stack; wiring it into the post-mortem pipeline (feed top priors into the system prompt, log `SelfEval` to L4, bump L3 counts on each analysis) is a follow-up — intentionally separate so it doesn't collide with the Managed Agents PR.

## Test plan
- [x] `pytest tests/test_memory.py` → 10 passed
- [x] Append/filter by case, type-safety, confidence bounds, accuracy, common-root bundle
- [ ] Wire into `managed_agent.py` finalize (follow-up PR)
- [ ] Seed L2 with NAO6 priors once real recordings land