### PR TITLE
feat(nao6): add ingestion adapter scaffold with synthetic fall fixture

### DIFF
--- a/src/black_box/platforms/__init__.py
+++ b/src/black_box/platforms/__init__.py
@@ -1,0 +1,1 @@
+"""Platform-specific ingestion adapters (non-ROS robots)."""

--- a/src/black_box/platforms/nao6/__init__.py
+++ b/src/black_box/platforms/nao6/__init__.py
@@ -1,0 +1,5 @@
+"""NAO6 (SoftBank Aldebaran) ingestion adapter."""
+
+from .adapter import NAO6Adapter
+
+__all__ = ["NAO6Adapter"]

--- a/src/black_box/platforms/nao6/_fixture.py
+++ b/src/black_box/platforms/nao6/_fixture.py
@@ -1,0 +1,202 @@
+"""Deterministic synthetic NAO6 forward-fall fixture.
+
+Writes real MP4 + CSV + .py artifacts to disk so the adapter runs the same
+code path it would on tomorrow's real recordings. No randomness — any math
+uses fixed constants so tests are reproducible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+# Scenario constants
+_FPS = 10
+_DURATION_S = 3
+_TOTAL_FRAMES = _FPS * _DURATION_S  # 30
+_WIDTH = 320
+_HEIGHT = 240
+_TELE_HZ = 100
+
+
+def generate_fall_fixture(out_dir: Path) -> dict[str, Path]:
+    """Emit a reproducible NAO6 forward-fall scenario on disk.
+
+    Produces:
+      top_video.mp4   — gradient scene that rotates with robot pitch
+      bottom_video.mp4 — floor texture progressively occluded by collapse
+      telemetry.csv   — IMU-style time series + one non-numeric state key
+      controller.py   — toy balance controller with an intentional PID wind-up
+
+    Returns paths keyed as: top_video, bottom_video, telemetry_csv, controller_source.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    top_path = out_dir / "top_video.mp4"
+    bottom_path = out_dir / "bottom_video.mp4"
+    tele_path = out_dir / "telemetry.csv"
+    ctrl_path = out_dir / "controller.py"
+
+    _write_top_video(top_path)
+    _write_bottom_video(bottom_path)
+    _write_telemetry(tele_path)
+    _write_controller(ctrl_path)
+
+    return {
+        "top_video": top_path,
+        "bottom_video": bottom_path,
+        "telemetry_csv": tele_path,
+        "controller_source": ctrl_path,
+    }
+
+
+# ---- video writers ---------------------------------------------------------
+
+
+def _fourcc() -> int:
+    # mp4v is the most portable cv2 MP4 fourcc; avoids external codecs.
+    return cv2.VideoWriter_fourcc(*"mp4v")
+
+
+def _write_top_video(path: Path) -> None:
+    vw = cv2.VideoWriter(str(path), _fourcc(), _FPS, (_WIDTH, _HEIGHT))
+    try:
+        # Base horizon: upper sky band, lower ground band.
+        sky = np.full((_HEIGHT, _WIDTH, 3), (200, 160, 90), dtype=np.uint8)  # BGR bluish
+        ground = np.full((_HEIGHT, _WIDTH, 3), (60, 90, 40), dtype=np.uint8)  # dark green
+        horizon = _HEIGHT // 2
+        base = sky.copy()
+        base[horizon:] = ground[horizon:]
+
+        for i in range(_TOTAL_FRAMES):
+            # Stable for first 2s, then rotate linearly to -60deg as robot pitches forward
+            t_s = i / _FPS
+            if t_s < 2.0:
+                angle_deg = 0.0
+            else:
+                frac = (t_s - 2.0) / 1.0
+                angle_deg = -60.0 * frac
+            m = cv2.getRotationMatrix2D((_WIDTH / 2, _HEIGHT / 2), angle_deg, 1.0)
+            rotated = cv2.warpAffine(base, m, (_WIDTH, _HEIGHT), borderValue=(0, 0, 0))
+            vw.write(rotated)
+    finally:
+        vw.release()
+
+
+def _write_bottom_video(path: Path) -> None:
+    vw = cv2.VideoWriter(str(path), _fourcc(), _FPS, (_WIDTH, _HEIGHT))
+    try:
+        # Floor texture: checkerboard
+        floor = np.zeros((_HEIGHT, _WIDTH, 3), dtype=np.uint8)
+        tile = 40
+        for y in range(0, _HEIGHT, tile):
+            for x in range(0, _WIDTH, tile):
+                if ((x // tile) + (y // tile)) % 2 == 0:
+                    floor[y : y + tile, x : x + tile] = (180, 180, 180)
+                else:
+                    floor[y : y + tile, x : x + tile] = (110, 110, 110)
+
+        for i in range(_TOTAL_FRAMES):
+            t_s = i / _FPS
+            frame = floor.copy()
+            # Occlusion grows from top as the robot tips forward onto its face
+            if t_s < 2.0:
+                occl_px = 0
+            else:
+                frac = (t_s - 2.0) / 1.0
+                occl_px = int(frac * _HEIGHT)
+            if occl_px > 0:
+                frame[:occl_px] = (20, 20, 20)
+            vw.write(frame)
+    finally:
+        vw.release()
+
+
+# ---- telemetry -------------------------------------------------------------
+
+
+def _write_telemetry(path: Path) -> None:
+    samples = _TELE_HZ * _DURATION_S  # 300
+    dt_ns = int(1e9 / _TELE_HZ)
+
+    rows: list[tuple[int, str, str]] = []
+    for i in range(samples):
+        t_ns = i * dt_ns
+        t_s = i / _TELE_HZ
+
+        # AngleY: 0.02 rad for 2s, then linear ramp to 0.8 rad over the final 1s
+        if t_s < 2.0:
+            angle_y = 0.02
+        else:
+            frac = (t_s - 2.0) / 1.0
+            angle_y = 0.02 + (0.8 - 0.02) * frac
+        rows.append((t_ns, "InertialSensor/AngleY/Sensor/Value", f"{angle_y:.6f}"))
+
+        # GyrY: ~0 for 2s, -3.0 rad/s during fall
+        gyr_y = 0.0 if t_s < 2.0 else -3.0
+        rows.append((t_ns, "GyrY", f"{gyr_y:.6f}"))
+
+        # AccZ: -9.81 nominal, -3.0 freefall mid-fall, hard negative spike at impact
+        if t_s < 2.0:
+            acc_z = -9.81
+        elif t_s < 2.8:
+            acc_z = -3.0
+        elif t_s < 2.9:
+            acc_z = -40.0  # impact spike
+        else:
+            acc_z = -9.81
+        rows.append((t_ns, "AccZ", f"{acc_z:.6f}"))
+
+        # Non-numeric state key — adapter must skip these without crashing.
+        state = "standing" if t_s < 2.0 else "falling"
+        rows.append((t_ns, "BalanceController/State", state))
+
+    with path.open("w", newline="") as f:
+        w = __import__("csv").writer(f)
+        w.writerow(["t_ns", "key", "value"])
+        for row in rows:
+            w.writerow(row)
+
+
+# ---- controller source -----------------------------------------------------
+
+
+_CONTROLLER_SRC = '''"""Toy NAO6 balance controller.
+
+BUG (intentional, for synthetic QA — bug_class: pid_saturation):
+The PID integral term is never reset when the state transitions from
+"standing" to "falling". Under a sustained forward pitch error the
+integral winds up without bound and the commanded ankle torque saturates
+the actuator, so the recovery step never fires.
+"""
+
+from __future__ import annotations
+
+
+class BalancePID:
+    def __init__(self, kp: float = 4.0, ki: float = 1.5, kd: float = 0.2) -> None:
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self.integral = 0.0
+        self.last_err = 0.0
+        self.state = "standing"
+
+    def step(self, angle_y: float, dt: float) -> float:
+        err = 0.0 - angle_y  # setpoint = upright
+        self.integral += err * dt  # BUG: never clamped, never reset on state switch
+        deriv = (err - self.last_err) / max(dt, 1e-6)
+        self.last_err = err
+        if abs(angle_y) > 0.25:
+            self.state = "falling"
+        torque = self.kp * err + self.ki * self.integral + self.kd * deriv
+        return torque
+'''
+
+
+def _write_controller(path: Path) -> None:
+    path.write_text(_CONTROLLER_SRC, encoding="utf-8")

--- a/src/black_box/platforms/nao6/adapter.py
+++ b/src/black_box/platforms/nao6/adapter.py
@@ -1,0 +1,217 @@
+"""NAO6 ingestion adapter.
+
+Converts NAO6 onboard artifacts (CameraTop/CameraBottom MP4s, ALMemory CSV,
+controller source) into the canonical analysis-input dict consumed by the
+Black Box pipeline.
+
+Canonical output dict keys (see brief / split C):
+    case_key, platform, duration_s, frames, frame_timestamps_ns,
+    time_series, code_blobs, metadata
+
+Dual-camera handling: frames from top + bottom cameras are merged into a
+single time-ordered list. A parallel list `metadata["camera_order"]` tags
+each frame with its source ("top" or "bottom"). This keeps the canonical
+shape flat (one `frames`, one `frame_timestamps_ns`) while preserving the
+cross-view information for downstream multi-view reasoning.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import cv2
+import numpy as np
+from PIL import Image
+
+
+class NAO6Adapter:
+    """Ingest NAO6 artifacts and emit the canonical pipeline input dict."""
+
+    def ingest(
+        self,
+        *,
+        case_key: str,
+        top_video: Path | None = None,
+        bottom_video: Path | None = None,
+        telemetry_csv: Path | None = None,
+        controller_source: Path | None = None,
+        max_frames_per_camera: int = 24,
+        sample_stride_ms: int = 100,
+        synthetic: bool = False,
+    ) -> dict:
+        frames: list[Image.Image] = []
+        frame_ts_ns: list[int] = []
+        camera_order: list[str] = []
+        cameras_used: list[str] = []
+        frame_count_per_camera: dict[str, int] = {}
+
+        max_duration_s = 0.0
+
+        for cam_label, cam_path in (("top", top_video), ("bottom", bottom_video)):
+            if cam_path is None:
+                continue
+            cam_path = Path(cam_path)
+            if not cam_path.exists():
+                continue
+            cam_frames, cam_ts, cam_dur = _decode_video(
+                cam_path,
+                stride_ms=sample_stride_ms,
+                max_frames=max_frames_per_camera,
+            )
+            if not cam_frames:
+                continue
+            cameras_used.append(cam_label)
+            frame_count_per_camera[cam_label] = len(cam_frames)
+            max_duration_s = max(max_duration_s, cam_dur)
+            frames.extend(cam_frames)
+            frame_ts_ns.extend(cam_ts)
+            camera_order.extend([cam_label] * len(cam_frames))
+
+        # Time-order the merged stream (stable sort keeps per-camera order on ties)
+        if frames:
+            order = sorted(range(len(frames)), key=lambda i: frame_ts_ns[i])
+            frames = [frames[i] for i in order]
+            frame_ts_ns = [frame_ts_ns[i] for i in order]
+            camera_order = [camera_order[i] for i in order]
+
+        time_series = _parse_telemetry_csv(telemetry_csv) if telemetry_csv else {}
+        code_blobs = _load_controller_source(controller_source) if controller_source else {}
+
+        # Duration preference: span of telemetry if present, else video duration
+        duration_s = max_duration_s
+        if time_series:
+            span_ns = 0
+            for series in time_series.values():
+                if len(series) >= 2:
+                    span_ns = max(span_ns, series[-1][0] - series[0][0])
+            if span_ns > 0:
+                duration_s = max(duration_s, span_ns / 1e9)
+
+        metadata = {
+            "platform": "nao6",
+            "frame_count_per_camera": frame_count_per_camera,
+            "cameras_used": cameras_used,
+            "sample_stride_ms": sample_stride_ms,
+            "synthetic": synthetic,
+            "camera_order": camera_order,
+            "timestamp_origin": "synthesized_monotonic_from_fps",
+        }
+
+        return {
+            "case_key": case_key,
+            "platform": "nao6",
+            "duration_s": float(duration_s),
+            "frames": frames,
+            "frame_timestamps_ns": frame_ts_ns,
+            "time_series": time_series,
+            "code_blobs": code_blobs,
+            "metadata": metadata,
+        }
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _decode_video(
+    path: Path, *, stride_ms: int, max_frames: int
+) -> tuple[list[Image.Image], list[int], float]:
+    """Decode a video, sample frames every stride_ms, return PIL frames + t_ns + duration.
+
+    Timestamps are synthesized monotonically from FPS when absolute timestamps
+    are absent (they typically are for plain MP4 captures).
+    """
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return [], [], 0.0
+
+    fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+    if fps <= 0 or total <= 0:
+        cap.release()
+        return [], [], 0.0
+
+    frame_period_ms = 1000.0 / fps
+    # stride in source frames (at least 1)
+    stride = max(1, int(round(stride_ms / frame_period_ms)))
+
+    frames: list[Image.Image] = []
+    ts_ns: list[int] = []
+    idx = 0
+    while len(frames) < max_frames:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        ok, bgr = cap.read()
+        if not ok or bgr is None:
+            break
+        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+        frames.append(Image.fromarray(rgb))
+        t_ns = int(round(idx * frame_period_ms * 1_000_000))
+        ts_ns.append(t_ns)
+        idx += stride
+        if idx >= total:
+            break
+
+    duration_s = total / fps
+    cap.release()
+    return frames, ts_ns, duration_s
+
+
+def _parse_telemetry_csv(path: Path) -> dict[str, list[tuple[int, float]]]:
+    """Parse ALMemory-style dump: columns `t_ns,key,value`.
+
+    Non-float values are silently skipped per the spec (e.g., string state
+    keys like `BalanceController/State`).
+    """
+    out: dict[str, list[tuple[int, float]]] = {}
+    path = Path(path)
+    if not path.exists():
+        return out
+    with path.open("r", newline="") as f:
+        reader = csv.reader(f)
+        header: list[str] | None = None
+        for row in reader:
+            if not row:
+                continue
+            if header is None:
+                # Allow a header row or no header — detect by trying to parse t_ns.
+                try:
+                    int(row[0])
+                    header = ["t_ns", "key", "value"]  # assume default order
+                    # fall through and process this row
+                except ValueError:
+                    header = [c.strip() for c in row]
+                    continue
+            if len(row) < 3:
+                continue
+            try:
+                t_ns = int(row[0])
+            except (ValueError, TypeError):
+                continue
+            key = row[1]
+            try:
+                val = float(row[2])
+            except (ValueError, TypeError):
+                continue
+            out.setdefault(key, []).append((t_ns, val))
+    for k in out:
+        out[k].sort(key=lambda p: p[0])
+    return out
+
+
+def _load_controller_source(path: Path) -> dict[str, str]:
+    path = Path(path)
+    if not path.exists():
+        return {}
+    if path.is_file():
+        try:
+            return {path.name: path.read_text(encoding="utf-8", errors="replace")}
+        except OSError:
+            return {}
+    blobs: dict[str, str] = {}
+    for py in sorted(path.rglob("*.py")):
+        try:
+            rel = py.relative_to(path).as_posix()
+            blobs[rel] = py.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+    return blobs

--- a/tests/test_nao6_adapter.py
+++ b/tests/test_nao6_adapter.py
@@ -1,0 +1,115 @@
+"""NAO6 adapter scaffold tests — uses the synthetic fall fixture."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from black_box.platforms.nao6 import NAO6Adapter
+from black_box.platforms.nao6._fixture import generate_fall_fixture
+
+
+ANGLE_KEY = "InertialSensor/AngleY/Sensor/Value"
+
+
+@pytest.fixture
+def fixture_dir(tmp_path: Path) -> Path:
+    return tmp_path / "nao6_fall"
+
+
+@pytest.fixture
+def artifacts(fixture_dir: Path) -> dict[str, Path]:
+    return generate_fall_fixture(fixture_dir)
+
+
+def test_ingest_dual_camera(artifacts: dict[str, Path]) -> None:
+    result = NAO6Adapter().ingest(
+        case_key="nao6_fall_synth_001",
+        top_video=artifacts["top_video"],
+        bottom_video=artifacts["bottom_video"],
+        telemetry_csv=artifacts["telemetry_csv"],
+        controller_source=artifacts["controller_source"],
+        synthetic=True,
+    )
+
+    assert result["platform"] == "nao6"
+    assert result["case_key"] == "nao6_fall_synth_001"
+
+    assert 2.5 < result["duration_s"] < 3.5
+
+    frames = result["frames"]
+    assert len(frames) > 0
+    for f in frames:
+        assert isinstance(f, Image.Image)
+
+    # Parallel timestamp list
+    assert len(result["frame_timestamps_ns"]) == len(frames)
+
+    # Telemetry present + fall is in the data
+    assert ANGLE_KEY in result["time_series"]
+    angle_series = result["time_series"][ANGLE_KEY]
+    assert angle_series[-1][1] > 0.5
+
+    # Non-numeric state key must have been skipped without error
+    assert "BalanceController/State" not in result["time_series"]
+
+    # Controller source loaded (single file)
+    assert len(result["code_blobs"]) == 1
+    assert "controller.py" in result["code_blobs"]
+
+    # Dual camera metadata
+    meta = result["metadata"]
+    assert meta["synthetic"] is True
+    assert set(meta["cameras_used"]) == {"top", "bottom"}
+    assert len(meta["camera_order"]) == len(frames)
+    assert set(meta["camera_order"]) == {"top", "bottom"}
+
+
+def test_ingest_single_camera(artifacts: dict[str, Path]) -> None:
+    result = NAO6Adapter().ingest(
+        case_key="nao6_fall_synth_top_only",
+        top_video=artifacts["top_video"],
+        bottom_video=None,
+        telemetry_csv=artifacts["telemetry_csv"],
+        controller_source=artifacts["controller_source"],
+    )
+
+    assert result["platform"] == "nao6"
+    assert result["metadata"]["cameras_used"] == ["top"]
+    assert set(result["metadata"]["camera_order"]) == {"top"}
+    assert len(result["frames"]) > 0
+
+
+def test_non_float_rows_skipped(artifacts: dict[str, Path]) -> None:
+    # BalanceController/State has string values; adapter must not raise.
+    result = NAO6Adapter().ingest(
+        case_key="nao6_nonfloat",
+        top_video=artifacts["top_video"],
+        telemetry_csv=artifacts["telemetry_csv"],
+        controller_source=artifacts["controller_source"],
+    )
+    numeric_keys = set(result["time_series"].keys())
+    assert ANGLE_KEY in numeric_keys
+    assert "BalanceController/State" not in numeric_keys
+
+
+def test_canonical_dict_keys(artifacts: dict[str, Path]) -> None:
+    result = NAO6Adapter().ingest(
+        case_key="nao6_keys",
+        top_video=artifacts["top_video"],
+        telemetry_csv=artifacts["telemetry_csv"],
+        controller_source=artifacts["controller_source"],
+    )
+    expected = {
+        "case_key",
+        "platform",
+        "duration_s",
+        "frames",
+        "frame_timestamps_ns",
+        "time_series",
+        "code_blobs",
+        "metadata",
+    }
+    assert expected <= set(result.keys())


### PR DESCRIPTION
> Re-opening of #4, which was auto-closed with the #1 merge cascade. Rebased onto current master, no conflicts.

## Summary
- New `src/black_box/platforms/nao6/` package with `NAO6Adapter.ingest(...)` producing the canonical dict: `case_key, platform, duration_s, frames, frame_timestamps_ns, time_series, code_blobs, metadata`.
- Dual cameras (CameraTop + CameraBottom) merged into a single time-ordered list; per-frame source tagged in `metadata["camera_order"]`.
- Telemetry parser accepts ALMemory-style `t_ns,key,value` CSV with/without header; silently skips non-numeric values.
- Synthetic fixture: 3s forward-fall, 10 fps / 320x240 both cams, 100 Hz IMU telemetry, toy PID with intentional wind-up bug (ground truth = `pid_saturation`).

## Why now
Operator is doing real NAO6 recordings tomorrow (2026-04-23). This PR is the scaffolding so tomorrow's files drop in without adapter changes.

## Test plan
- [x] `pytest tests/test_nao6_adapter.py` → 4 passed
- [ ] Swap synthetic fixture for real recordings (tomorrow)