### PR TITLE
feat(ui,reporting): demo-video polish — streaming reasoning + side-by-side diff + NTSB PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ data/uploads_raw/
 data/uploads_review/
 data/uploads_safe/
 data/local_notes/
+data/

--- a/src/black_box/reporting/__init__.py
+++ b/src/black_box/reporting/__init__.py
@@ -1,5 +1,11 @@
 """Black Box reporting module — PDF generation and diff utilities."""
-from .diff import scoped_check, side_by_side_html, unified_diff_str
+from .diff import (
+    demo_side_by_side_html,
+    parse_patch_proposal,
+    scoped_check,
+    side_by_side_html,
+    unified_diff_str,
+)
 from .pdf_report import build_report
 
 __all__ = [
@@ -7,4 +13,6 @@ __all__ = [
     "unified_diff_str",
     "scoped_check",
     "side_by_side_html",
+    "demo_side_by_side_html",
+    "parse_patch_proposal",
 ]

--- a/src/black_box/reporting/diff.py
+++ b/src/black_box/reporting/diff.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import difflib
 import html
+import re
 from typing import Tuple
 
 
@@ -134,6 +135,195 @@ def side_by_side_html(old: str, new: str, title: str = "patch") -> str:
 </tbody>
 </table>
 <p style="color:#666;font-size:11px;">added bg {added_bg} &middot; removed bg {removed_bg}</p>
+</body>
+</html>
+"""
+    return doc
+
+
+# ---------- demo-sized side-by-side renderer ----------
+
+def parse_patch_proposal(text: str) -> Tuple[str, str, str]:
+    """Extract (file_path, old, new) from a loose patch_proposal string.
+
+    The schema stores patch_proposal as an informal pseudo-diff like:
+
+        In pid.cpp, line 45:
+        - integral += error;
+        + integral += error;
+        + integral = clamp(integral, -1, 1);
+
+    This returns the file path (best-effort) plus the reconstructed old
+    and new blobs so they can be fed to ``demo_side_by_side_html``. If no
+    ``-``/``+`` lines exist, both blobs are empty.
+    """
+    path = "patch"
+    old_lines: list[str] = []
+    new_lines: list[str] = []
+
+    m = re.match(r"\s*(?:In\s+)?([^\s:,]+)", text or "")
+    if m:
+        cand = m.group(1)
+        if any(sep in cand for sep in (".", "/")):
+            path = cand.rstrip(":,")
+
+    for raw in (text or "").splitlines():
+        if raw.startswith("+++") or raw.startswith("---") or raw.startswith("@@"):
+            continue
+        if raw.startswith("-"):
+            old_lines.append(raw[1:].lstrip(" "))
+        elif raw.startswith("+"):
+            new_lines.append(raw[1:].lstrip(" "))
+    return path, "\n".join(old_lines) + ("\n" if old_lines else ""), \
+        "\n".join(new_lines) + ("\n" if new_lines else "")
+
+
+def demo_side_by_side_html(
+    old: str,
+    new: str,
+    file_path: str = "patch",
+    case_key: str = "",
+    title: str = "Proposed Fix",
+) -> str:
+    """Large-font side-by-side diff designed for the 2:00–2:20 demo beat.
+
+    Same row-opcode logic as ``side_by_side_html`` but NTSB-styled: IBM Plex
+    Serif header, monospace at 14px so it reads at 1080p, case banner, red
+    accent on the title bar, muted green/red row backgrounds.
+    """
+    added_bg = "#eaf7ec"
+    removed_bg = "#fbecec"
+    added_marker = "#2f855a"
+    removed_marker = "#b33"
+
+    old_lines_all = old.splitlines()
+    new_lines_all = new.splitlines()
+    sm = difflib.SequenceMatcher(a=old_lines_all, b=new_lines_all)
+
+    left_rows: list[tuple[str, str, str]] = []   # (bg, marker, text)
+    right_rows: list[tuple[str, str, str]] = []
+
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        a_chunk = old_lines_all[i1:i2]
+        b_chunk = new_lines_all[j1:j2]
+        if tag == "equal":
+            for line in a_chunk:
+                left_rows.append(("#ffffff", " ", line))
+                right_rows.append(("#ffffff", " ", line))
+        elif tag == "replace":
+            n = max(len(a_chunk), len(b_chunk))
+            for k in range(n):
+                if k < len(a_chunk):
+                    left_rows.append((removed_bg, "−", a_chunk[k]))
+                else:
+                    left_rows.append(("#ffffff", " ", ""))
+                if k < len(b_chunk):
+                    right_rows.append((added_bg, "+", b_chunk[k]))
+                else:
+                    right_rows.append(("#ffffff", " ", ""))
+        elif tag == "delete":
+            for line in a_chunk:
+                left_rows.append((removed_bg, "−", line))
+                right_rows.append(("#ffffff", " ", ""))
+        elif tag == "insert":
+            for line in b_chunk:
+                left_rows.append(("#ffffff", " ", ""))
+                right_rows.append((added_bg, "+", line))
+
+    def cell(bg: str, marker: str, text: str, marker_color: str) -> str:
+        return (
+            f'<pre style="margin:0;padding:4px 10px 4px 6px;background:{bg};'
+            f"font-family:ui-monospace,SFMono-Regular,Menlo,monospace;"
+            f'font-size:14px;line-height:1.45;white-space:pre;overflow-x:auto;'
+            f'color:#1c1c1a;">'
+            f'<span style="color:{marker_color};user-select:none;'
+            f'display:inline-block;width:1em;">{marker}</span>'
+            f'{html.escape(text) or "&nbsp;"}</pre>'
+        )
+
+    rows_html = []
+    for i, ((lbg, lmark, ltxt), (rbg, rmark, rtxt)) in enumerate(zip(left_rows, right_rows)):
+        ln_l = i + 1
+        ln_r = i + 1
+        rows_html.append(
+            "<tr>"
+            f'<td class="ln">{ln_l}</td>'
+            f'<td class="side left">{cell(lbg, lmark, ltxt, removed_marker)}</td>'
+            f'<td class="ln">{ln_r}</td>'
+            f'<td class="side right">{cell(rbg, rmark, rtxt, added_marker)}</td>'
+            "</tr>"
+        )
+
+    case_tag = (
+        f'<span style="color:#9a958a;font-family:ui-monospace,monospace;'
+        f'font-size:12px;">CASE {html.escape(case_key)}</span>'
+        if case_key else ""
+    )
+
+    doc = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{html.escape(title)} — {html.escape(file_path)}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@400;600&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  html, body {{ margin: 0; padding: 0; background: #f6f4ef; color: #1c1c1a;
+    font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, sans-serif; }}
+  main {{ max-width: 1180px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }}
+  .banner {{ display:flex; justify-content:space-between; align-items:baseline;
+    border-bottom: 2px solid #1c1c1a; padding-bottom: 0.6rem; margin-bottom: 1.25rem; }}
+  .banner h1 {{ font-family: "IBM Plex Serif", Georgia, serif; font-weight: 600;
+    font-size: 1.6rem; margin: 0; }}
+  .banner .sub {{ color: #b33; font-family: ui-monospace, monospace; font-size: 0.85rem;
+    text-transform: uppercase; letter-spacing: 0.1em; }}
+  .path {{ display:inline-block; background: #fffdf8; border: 1px solid #d9d6cc;
+    padding: 0.35rem 0.7rem; border-radius: 3px; font-family: ui-monospace, monospace;
+    font-size: 0.9rem; margin-bottom: 1rem; }}
+  table.diff {{ border-collapse: collapse; width: 100%; background: #fffdf8;
+    border: 1px solid #d9d6cc; border-radius: 4px; overflow: hidden; }}
+  table.diff thead th {{ text-align: left; padding: 0.55rem 0.75rem;
+    font-family: "IBM Plex Sans", sans-serif; font-size: 0.78rem;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #6b6b66;
+    background: #f2efe6; border-bottom: 1px solid #d9d6cc; }}
+  table.diff td.ln {{ width: 2.5em; text-align: right; padding: 0 8px; color: #a8a49a;
+    font-family: ui-monospace, monospace; font-size: 12px;
+    background: #faf8f2; border-right: 1px solid #eeeae0; user-select: none; }}
+  table.diff td.side {{ vertical-align: top; }}
+  table.diff td.side.left {{ border-right: 1px solid #eeeae0; }}
+  .legend {{ margin-top: 0.9rem; color: #6b6b66; font-size: 0.82rem;
+    font-family: ui-monospace, monospace; }}
+  .legend .pill {{ display:inline-block; padding: 1px 8px; border-radius: 2px;
+    margin-right: 6px; }}
+</style>
+</head>
+<body>
+<main>
+  <div class="banner">
+    <h1>{html.escape(title)}</h1>
+    <span class="sub">BLACK BOX — FORENSIC DIFF</span>
+  </div>
+  <div class="path">{html.escape(file_path)}</div>
+  <table class="diff">
+    <thead>
+      <tr>
+        <th style="width:2.5em;"></th>
+        <th>Before</th>
+        <th style="width:2.5em;"></th>
+        <th>After</th>
+      </tr>
+    </thead>
+    <tbody>
+      {''.join(rows_html)}
+    </tbody>
+  </table>
+  <div class="legend">
+    <span class="pill" style="background:{removed_bg};color:{removed_marker};">− removed</span>
+    <span class="pill" style="background:{added_bg};color:{added_marker};">+ added</span>
+    &middot; {case_tag}
+  </div>
+</main>
 </body>
 </html>
 """

--- a/src/black_box/reporting/pdf_report.py
+++ b/src/black_box/reporting/pdf_report.py
@@ -50,6 +50,25 @@ def _styles():
             alignment=1,
             spaceAfter=6,
         ),
+        "cover_classification": ParagraphStyle(
+            "cover_classification",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=9,
+            leading=11,
+            alignment=1,
+            textColor=colors.HexColor("#b22222"),
+            spaceAfter=4,
+        ),
+        "cover_case_key": ParagraphStyle(
+            "cover_case_key",
+            parent=base["Normal"],
+            fontName="Courier-Bold",
+            fontSize=14,
+            leading=18,
+            alignment=1,
+            spaceAfter=4,
+        ),
         "h1": ParagraphStyle(
             "h1",
             parent=base["Heading1"],
@@ -201,17 +220,64 @@ def build_report(
 
     styles = _styles()
     page_w, page_h = LETTER
+    case_key = case_meta.get("case_key", "unknown")
+    mode_label = case_meta.get("mode", "post_mortem")
     doc = SimpleDocTemplate(
         str(out_pdf),
         pagesize=LETTER,
-        leftMargin=0.75 * inch,
-        rightMargin=0.75 * inch,
-        topMargin=0.75 * inch,
-        bottomMargin=0.75 * inch,
-        title=f"Black Box Report — {case_meta.get('case_key', 'unknown')}",
+        leftMargin=0.85 * inch,
+        rightMargin=0.85 * inch,
+        topMargin=0.95 * inch,
+        bottomMargin=0.85 * inch,
+        title=f"Black Box Report — {case_key}",
         author="Black Box",
     )
     content_w = page_w - doc.leftMargin - doc.rightMargin
+
+    def _draw_page_chrome(canvas, doc_):
+        canvas.saveState()
+        # Top rule
+        canvas.setStrokeColor(colors.black)
+        canvas.setLineWidth(0.75)
+        canvas.line(
+            doc_.leftMargin,
+            page_h - 0.55 * inch,
+            page_w - doc_.rightMargin,
+            page_h - 0.55 * inch,
+        )
+        # Header text
+        canvas.setFont("Times-Bold", 9)
+        canvas.setFillColor(colors.black)
+        canvas.drawString(
+            doc_.leftMargin,
+            page_h - 0.42 * inch,
+            "BLACK BOX — FORENSIC REPORT",
+        )
+        canvas.setFont("Courier", 8)
+        canvas.setFillColor(colors.HexColor("#6b6b66"))
+        canvas.drawRightString(
+            page_w - doc_.rightMargin,
+            page_h - 0.42 * inch,
+            f"CASE {case_key} · {mode_label}",
+        )
+        # Footer rule + page number
+        canvas.setStrokeColor(colors.HexColor("#b0ac9f"))
+        canvas.setLineWidth(0.35)
+        canvas.line(
+            doc_.leftMargin,
+            0.58 * inch,
+            page_w - doc_.rightMargin,
+            0.58 * inch,
+        )
+        canvas.setFont("Helvetica", 8)
+        canvas.setFillColor(colors.HexColor("#6b6b66"))
+        canvas.drawString(doc_.leftMargin, 0.42 * inch, "Inference-only · Opus 4.7")
+        canvas.drawRightString(
+            page_w - doc_.rightMargin,
+            0.42 * inch,
+            f"Page {canvas.getPageNumber()}",
+        )
+        canvas.restoreState()
 
     hypotheses = list(report_json.get("hypotheses", []) or [])
     timeline = list(report_json.get("timeline", []) or [])
@@ -219,13 +285,17 @@ def build_report(
     story: list[Any] = []
 
     # ---------- 1. Cover ----------
-    story.append(Spacer(1, 1.4 * inch))
+    story.append(Spacer(1, 1.1 * inch))
+    story.append(Paragraph(
+        "— OFFICIAL CASE REPORT · FOR TECHNICAL REVIEW —",
+        styles["cover_classification"],
+    ))
+    story.append(Spacer(1, 0.12 * inch))
     story.append(Paragraph("BLACK BOX — FORENSIC REPORT", styles["cover_title"]))
     story.append(_rule(content_w * 0.6, colors.black))
     story.append(Spacer(1, 0.3 * inch))
-    story.append(Paragraph(f"Case: <b>{case_meta.get('case_key', 'unknown')}</b>",
-                           styles["cover_meta"]))
-    story.append(Paragraph(f"Mode: {case_meta.get('mode', 'post_mortem')}", styles["cover_meta"]))
+    story.append(Paragraph(case_key, styles["cover_case_key"]))
+    story.append(Paragraph(f"Mode: {mode_label}", styles["cover_meta"]))
     if case_meta.get("bag_path"):
         story.append(Paragraph(f"Source: {case_meta['bag_path']}", styles["cover_meta"]))
     if case_meta.get("duration_s") is not None:
@@ -388,5 +458,5 @@ def build_report(
         story.append(Spacer(1, 6))
         story.append(Preformatted(code_diff, styles["mono"]))
 
-    doc.build(story)
+    doc.build(story, onFirstPage=_draw_page_chrome, onLaterPages=_draw_page_chrome)
     return out_pdf

--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -20,6 +20,8 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from black_box.reporting.diff import demo_side_by_side_html, parse_patch_proposal
+
 # ---- paths ------------------------------------------------------------------
 BASE_DIR = Path(__file__).resolve().parent
 REPO_ROOT = BASE_DIR.parent.parent.parent  # src/black_box/ui -> repo root
@@ -27,7 +29,8 @@ DATA_DIR = REPO_ROOT / "data"
 JOBS_DIR = DATA_DIR / "jobs"
 REPORTS_DIR = DATA_DIR / "reports"
 UPLOADS_DIR = DATA_DIR / "uploads"
-for d in (JOBS_DIR, REPORTS_DIR, UPLOADS_DIR):
+PATCHES_DIR = DATA_DIR / "patches"
+for d in (JOBS_DIR, REPORTS_DIR, UPLOADS_DIR, PATCHES_DIR):
     d.mkdir(parents=True, exist_ok=True)
 
 # ---- app --------------------------------------------------------------------
@@ -38,6 +41,36 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 Mode = Literal["post_mortem", "scenario_mining", "synthetic_qa"]
 
+# Per-stage reasoning chunks — visible during the stream so the demo reads
+# as a thought process, not a progress bar. Stub only; real pipeline streams
+# from Claude's managed-agent session events.
+_STAGE_CHUNKS: dict[str, list[str]] = {
+    "ingesting": [
+        "Opening recording and enumerating topics...",
+        "Found /imu (100 Hz), /cam_{front,left,right,back,top} (10 Hz), /joint_states.",
+        "Decoded 3.2 s of telemetry; sampling frames at 10 fps across 5 cameras.",
+    ],
+    "analyzing": [
+        "Pulled 5-camera composite at t=1.8s (telemetry delta flagged this window).",
+        "Claude call 1: cross-view reasoning over 5 thumbnails + IMU window.",
+        "IMU pitch slope = -0.42 rad/s; /joint/LHipPitch command at +2.5 while joint saturates.",
+        "Working theory: PID integral wind-up on hip pitch during step initiation.",
+    ],
+    "synthesizing": [
+        "Grounding gate: 3/3 hypotheses meet min_evidence=2 (telemetry + camera).",
+        "Cross-source corroboration: cameras {front, left} + /imu + pid_controller.cpp.",
+        "Dropping 1 low-confidence info moment; keeping 2 anomalous.",
+    ],
+    "reporting": [
+        "Rendering annotated frames with bbox overlays on hip joint...",
+        "Generating unified diff against pid_controller.cpp...",
+        "Writing NTSB-style PDF to data/reports/{job}.pdf.",
+    ],
+    "done": [
+        "Done. Root cause: pid_saturation (confidence 0.82). Patch: clamp integral ±1.0.",
+    ],
+}
+
 STAGES = [
     ("ingesting", "Decoding bag and extracting frames"),
     ("analyzing", "Claude is reviewing evidence"),
@@ -46,9 +79,36 @@ STAGES = [
     ("done", "Complete"),
 ]
 
+# Stub patch artifact used by the diff viewer demo beat.
+_STUB_PATCH = {
+    "file_path": "src/controllers/pid_controller.cpp",
+    "old": (
+        "void PidController::update(double error, double dt) {\n"
+        "    integral_ += error * dt;\n"
+        "    double derivative = (error - prev_error_) / dt;\n"
+        "    output_ = kp_ * error + ki_ * integral_ + kd_ * derivative;\n"
+        "    prev_error_ = error;\n"
+        "}\n"
+    ),
+    "new": (
+        "void PidController::update(double error, double dt) {\n"
+        "    integral_ += error * dt;\n"
+        "    integral_ = std::clamp(integral_, -integral_limit_, integral_limit_);\n"
+        "    double derivative = (error - prev_error_) / dt;\n"
+        "    output_ = kp_ * error + ki_ * integral_ + kd_ * derivative;\n"
+        "    output_ = std::clamp(output_, -output_limit_, output_limit_);\n"
+        "    prev_error_ = error;\n"
+        "}\n"
+    ),
+}
+
 
 def _job_path(job_id: str) -> Path:
     return JOBS_DIR / f"{job_id}.json"
+
+
+def _patch_path(job_id: str) -> Path:
+    return PATCHES_DIR / f"{job_id}.json"
 
 
 def _write_status(job_id: str, payload: dict) -> None:
@@ -67,28 +127,37 @@ def _read_status(job_id: str) -> dict | None:
 
 # ---- background stub --------------------------------------------------------
 def _run_pipeline_stub(job_id: str, upload_path: Path, mode: Mode) -> None:
-    """Fake pipeline: walks through stages with sleeps.
+    """Fake pipeline: streams reasoning chunks and walks through stages.
 
     TODO(pipeline): wire real ingestion -> claude -> reporting here.
     """
+    buffer: list[str] = []
     try:
-        for stage, label in STAGES:
-            reasoning = f"[{mode}] {label} for {upload_path.name}..."
-            _write_status(
-                job_id,
-                {
-                    "job_id": job_id,
-                    "stage": stage,
-                    "label": label,
-                    "progress": (STAGES.index((stage, label)) + 1) / len(STAGES),
-                    "mode": mode,
-                    "upload": str(upload_path.name),
-                    "reasoning": reasoning,
-                },
-            )
-            if stage != "done":
-                time.sleep(2)
+        for i, (stage, label) in enumerate(STAGES):
+            chunks = _STAGE_CHUNKS.get(stage, [label])
+            base_progress = i / len(STAGES)
+            for j, chunk in enumerate(chunks):
+                buffer.append(f"[{stage}] {chunk}")
+                inner_progress = base_progress + ((j + 1) / len(chunks)) * (1.0 / len(STAGES))
+                _write_status(
+                    job_id,
+                    {
+                        "job_id": job_id,
+                        "stage": stage,
+                        "label": label,
+                        "progress": inner_progress,
+                        "mode": mode,
+                        "upload": str(upload_path.name),
+                        "reasoning_buffer": list(buffer),
+                        "has_diff": stage == "done",
+                    },
+                )
+                if stage != "done":
+                    time.sleep(0.8)
+        # Write stub patch artifact for the diff route.
+        _patch_path(job_id).write_text(json.dumps(_STUB_PATCH, indent=2))
     except Exception as e:  # pragma: no cover - defensive
+        buffer.append(f"ERROR: {e!r}")
         _write_status(
             job_id,
             {
@@ -97,7 +166,8 @@ def _run_pipeline_stub(job_id: str, upload_path: Path, mode: Mode) -> None:
                 "label": "Pipeline error",
                 "progress": 0.0,
                 "mode": mode,
-                "reasoning": f"ERROR: {e!r}",
+                "reasoning_buffer": list(buffer),
+                "has_diff": False,
             },
         )
 
@@ -133,12 +203,12 @@ async def analyze(
             "progress": 0.0,
             "mode": mode,
             "upload": upload_path.name,
-            "reasoning": "Waiting for worker...",
+            "reasoning_buffer": ["Waiting for worker..."],
+            "has_diff": False,
         },
     )
     background.add_task(_run_pipeline_stub, job_id, upload_path, mode)  # type: ignore[arg-type]
 
-    # Return the progress fragment so HTMX swaps it into #result
     return templates.TemplateResponse(
         request,
         "progress.html",
@@ -164,3 +234,34 @@ async def report(job_id: str) -> FileResponse:
     if not pdf.exists():
         raise HTTPException(404, "report not ready")
     return FileResponse(str(pdf), media_type="application/pdf", filename=pdf.name)
+
+
+@app.get("/diff/{job_id}", response_class=HTMLResponse)
+async def diff_view(job_id: str) -> HTMLResponse:
+    """Side-by-side diff viewer — the 2:00–2:20 demo beat.
+
+    Reads the patch artifact written by the pipeline. Falls back to parsing
+    ``patch_proposal`` from the JSON report if no structured artifact exists.
+    """
+    patch_file = _patch_path(job_id)
+    if patch_file.exists():
+        patch = json.loads(patch_file.read_text())
+        old, new = patch["old"], patch["new"]
+        file_path = patch.get("file_path", "patch")
+    else:
+        # Fallback: parse a text patch_proposal if a report JSON is present.
+        report_json = JOBS_DIR / f"{job_id}_report.json"
+        if not report_json.exists():
+            raise HTTPException(404, "no patch artifact for job")
+        rep = json.loads(report_json.read_text())
+        proposal = rep.get("patch_proposal", "")
+        file_path, old, new = parse_patch_proposal(proposal)
+
+    html = demo_side_by_side_html(
+        old=old,
+        new=new,
+        file_path=file_path,
+        case_key=job_id,
+        title="Proposed Fix",
+    )
+    return HTMLResponse(html)

--- a/src/black_box/ui/static/style.css
+++ b/src/black_box/ui/static/style.css
@@ -111,18 +111,81 @@ button:hover { background: #000; }
 .bar-bg { fill: var(--line); }
 .bar-fg { fill: var(--ink); transition: width 0.4s ease; }
 
+.reasoning-stream {
+  margin: 0.25rem 0 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: #141412;
+  color: #e7e4db;
+  overflow: hidden;
+}
+
+.reasoning-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 0.75rem;
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #9a958a;
+  background: #1e1d1b;
+  border-bottom: 1px solid #2a2825;
+}
+
+.stream-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #e0b14b;
+  box-shadow: 0 0 8px #e0b14b;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+.stream-dot.done {
+  background: #6fb26f;
+  box-shadow: 0 0 8px #6fb26f;
+  animation: none;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.4; }
+  50%      { opacity: 1; }
+}
+
 .reasoning {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.82rem;
-  color: #333;
-  background: #f2efe6;
-  padding: 0.75rem;
-  border-radius: 3px;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: #e7e4db;
+  background: transparent;
+  padding: 0.85rem 1rem;
   white-space: pre-wrap;
   margin: 0;
-  max-height: 180px;
+  max-height: 260px;
   overflow: auto;
 }
+
+.reasoning-line {
+  display: block;
+  animation: fade-in 0.28s ease-out;
+}
+.reasoning-line:last-child {
+  color: #fff;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.cursor {
+  display: inline-block;
+  color: #e0b14b;
+  animation: blink 0.9s steps(1) infinite;
+  margin-left: 2px;
+}
+@keyframes blink { 50% { opacity: 0; } }
 
 .meta {
   display: flex;
@@ -133,7 +196,8 @@ button:hover { background: #000; }
   flex-wrap: wrap;
 }
 .meta code { font-size: 0.82rem; color: var(--ink); }
-.meta a { color: var(--ink); }
+.meta a { color: var(--ink); text-decoration: underline; text-underline-offset: 3px; }
+.meta a.link-diff { color: var(--accent); font-weight: 500; }
 
 footer {
   margin-top: 3.5rem;

--- a/src/black_box/ui/templates/progress.html
+++ b/src/black_box/ui/templates/progress.html
@@ -1,7 +1,9 @@
 {% set stage = status.get('stage', 'queued') %}
 {% set pct = (status.get('progress', 0.0) * 100) | round(0, 'floor') %}
 {% set done = stage in ['done', 'failed'] %}
+{% set buffer = status.get('reasoning_buffer', []) %}
 <div
+  id="progress-card"
   class="progress-card {% if stage == 'failed' %}failed{% endif %}"
   {% if not done %}
   hx-get="/status/{{ job_id }}"
@@ -19,13 +21,30 @@
     <rect x="0" y="0" width="{{ pct }}" height="4" class="bar-fg"/>
   </svg>
 
-  <pre class="reasoning">{{ status.get('reasoning', '') }}</pre>
+  <div class="reasoning-stream" data-stage="{{ stage }}">
+    <div class="reasoning-header">
+      <span>forensic reasoning</span>
+      <span class="stream-dot {% if done %}done{% endif %}"></span>
+    </div>
+    <pre class="reasoning" id="reasoning-pre">{% for line in buffer -%}
+<span class="reasoning-line">{{ line }}</span>{% if not loop.last %}
+{% endif %}{% endfor %}{% if not done and buffer %}<span class="cursor">▍</span>{% endif %}</pre>
+  </div>
 
   <div class="meta">
     <span>job <code>{{ job_id }}</code></span>
     <span>mode {{ status.get('mode', '—') }}</span>
+    {% if status.get('has_diff') %}
+      <a class="link-diff" href="/diff/{{ job_id }}" target="_blank" rel="noopener">View proposed fix →</a>
+    {% endif %}
     {% if stage == 'done' %}
-      <a href="/report/{{ job_id }}">Download report</a>
+      <a class="link-report" href="/report/{{ job_id }}">Download report</a>
     {% endif %}
   </div>
 </div>
+<script>
+  (function () {
+    var pre = document.getElementById('reasoning-pre');
+    if (pre) { pre.scrollTop = pre.scrollHeight; }
+  })();
+</script>

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -8,6 +8,8 @@ from PIL import Image, ImageDraw
 
 from black_box.reporting import (
     build_report,
+    demo_side_by_side_html,
+    parse_patch_proposal,
     scoped_check,
     side_by_side_html,
     unified_diff_str,
@@ -108,6 +110,49 @@ def test_side_by_side_html() -> None:
     assert "delta" in html_out
     assert "#e6ffed" in html_out  # added bg color
     assert "<html" in html_out.lower()
+
+
+def test_demo_side_by_side_html_has_ntsb_chrome() -> None:
+    old = "x = 1\ny = 2\n"
+    new = "x = 1\ny = clamp(2, 0, 5)\n"
+    out = demo_side_by_side_html(
+        old, new,
+        file_path="src/controller.cpp",
+        case_key="c1_faceplant",
+        title="Proposed Fix",
+    )
+    # Banner + case key visible
+    assert "BLACK BOX — FORENSIC DIFF" in out
+    assert "c1_faceplant" in out
+    assert "src/controller.cpp" in out
+    # Legend keys
+    assert "− removed" in out
+    assert "+ added" in out
+    # Demo-size font: 14px, not 12px
+    assert "font-size:14px" in out
+    # Both columns still rendered
+    assert "clamp(2, 0, 5)" in out
+
+
+def test_parse_patch_proposal_extracts_file_and_sides() -> None:
+    text = (
+        "In pid_controller.cpp, line 45:\n"
+        "- integral += error;\n"
+        "+ integral += error;\n"
+        "+ integral = clamp(integral, -1.0, 1.0);\n"
+    )
+    path, old, new = parse_patch_proposal(text)
+    assert path == "pid_controller.cpp"
+    assert "integral += error;" in old
+    assert "clamp(integral" in new
+    assert "clamp(integral" not in old
+
+
+def test_parse_patch_proposal_empty_text() -> None:
+    path, old, new = parse_patch_proposal("")
+    assert path == "patch"
+    assert old == ""
+    assert new == ""
 
 
 if __name__ == "__main__":

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import io
+import json
 
 from fastapi.testclient import TestClient
 
+from black_box.ui import app as ui_app
 from black_box.ui.app import app
 
 
@@ -28,6 +30,72 @@ def test_analyze_creates_job():
     # progress fragment carries the job id in its polling URL
     assert "/status/" in r.text
     assert "stage-label" in r.text or "progress-card" in r.text
+
+
+def test_status_renders_reasoning_buffer(tmp_path, monkeypatch):
+    """Status fragment should render every line of the streaming buffer."""
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    job_id = "bufjob"
+    (tmp_path / f"{job_id}.json").write_text(json.dumps({
+        "job_id": job_id,
+        "stage": "analyzing",
+        "label": "Claude is reviewing evidence",
+        "progress": 0.5,
+        "mode": "post_mortem",
+        "reasoning_buffer": [
+            "[analyzing] Pulled 5-camera composite.",
+            "[analyzing] IMU pitch slope = -0.42 rad/s.",
+        ],
+        "has_diff": False,
+    }))
+    client = TestClient(app)
+    r = client.get(f"/status/{job_id}")
+    assert r.status_code == 200
+    assert "5-camera composite" in r.text
+    assert "-0.42 rad/s" in r.text
+    # Cursor is present while streaming
+    assert "cursor" in r.text
+
+
+def test_status_done_state_shows_diff_and_report_links(tmp_path, monkeypatch):
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    job_id = "donejob"
+    (tmp_path / f"{job_id}.json").write_text(json.dumps({
+        "job_id": job_id,
+        "stage": "done",
+        "label": "Complete",
+        "progress": 1.0,
+        "mode": "post_mortem",
+        "reasoning_buffer": ["[done] Root cause: pid_saturation."],
+        "has_diff": True,
+    }))
+    client = TestClient(app)
+    r = client.get(f"/status/{job_id}")
+    assert r.status_code == 200
+    assert f"/diff/{job_id}" in r.text
+    assert f"/report/{job_id}" in r.text
+
+
+def test_diff_route_renders_patch(tmp_path, monkeypatch):
+    monkeypatch.setattr(ui_app, "PATCHES_DIR", tmp_path)
+    job_id = "diffjob"
+    (tmp_path / f"{job_id}.json").write_text(json.dumps({
+        "file_path": "src/pid.cpp",
+        "old": "integral += error;\n",
+        "new": "integral += error;\nintegral = clamp(integral, -1, 1);\n",
+    }))
+    client = TestClient(app)
+    r = client.get(f"/diff/{job_id}")
+    assert r.status_code == 200
+    assert "src/pid.cpp" in r.text
+    assert "clamp(integral" in r.text
+    assert "BLACK BOX — FORENSIC DIFF" in r.text
+
+
+def test_diff_route_404_for_missing_patch():
+    client = TestClient(app)
+    r = client.get("/diff/no-such-job")
+    assert r.status_code == 404
 
 
 def test_status_unknown_job_404s():


### PR DESCRIPTION
## Summary
Addresses the three demo-video beats you flagged in the 6:15 PM message:

- **Streaming reasoning view (0:45–1:15)** — `_run_pipeline_stub` now emits 12 reasoning chunks across 5 stages into a `reasoning_buffer: list[str]`. `progress.html` renders each chunk as a `.reasoning-line` with fade-in animation, blinking cursor on the last line while streaming, and a live indicator dot in the header. Dark-terminal look (`#141412` bg, Plex mono) auto-scrolls to bottom. Polls at 1s via HTMX.
- **Side-by-side diff viewer (2:00–2:20)** — new `GET /diff/{job_id}` route renders the patch artifact with `demo_side_by_side_html()`: 14px mono, IBM Plex Serif banner, file-path pill, line-number gutters, muted green/red row bg, legend + case key footer. Also added `parse_patch_proposal()` so the route can fall back to the schema's informal pseudo-diff.
- **NTSB-style PDF (1:15–1:40)** — every page now has a top rule + `BLACK BOX — FORENSIC REPORT` (Times-Bold) with `CASE {key} · {mode}` right-aligned, and a footer rule with `Inference-only · Opus 4.7` + page number. Cover adds the small-caps red classification banner and case key in Courier-Bold.

Stub writes a realistic PID-clamp patch artifact on `done` so the diff route has something to render end-to-end for the demo.

## Test plan
- [x] `PYTHONPATH=src pytest tests/test_reporting.py tests/test_ui.py tests/test_eval.py tests/test_synthesis.py -q` → **21 passed**
- [x] New tests: demo diff NTSB chrome, `parse_patch_proposal` happy/empty, reasoning buffer rendering with cursor, diff-route happy/404, done-state link rendering
- [x] Visual check: rendered a sample PDF — banner + header/footer chrome intact
- [x] Visual check: rendered the diff page — 14px mono, file pill, legend all present
- [ ] Wire real pipeline into `_run_pipeline_stub` (intentional follow-up; stub is demo-ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)