### PR TITLE
feat(nao6): controller snapshots + fixture variants + humanoid taxonomy

### DIFF
--- a/scripts/snapshot_controllers.py
+++ b/scripts/snapshot_controllers.py
@@ -1,0 +1,111 @@
+"""Freeze a copy of the NAO6 controllers at fall-trigger time.
+
+Writes controller sources verbatim into an output directory along with a
+manifest containing git SHA, timestamp, Python version, and per-file hashes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTROLLERS_DIR = REPO_ROOT / "src" / "black_box" / "platforms" / "nao6" / "controllers"
+
+
+def _git_sha(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return "no-git"
+    if result.returncode != 0:
+        return "no-git"
+    sha = result.stdout.strip()
+    return sha or "no-git"
+
+
+def _hash_file(path: Path) -> tuple[str, int, int]:
+    data = path.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    line_count = data.count(b"\n") + (0 if data.endswith(b"\n") or not data else 1)
+    return digest, len(data), line_count
+
+
+def snapshot(case_key: str, out_dir: Path) -> dict:
+    if not CONTROLLERS_DIR.is_dir():
+        print(
+            f"error: controllers directory not found at {CONTROLLERS_DIR}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    out_dir = Path(out_dir)
+    snapshot_dir = out_dir / "controllers_snapshot"
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    controllers = sorted(CONTROLLERS_DIR.glob("*.py"))
+    entries: list[dict] = []
+    for src in controllers:
+        dest = snapshot_dir / src.name
+        dest.write_bytes(src.read_bytes())
+        digest, size, lines = _hash_file(dest)
+        entries.append(
+            {
+                "filename": src.name,
+                "sha256": digest,
+                "size_bytes": size,
+                "line_count": lines,
+            }
+        )
+
+    sha = _git_sha(REPO_ROOT)
+    manifest = {
+        "case_key": case_key,
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "git_sha": sha,
+        "python_version": sys.version.split()[0],
+        "controllers": entries,
+    }
+
+    manifest_path = out_dir / "snapshot_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    short = sha[:8] if sha != "no-git" else "no-git"
+    print(f"snapshotted {len(entries)} controllers to {out_dir} (sha {short})")
+    return manifest
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Snapshot NAO6 controllers at fall-trigger time."
+    )
+    parser.add_argument(
+        "--case-key",
+        required=True,
+        help="Case identifier (e.g. c1_faceplant)",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output directory for the snapshot",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    snapshot(args.case_key, args.out)

--- a/src/black_box/platforms/nao6/__init__.py
+++ b/src/black_box/platforms/nao6/__init__.py
@@ -1,5 +1,12 @@
-"""NAO6 (SoftBank Aldebaran) ingestion adapter."""
+"""NAO6 (SoftBank Aldebaran) ingestion adapter + humanoid-specific taxonomy."""
 
 from .adapter import NAO6Adapter
+from .taxonomy import NAO6_TAXONOMY, NAO6BugClass, by_slug, to_global
 
-__all__ = ["NAO6Adapter"]
+__all__ = [
+    "NAO6Adapter",
+    "NAO6BugClass",
+    "NAO6_TAXONOMY",
+    "by_slug",
+    "to_global",
+]

--- a/src/black_box/platforms/nao6/_fixture.py
+++ b/src/black_box/platforms/nao6/_fixture.py
@@ -1,12 +1,18 @@
-"""Deterministic synthetic NAO6 forward-fall fixture.
+"""Deterministic synthetic NAO6 fall fixtures.
 
 Writes real MP4 + CSV + .py artifacts to disk so the adapter runs the same
 code path it would on tomorrow's real recordings. No randomness — any math
 uses fixed constants so tests are reproducible.
+
+Scenarios:
+  generate_fall_fixture              — forward faceplant from PID wind-up
+  generate_lateral_tip_fixture       — sideways tip from weak roll gain
+  generate_stumble_recovery_fail_fixture — teeter then topple from stuck recovery FSM
 """
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import cv2
@@ -200,3 +206,347 @@ class BalancePID:
 
 def _write_controller(path: Path) -> None:
     path.write_text(_CONTROLLER_SRC, encoding="utf-8")
+
+
+# ---- shared helpers for variant scenarios ----------------------------------
+
+
+def _build_horizon_base() -> np.ndarray:
+    """Sky over ground base image (same look as the forward-fall top video)."""
+    sky = np.full((_HEIGHT, _WIDTH, 3), (200, 160, 90), dtype=np.uint8)
+    ground = np.full((_HEIGHT, _WIDTH, 3), (60, 90, 40), dtype=np.uint8)
+    base = sky.copy()
+    base[_HEIGHT // 2 :] = ground[_HEIGHT // 2 :]
+    return base
+
+
+def _build_checkerboard_floor() -> np.ndarray:
+    floor = np.zeros((_HEIGHT, _WIDTH, 3), dtype=np.uint8)
+    tile = 40
+    for y in range(0, _HEIGHT, tile):
+        for x in range(0, _WIDTH, tile):
+            if ((x // tile) + (y // tile)) % 2 == 0:
+                floor[y : y + tile, x : x + tile] = (180, 180, 180)
+            else:
+                floor[y : y + tile, x : x + tile] = (110, 110, 110)
+    return floor
+
+
+def _write_csv(path: Path, rows: list[tuple[int, str, str]]) -> None:
+    import csv as _csv
+
+    with path.open("w", newline="") as f:
+        w = _csv.writer(f)
+        w.writerow(["t_ns", "key", "value"])
+        for row in rows:
+            w.writerow(row)
+
+
+# ---- Scenario A: lateral tip-over ------------------------------------------
+
+
+def generate_lateral_tip_fixture(out_dir: Path) -> dict[str, Path]:
+    """Emit a reproducible NAO6 lateral (sideways) tip-over scenario.
+
+    Roll (AngleX) ramps while pitch stays flat. Top camera rolls about its
+    optical axis; bottom camera gets occluded from the LEFT as the robot
+    tips onto its side. Controller bug: weak Kp_roll — bad_gain_tuning.
+
+    Returns paths keyed as: top_video, bottom_video, telemetry_csv, controller_source.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    top_path = out_dir / "top_video.mp4"
+    bottom_path = out_dir / "bottom_video.mp4"
+    tele_path = out_dir / "telemetry.csv"
+    ctrl_path = out_dir / "controller.py"
+
+    _write_top_video_lateral(top_path)
+    _write_bottom_video_lateral(bottom_path)
+    _write_telemetry_lateral(tele_path)
+    ctrl_path.write_text(_CONTROLLER_LATERAL_SRC, encoding="utf-8")
+
+    return {
+        "top_video": top_path,
+        "bottom_video": bottom_path,
+        "telemetry_csv": tele_path,
+        "controller_source": ctrl_path,
+    }
+
+
+def _write_top_video_lateral(path: Path) -> None:
+    vw = cv2.VideoWriter(str(path), _fourcc(), _FPS, (_WIDTH, _HEIGHT))
+    try:
+        base = _build_horizon_base()
+        for i in range(_TOTAL_FRAMES):
+            t_s = i / _FPS
+            # Stable 1.5s, then roll to +70deg over remaining 1.5s (horizon tilts left)
+            if t_s < 1.5:
+                angle_deg = 0.0
+            else:
+                frac = (t_s - 1.5) / 1.5
+                angle_deg = 70.0 * frac
+            m = cv2.getRotationMatrix2D((_WIDTH / 2, _HEIGHT / 2), angle_deg, 1.0)
+            rotated = cv2.warpAffine(base, m, (_WIDTH, _HEIGHT), borderValue=(0, 0, 0))
+            vw.write(rotated)
+    finally:
+        vw.release()
+
+
+def _write_bottom_video_lateral(path: Path) -> None:
+    vw = cv2.VideoWriter(str(path), _fourcc(), _FPS, (_WIDTH, _HEIGHT))
+    try:
+        floor = _build_checkerboard_floor()
+        for i in range(_TOTAL_FRAMES):
+            t_s = i / _FPS
+            frame = floor.copy()
+            # Occlusion sweeps in from the LEFT as the robot lies on its side
+            if t_s < 1.5:
+                occl_px = 0
+            else:
+                frac = (t_s - 1.5) / 1.5
+                occl_px = int(frac * _WIDTH)
+            if occl_px > 0:
+                frame[:, :occl_px] = (20, 20, 20)
+            vw.write(frame)
+    finally:
+        vw.release()
+
+
+def _write_telemetry_lateral(path: Path) -> None:
+    samples = _TELE_HZ * _DURATION_S
+    dt_ns = int(1e9 / _TELE_HZ)
+    rows: list[tuple[int, str, str]] = []
+    for i in range(samples):
+        t_ns = i * dt_ns
+        t_s = i / _TELE_HZ
+
+        # AngleX (roll): 0.01 rad for 1.5s, then ramp to 0.9 rad
+        if t_s < 1.5:
+            angle_x = 0.01
+        else:
+            frac = (t_s - 1.5) / 1.5
+            angle_x = 0.01 + (0.9 - 0.01) * frac
+        rows.append((t_ns, "InertialSensor/AngleX/Sensor/Value", f"{angle_x:.6f}"))
+
+        # GyrX: ~0 for 1.5s, then +2.7 rad/s as robot rolls sideways
+        gyr_x = 0.0 if t_s < 1.5 else 2.7
+        rows.append((t_ns, "GyrX", f"{gyr_x:.6f}"))
+
+        # AccZ: nominal, freefall dip, impact spike, rest
+        if t_s < 1.5:
+            acc_z = -9.81
+        elif t_s < 2.7:
+            acc_z = -4.0
+        elif t_s < 2.8:
+            acc_z = -38.0
+        else:
+            acc_z = -9.81
+        rows.append((t_ns, "AccZ", f"{acc_z:.6f}"))
+
+        state = "standing" if t_s < 1.5 else "tipping"
+        rows.append((t_ns, "BalanceController/State", state))
+
+    _write_csv(path, rows)
+
+
+_CONTROLLER_LATERAL_SRC = '''"""Toy NAO6 lateral balance controller.
+
+BUG (intentional, for synthetic QA — bug_class: bad_gain_tuning):
+The roll-axis proportional gain (kp_roll) was copy-pasted from an early
+prototype at 0.8 when the tuned value should be ~4.0. Under a real
+lateral disturbance the commanded hip-roll correction is ~5x too small,
+so the robot tips sideways faster than the controller can restore it.
+"""
+
+from __future__ import annotations
+
+
+class LateralBalancePID:
+    def __init__(self, kp_roll: float = 0.8, ki_roll: float = 0.2, kd_roll: float = 0.1) -> None:
+        # BUG: kp_roll=0.8 is the un-tuned prototype value; sane value ~= 4.0
+        self.kp_roll = kp_roll
+        self.ki_roll = ki_roll
+        self.kd_roll = kd_roll
+        self.integral = 0.0
+        self.last_err = 0.0
+        self.state = "standing"
+
+    def step(self, angle_x: float, dt: float) -> float:
+        err = 0.0 - angle_x  # setpoint = upright about the roll axis
+        self.integral += err * dt
+        deriv = (err - self.last_err) / max(dt, 1e-6)
+        self.last_err = err
+        if abs(angle_x) > 0.2:
+            self.state = "tipping"
+        # Under-gained response — will not arrest the tip in time.
+        hip_roll_torque = self.kp_roll * err + self.ki_roll * self.integral + self.kd_roll * deriv
+        return hip_roll_torque
+'''
+
+
+# ---- Scenario B: stumble + recovery-deadlock -------------------------------
+
+
+def generate_stumble_recovery_fail_fixture(out_dir: Path) -> dict[str, Path]:
+    """Emit a reproducible NAO6 stumble -> failed recovery scenario.
+
+    Pitch oscillates for 1.5s (teeter), then ramps forward as the robot
+    slowly topples. The controller enters RECOVERING and deadlocks.
+    Bug_class: state_machine_deadlock.
+
+    Returns paths keyed as: top_video, bottom_video, telemetry_csv, controller_source.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    top_path = out_dir / "top_video.mp4"
+    bottom_path = out_dir / "bottom_video.mp4"
+    tele_path = out_dir / "telemetry.csv"
+    ctrl_path = out_dir / "controller.py"
+
+    _write_top_video_stumble(top_path)
+    _write_bottom_video_stumble(bottom_path)
+    _write_telemetry_stumble(tele_path)
+    ctrl_path.write_text(_CONTROLLER_STUMBLE_SRC, encoding="utf-8")
+
+    return {
+        "top_video": top_path,
+        "bottom_video": bottom_path,
+        "telemetry_csv": tele_path,
+        "controller_source": ctrl_path,
+    }
+
+
+def _write_top_video_stumble(path: Path) -> None:
+    vw = cv2.VideoWriter(str(path), _fourcc(), _FPS, (_WIDTH, _HEIGHT))
+    try:
+        base = _build_horizon_base()
+        for i in range(_TOTAL_FRAMES):
+            t_s = i / _FPS
+            if t_s < 1.5:
+                # Small pitch oscillation — ~+/-8 deg at 2 Hz
+                angle_deg = -8.0 * math.sin(2.0 * math.pi * 2.0 * t_s)
+            else:
+                # Monotonic forward pitch: 0 -> -55 deg over last 1.5s
+                frac = (t_s - 1.5) / 1.5
+                angle_deg = -55.0 * frac
+            m = cv2.getRotationMatrix2D((_WIDTH / 2, _HEIGHT / 2), angle_deg, 1.0)
+            rotated = cv2.warpAffine(base, m, (_WIDTH, _HEIGHT), borderValue=(0, 0, 0))
+            vw.write(rotated)
+    finally:
+        vw.release()
+
+
+def _write_bottom_video_stumble(path: Path) -> None:
+    vw = cv2.VideoWriter(str(path), _fourcc(), _FPS, (_WIDTH, _HEIGHT))
+    try:
+        floor = _build_checkerboard_floor()
+        for i in range(_TOTAL_FRAMES):
+            t_s = i / _FPS
+            frame = floor.copy()
+            # Stable for the teeter phase, then gradual top-down occlusion
+            if t_s < 1.5:
+                occl_px = 0
+            else:
+                frac = (t_s - 1.5) / 1.5
+                occl_px = int(frac * _HEIGHT)
+            if occl_px > 0:
+                frame[:occl_px] = (20, 20, 20)
+            vw.write(frame)
+    finally:
+        vw.release()
+
+
+def _write_telemetry_stumble(path: Path) -> None:
+    samples = _TELE_HZ * _DURATION_S
+    dt_ns = int(1e9 / _TELE_HZ)
+    rows: list[tuple[int, str, str]] = []
+    for i in range(samples):
+        t_ns = i * dt_ns
+        t_s = i / _TELE_HZ
+
+        # AngleY: sine oscillation (amplitude 0.15 rad) for 1.5s, then ramp to 0.75 rad
+        if t_s < 1.5:
+            angle_y = 0.15 * math.sin(2.0 * math.pi * 2.0 * t_s)
+        else:
+            frac = (t_s - 1.5) / 1.5
+            angle_y = 0.0 + (0.75 - 0.0) * frac
+        rows.append((t_ns, "InertialSensor/AngleY/Sensor/Value", f"{angle_y:.6f}"))
+
+        # GyrY tracks the derivative roughly: oscillating, then steady negative
+        if t_s < 1.5:
+            gyr_y = 0.15 * 2.0 * math.pi * 2.0 * math.cos(2.0 * math.pi * 2.0 * t_s)
+        else:
+            gyr_y = -2.2
+        rows.append((t_ns, "GyrY", f"{gyr_y:.6f}"))
+
+        # AccZ: nominal with brief freefall when toppling begins, impact near end
+        if t_s < 1.5:
+            acc_z = -9.81
+        elif t_s < 2.7:
+            acc_z = -5.0
+        elif t_s < 2.8:
+            acc_z = -36.0
+        else:
+            acc_z = -9.81
+        rows.append((t_ns, "AccZ", f"{acc_z:.6f}"))
+
+        # State machine: standing -> teetering -> recovering -> fell.
+        # Notice: once "recovering" appears, it never returns to "standing".
+        if t_s < 0.8:
+            state = "standing"
+        elif t_s < 1.5:
+            state = "teetering"
+        elif t_s < 2.7:
+            state = "recovering"
+        else:
+            state = "fell"
+        rows.append((t_ns, "BalanceController/State", state))
+
+    _write_csv(path, rows)
+
+
+_CONTROLLER_STUMBLE_SRC = '''"""Toy NAO6 stumble-recovery FSM.
+
+BUG (intentional, for synthetic QA — bug_class: state_machine_deadlock):
+The controller transitions STANDING -> TEETERING -> RECOVERING on a
+stumble, and is supposed to return to STANDING when |angle_y| drops
+back below a small threshold. There is no timeout and no fall-back
+branch, so if the recovery condition never fires the controller stays
+in RECOVERING forever while the robot slowly topples.
+"""
+
+from __future__ import annotations
+
+
+STANDING = "standing"
+TEETERING = "teetering"
+RECOVERING = "recovering"
+
+
+class StumbleFSM:
+    def __init__(self) -> None:
+        self.state = STANDING
+        self.teeter_thresh = 0.10
+        self.recover_thresh = 0.02  # never reached once the robot begins to topple
+
+    def step(self, angle_y: float, dt: float) -> float:
+        if self.state == STANDING:
+            if abs(angle_y) > self.teeter_thresh:
+                self.state = TEETERING
+        elif self.state == TEETERING:
+            if abs(angle_y) > self.teeter_thresh * 1.2:
+                self.state = RECOVERING
+        elif self.state == RECOVERING:
+            # BUG: only way out is recover_thresh; no timeout, no "give up and brace"
+            # branch. Once angle_y drifts past teeter_thresh monotonically, we are stuck.
+            if abs(angle_y) < self.recover_thresh:
+                self.state = STANDING
+
+        # Simple proportional response regardless of state — fine on paper,
+        # but since we never leave RECOVERING the higher-level planner waits
+        # on a state it will never see.
+        return -3.0 * angle_y
+'''

--- a/src/black_box/platforms/nao6/controllers/__init__.py
+++ b/src/black_box/platforms/nao6/controllers/__init__.py
@@ -1,0 +1,1 @@
+"""NAO6 controller source snapshots — analyzed as artifacts, not imported as library code."""

--- a/src/black_box/platforms/nao6/controllers/balance.py
+++ b/src/black_box/platforms/nao6/controllers/balance.py
@@ -1,0 +1,108 @@
+"""NAO6 balance / fall-prevention controller.
+
+Reads body-frame attitude from the onboard IMU (InertialSensor) and blends a
+reactive ankle-strategy torque with a hip nudge when the robot starts to tip.
+Runs at 100 Hz from the behavior manager.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class BalanceState(Enum):
+    UPRIGHT = "UPRIGHT"
+    TEETERING = "TEETERING"
+    FALL_IMMINENT = "FALL_IMMINENT"
+    RECOVERING = "RECOVERING"
+
+
+# Thresholds in radians (body-frame) and rad/s (gyro).
+_TEETER_ANGLE = 0.12
+_IMMINENT_ANGLE = 0.28
+_TEETER_GYRO = 0.9
+_IMMINENT_GYRO = 2.0
+
+# Recovery torque limits (NAOqi ankle stiffness is clamped to [0, 1] on the API
+# side; these are internal torque-equivalent scalars that map to that range).
+_ANKLE_TORQUE_MAX = 1.0
+_HIP_NUDGE_MAX = 0.6
+
+
+@dataclass
+class BalanceController:
+    state: BalanceState = BalanceState.UPRIGHT
+    t_in_state: float = 0.0
+    last_ankle_cmd: float = 0.0
+    last_hip_cmd: float = 0.0
+    _prev_state: BalanceState = field(default=BalanceState.UPRIGHT)
+
+    def _classify(self, angle_x: float, angle_y: float, gyr_x: float, gyr_y: float) -> BalanceState:
+        tilt = max(abs(angle_x), abs(angle_y))
+        rate = max(abs(gyr_x), abs(gyr_y))
+        if tilt >= _IMMINENT_ANGLE or rate >= _IMMINENT_GYRO:
+            return BalanceState.FALL_IMMINENT
+        if tilt >= _TEETER_ANGLE or rate >= _TEETER_GYRO:
+            return BalanceState.TEETERING
+        return BalanceState.UPRIGHT
+
+    def _ankle_strategy(self, angle_y: float, gyr_y: float) -> float:
+        # Simple PD on pitch: push ankles in the opposite direction of tilt.
+        cmd = -(4.5 * angle_y + 0.6 * gyr_y)
+        if cmd > _ANKLE_TORQUE_MAX:
+            cmd = _ANKLE_TORQUE_MAX
+        elif cmd < -_ANKLE_TORQUE_MAX:
+            cmd = -_ANKLE_TORQUE_MAX
+        return cmd
+
+    def _hip_nudge(self, angle_x: float) -> float:
+        cmd = -(3.0 * angle_x)
+        if cmd > _HIP_NUDGE_MAX:
+            cmd = _HIP_NUDGE_MAX
+        elif cmd < -_HIP_NUDGE_MAX:
+            cmd = -_HIP_NUDGE_MAX
+        return cmd
+
+    def step(
+        self,
+        angle_x: float,
+        angle_y: float,
+        gyr_x: float,
+        gyr_y: float,
+        dt: float,
+    ) -> dict[str, float]:
+        observed = self._classify(angle_x, angle_y, gyr_x, gyr_y)
+
+        # Transition table. UPRIGHT is re-entered only when fully settled.
+        if self.state is BalanceState.UPRIGHT:
+            if observed is not BalanceState.UPRIGHT:
+                self.state = observed
+                self.t_in_state = 0.0
+        elif self.state is BalanceState.TEETERING:
+            if observed is BalanceState.FALL_IMMINENT:
+                self.state = BalanceState.FALL_IMMINENT
+                self.t_in_state = 0.0
+            elif observed is BalanceState.UPRIGHT:
+                self.state = BalanceState.UPRIGHT
+                self.t_in_state = 0.0
+        elif self.state is BalanceState.FALL_IMMINENT:
+            # Engage active recovery; once engaged we drive RECOVERING until upright.
+            self.state = BalanceState.RECOVERING
+            self.t_in_state = 0.0
+        elif self.state is BalanceState.RECOVERING:
+            # Exit recovery only when the IMU reports upright again.
+            if observed is BalanceState.UPRIGHT:
+                self.state = BalanceState.UPRIGHT
+                self.t_in_state = 0.0
+
+        self.t_in_state += dt
+
+        ankle = self._ankle_strategy(angle_y, gyr_y)
+        hip = self._hip_nudge(angle_x) if self.state is not BalanceState.UPRIGHT else 0.0
+        if self.state is BalanceState.UPRIGHT:
+            ankle *= 0.25  # light trim only
+
+        self.last_ankle_cmd = ankle
+        self.last_hip_cmd = hip
+        return {"ankle_pitch_torque": ankle, "hip_roll_nudge": hip}

--- a/src/black_box/platforms/nao6/controllers/fall_detector.py
+++ b/src/black_box/platforms/nao6/controllers/fall_detector.py
@@ -1,0 +1,57 @@
+"""NAO6 fall detector.
+
+Trips when body pitch or roll exceeds thresholds for a sustained window. The
+behavior manager subscribes to the emitted event and halts motion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_ANGLE_Y_THRESH = 0.35  # rad, forward/backward pitch
+_ANGLE_X_THRESH = 0.30  # rad, side-to-side roll
+_SUSTAIN_NS = 100_000_000  # 100 ms
+
+
+@dataclass
+class FallDetector:
+    over_since_ns: int | None = None
+    tripped: bool = False
+
+    def update(self, t_ns: int, angle_x: float, angle_y: float) -> dict | None:
+        # TODO: add staleness check (compare against last_t_ns to reject stuck IMU frames)
+        over_y = abs(angle_y) > _ANGLE_Y_THRESH
+        over_x = abs(angle_x) > _ANGLE_X_THRESH
+        over = over_x or over_y
+
+        if not over:
+            self.over_since_ns = None
+            return None
+
+        if self.over_since_ns is None:
+            self.over_since_ns = t_ns
+            return None
+
+        if self.tripped:
+            return None
+
+        if (t_ns - self.over_since_ns) < _SUSTAIN_NS:
+            return None
+
+        self.tripped = True
+        if over_y:
+            direction = "forward" if angle_y > 0 else "backward"
+            angle_at_trip = angle_y
+        else:
+            direction = "right" if angle_x > 0 else "left"
+            angle_at_trip = angle_x
+        return {
+            "t_ns": t_ns,
+            "kind": "fall_detected",
+            "direction": direction,
+            "angle_at_trip": angle_at_trip,
+        }
+
+    def reset(self) -> None:
+        self.over_since_ns = None
+        self.tripped = False

--- a/src/black_box/platforms/nao6/controllers/walking_gait.py
+++ b/src/black_box/platforms/nao6/controllers/walking_gait.py
@@ -1,0 +1,112 @@
+"""NAO6 walking gait controller.
+
+Drives a simple alternating-step cycle via per-joint PID on the six sagittal
+leg joints. Joint targets are radians (NAOqi convention, positive = flexion
+forward for pitch joints). Commanded at 50 Hz from the main control loop.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class GaitState(Enum):
+    IDLE = "idle"
+    STEP_LEFT = "step_left"
+    STEP_RIGHT = "step_right"
+
+
+# Per-joint gains. HipPitch drives step initiation; Knee/Ankle handle lift + land.
+# NOTE: kp on HipPitch was bumped during indoor tuning to hit step cadence.
+_GAINS: dict[str, tuple[float, float, float]] = {
+    "LHipPitch":    (18.0, 0.4, 0.9),
+    "RHipPitch":    (18.0, 0.4, 0.9),
+    "LKneePitch":   ( 9.5, 0.3, 0.6),
+    "RKneePitch":   ( 9.5, 0.3, 0.6),
+    "LAnklePitch":  ( 8.0, 0.2, 0.5),
+    "RAnklePitch":  ( 8.0, 0.2, 0.5),
+}
+
+# Swing / stance targets in radians. Mirror across legs during alternation.
+_SWING_HIP = 0.45
+_SWING_KNEE = 0.70
+_SWING_ANKLE = -0.25
+_STANCE_HIP = 0.10
+_STANCE_KNEE = 0.15
+_STANCE_ANKLE = -0.05
+
+_STEP_DURATION_S = 0.55
+
+
+@dataclass
+class _PID:
+    kp: float
+    ki: float
+    kd: float
+    integral: float = 0.0
+    last_err: float = 0.0
+
+    def step(self, err: float, dt: float) -> float:
+        self.integral += err * dt
+        deriv = (err - self.last_err) / max(dt, 1e-6)
+        self.last_err = err
+        return self.kp * err + self.ki * self.integral + self.kd * deriv
+
+
+@dataclass
+class WalkingGait:
+    state: GaitState = GaitState.IDLE
+    t_in_state: float = 0.0
+    pids: dict[str, _PID] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.pids:
+            self.pids = {name: _PID(*g) for name, g in _GAINS.items()}
+
+    def targets_for_state(self) -> dict[str, float]:
+        if self.state is GaitState.STEP_LEFT:
+            return {
+                "LHipPitch": _SWING_HIP,   "LKneePitch": _SWING_KNEE,  "LAnklePitch": _SWING_ANKLE,
+                "RHipPitch": _STANCE_HIP,  "RKneePitch": _STANCE_KNEE, "RAnklePitch": _STANCE_ANKLE,
+            }
+        if self.state is GaitState.STEP_RIGHT:
+            return {
+                "LHipPitch": _STANCE_HIP,  "LKneePitch": _STANCE_KNEE, "LAnklePitch": _STANCE_ANKLE,
+                "RHipPitch": _SWING_HIP,   "RKneePitch": _SWING_KNEE,  "RAnklePitch": _SWING_ANKLE,
+            }
+        return {name: 0.0 for name in _GAINS}
+
+    def _advance_state(self, dt: float) -> None:
+        self.t_in_state += dt
+        if self.state is GaitState.IDLE:
+            self.state = GaitState.STEP_LEFT
+            self.t_in_state = 0.0
+            return
+        if self.t_in_state >= _STEP_DURATION_S:
+            self.state = (
+                GaitState.STEP_RIGHT if self.state is GaitState.STEP_LEFT else GaitState.STEP_LEFT
+            )
+            self.t_in_state = 0.0
+
+    def step(self, measured: dict[str, float], dt: float) -> dict[str, float]:
+        self._advance_state(dt)
+        targets = self.targets_for_state()
+        cmd: dict[str, float] = {}
+        for joint, target in targets.items():
+            err = target - measured.get(joint, 0.0)
+            cmd[joint] = self.pids[joint].step(err, dt)
+        return cmd
+
+    def stop(self) -> dict[str, float]:
+        self.state = GaitState.IDLE
+        self.t_in_state = 0.0
+        for pid in self.pids.values():
+            pid.integral = 0.0
+            pid.last_err = 0.0
+        return {name: 0.0 for name in _GAINS}
+
+
+def phase_angle(t_s: float) -> float:
+    return (2.0 * math.pi * t_s) / (2.0 * _STEP_DURATION_S)

--- a/src/black_box/platforms/nao6/taxonomy.py
+++ b/src/black_box/platforms/nao6/taxonomy.py
@@ -1,0 +1,155 @@
+"""NAO6-specific bug taxonomy.
+
+Presentation-layer vocabulary for the NAO6 humanoid platform. Each entry
+maps onto exactly one class from the global closed-set taxonomy in
+`src/black_box/analysis/schemas.py`. When Claude emits a report, the
+`global_class` is what flows into `schemas.Hypothesis.bug_class`; the
+humanoid-specific slug is carried in the report summary or metadata.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+GlobalBugClass = Literal[
+    "pid_saturation",
+    "sensor_timeout",
+    "state_machine_deadlock",
+    "bad_gain_tuning",
+    "missing_null_check",
+    "calibration_drift",
+    "latency_spike",
+    "other",
+]
+
+_ALLOWED_GLOBAL: frozenset[str] = frozenset(
+    {
+        "pid_saturation",
+        "sensor_timeout",
+        "state_machine_deadlock",
+        "bad_gain_tuning",
+        "missing_null_check",
+        "calibration_drift",
+        "latency_spike",
+        "other",
+    }
+)
+
+
+class NAO6BugClass(BaseModel):
+    """One NAO6-specific bug class mapped to a global taxonomy entry."""
+
+    slug: str = Field(min_length=1)
+    display_name: str = Field(min_length=1)
+    global_class: GlobalBugClass
+    description: str = Field(min_length=1)
+    example_signals: list[str] = Field(min_length=1)
+
+
+NAO6_TAXONOMY: list[NAO6BugClass] = [
+    NAO6BugClass(
+        slug="joint_pid_saturation",
+        display_name="Joint PID Saturation",
+        global_class="pid_saturation",
+        description=(
+            "A leg or arm joint PID integral term winds up during sustained "
+            "load; the actuator torque command pins at the NAOqi stiffness "
+            "limit and the joint can no longer track its reference."
+        ),
+        example_signals=[
+            "LHipPitch integral term grows unbounded during sustained forward pitch; actuator torque command saturates at NAOqi stiffness limit 1.0",
+            "Device/SubDeviceList/RAnklePitch/ElectricCurrent/Sensor/Value clipped at rated max for >800 ms while position error keeps increasing",
+            "Motion/Walk commanded joint velocity exceeds joint_velocity_limit and ALMotionProxy logs 'torque saturation' on RKneePitch",
+        ],
+    ),
+    NAO6BugClass(
+        slug="com_estimation_drift",
+        display_name="COM Estimation Drift",
+        global_class="calibration_drift",
+        description=(
+            "The estimated center-of-mass slowly diverges from the true COM "
+            "because IMU bias or foot-contact offsets were never "
+            "re-calibrated; the walk engine issues ZMP targets that violate "
+            "the real support polygon."
+        ),
+        example_signals=[
+            "InertialSensor/AngleX/Sensor/Value shows a +0.04 rad steady-state bias vs horizon after stand-init",
+            "Motion/Walk/ZmpError grows monotonically across steps while commanded ZMP stays nominal",
+            "Device/SubDeviceList/LFoot/FSR/TotalWeight diverges from RFoot/FSR/TotalWeight by >20% on a level floor",
+        ],
+    ),
+    NAO6BugClass(
+        slug="fall_recovery_deadlock",
+        display_name="Fall-Recovery Deadlock",
+        global_class="state_machine_deadlock",
+        description=(
+            "ALRobotPosture's fall-manager enters getUp but a guard "
+            "condition (e.g. torso angle or FSR contact) never flips, so the "
+            "state machine loops between PreGetUp and GetUpBack instead of "
+            "reaching Stand."
+        ),
+        example_signals=[
+            "ALRobotPosture/Event/PostureChanged stuck emitting 'GetUpBack' for >6 s with no transition to 'Stand'",
+            "ALMotion/FallManager/State oscillates PreGetUp -> GetUpBack -> PreGetUp at 1 Hz",
+            "InertialSensor/AngleY remains >1.2 rad (prone) while robotHasFallen flag stays True indefinitely",
+        ],
+    ),
+    NAO6BugClass(
+        slug="bad_gait_gains",
+        display_name="Bad Gait Gains",
+        global_class="bad_gain_tuning",
+        description=(
+            "ALMotion walk parameters (step height, stiffness, or "
+            "torso-sway) are set outside the stable envelope for the "
+            "current surface, producing a growing lateral oscillation that "
+            "ends in a side-fall within a few steps."
+        ),
+        example_signals=[
+            "Motion/Walk/TorsoSwayY amplitude grows step-over-step from 0.03 rad to 0.11 rad over 4 strides",
+            "setStiffnesses('LLeg', 0.4) called before ALMotion.moveTo — stiffness below 0.7 documented minimum for walk",
+            "stepHeight=0.06 with maxStepFrequency=1.0 exceeds the stable region for the carpet-surface preset",
+        ],
+    ),
+    NAO6BugClass(
+        slug="contact_sensor_timeout",
+        display_name="Contact Sensor Timeout",
+        global_class="sensor_timeout",
+        description=(
+            "The foot FSR or bumper topic stops updating (DCM tick miss or "
+            "USB bus stall) but the walk controller keeps consuming the "
+            "last-seen value, so a swing foot is believed to be in contact "
+            "and the next step is planned into empty space."
+        ),
+        example_signals=[
+            "Device/SubDeviceList/LFoot/FSR/FrontLeft/Sensor/Value timestamp frozen for 420 ms while DCM tick counter advances",
+            "ALMemory key RFoot/Bumper/Right/Sensor/Value last-update age exceeds 200 ms ALMotion staleness threshold",
+            "Motion/Walk/FootContact/Left remains True for 3 consecutive swing phases where ground-truth FSR is 0 N",
+        ],
+    ),
+]
+
+
+for _entry in NAO6_TAXONOMY:
+    if _entry.global_class not in _ALLOWED_GLOBAL:
+        raise RuntimeError(
+            f"NAO6 taxonomy entry '{_entry.slug}' maps to "
+            f"'{_entry.global_class}' which is not in the global closed set "
+            f"{sorted(_ALLOWED_GLOBAL)}"
+        )
+
+_BY_SLUG: dict[str, NAO6BugClass] = {e.slug: e for e in NAO6_TAXONOMY}
+
+
+def by_slug(slug: str) -> NAO6BugClass | None:
+    """Return the NAO6BugClass for a slug, or None if unknown."""
+    return _BY_SLUG.get(slug)
+
+
+def to_global(slug: str) -> str:
+    """Return the global taxonomy class for a NAO6 slug; KeyError if unknown."""
+    entry = _BY_SLUG.get(slug)
+    if entry is None:
+        raise KeyError(f"Unknown NAO6 bug slug: {slug!r}")
+    return entry.global_class

--- a/tests/test_nao6_fixture_variants.py
+++ b/tests/test_nao6_fixture_variants.py
@@ -1,0 +1,149 @@
+"""Tests for NAO6 synthetic fall-fixture variants.
+
+Each scenario must emit a 4-file artifact set the adapter can consume.
+We verify: file existence, CSV schema + sample counts, the intentional
+bug_class tag in each controller.py, and that each MP4 decodes to 30
+non-empty frames at 320x240.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from black_box.platforms.nao6._fixture import (
+    generate_lateral_tip_fixture,
+    generate_stumble_recovery_fail_fixture,
+)
+
+
+EXPECTED_KEYS = {"top_video", "bottom_video", "telemetry_csv", "controller_source"}
+EXPECTED_FRAMES = 30
+EXPECTED_SAMPLES_PER_NUMERIC_KEY = 300
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _count_samples_per_key(csv_path: Path) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    with csv_path.open("r", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            counts[row["key"]] += 1
+    return counts
+
+
+def _video_frames(path: Path) -> list[np.ndarray]:
+    cap = cv2.VideoCapture(str(path))
+    try:
+        assert cap.isOpened(), f"VideoCapture failed to open {path}"
+        frames: list[np.ndarray] = []
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            frames.append(frame)
+        return frames
+    finally:
+        cap.release()
+
+
+def _assert_valid_video(path: Path) -> None:
+    frames = _video_frames(path)
+    assert len(frames) == EXPECTED_FRAMES, f"{path.name}: got {len(frames)} frames, expected {EXPECTED_FRAMES}"
+    assert any(int(np.count_nonzero(f)) > 0 for f in frames), f"{path.name}: all frames are empty"
+    h, w = frames[0].shape[:2]
+    assert (w, h) == (320, 240), f"{path.name}: got {(w, h)}, expected (320, 240)"
+
+
+# ---- lateral tip -----------------------------------------------------------
+
+
+@pytest.fixture
+def lateral_artifacts(tmp_path: Path) -> dict[str, Path]:
+    return generate_lateral_tip_fixture(tmp_path / "lateral")
+
+
+def test_lateral_emits_all_four_files(lateral_artifacts: dict[str, Path]) -> None:
+    assert set(lateral_artifacts.keys()) == EXPECTED_KEYS
+    for p in lateral_artifacts.values():
+        assert p.exists(), f"missing {p}"
+        assert p.stat().st_size > 0, f"empty file {p}"
+
+
+def test_lateral_telemetry_keys_and_counts(lateral_artifacts: dict[str, Path]) -> None:
+    counts = _count_samples_per_key(lateral_artifacts["telemetry_csv"])
+    assert counts["InertialSensor/AngleX/Sensor/Value"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+    assert counts["GyrX"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+    assert counts["AccZ"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+    assert counts["BalanceController/State"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+    # The pitch-axis key is specifically NOT present in a lateral scenario.
+    assert "InertialSensor/AngleY/Sensor/Value" not in counts
+
+
+def test_lateral_controller_has_bug_class_tag(lateral_artifacts: dict[str, Path]) -> None:
+    src = lateral_artifacts["controller_source"].read_text(encoding="utf-8")
+    assert "bug_class: bad_gain_tuning" in src
+
+
+def test_lateral_videos_decode(lateral_artifacts: dict[str, Path]) -> None:
+    _assert_valid_video(lateral_artifacts["top_video"])
+    _assert_valid_video(lateral_artifacts["bottom_video"])
+
+
+# ---- stumble + recovery-fail ----------------------------------------------
+
+
+@pytest.fixture
+def stumble_artifacts(tmp_path: Path) -> dict[str, Path]:
+    return generate_stumble_recovery_fail_fixture(tmp_path / "stumble")
+
+
+def test_stumble_emits_all_four_files(stumble_artifacts: dict[str, Path]) -> None:
+    assert set(stumble_artifacts.keys()) == EXPECTED_KEYS
+    for p in stumble_artifacts.values():
+        assert p.exists(), f"missing {p}"
+        assert p.stat().st_size > 0, f"empty file {p}"
+
+
+def test_stumble_telemetry_keys_and_counts(stumble_artifacts: dict[str, Path]) -> None:
+    counts = _count_samples_per_key(stumble_artifacts["telemetry_csv"])
+    assert counts["InertialSensor/AngleY/Sensor/Value"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+    assert counts["GyrY"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+    assert counts["AccZ"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+    assert counts["BalanceController/State"] == EXPECTED_SAMPLES_PER_NUMERIC_KEY
+
+
+def test_stumble_state_transitions_exist(stumble_artifacts: dict[str, Path]) -> None:
+    """State sequence should visit standing -> teetering -> recovering -> fell,
+    and 'recovering' must never transition back to 'standing'."""
+    states_in_order: list[str] = []
+    with stumble_artifacts["telemetry_csv"].open("r", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row["key"] == "BalanceController/State":
+                states_in_order.append(row["value"])
+
+    # All four labels present
+    seen = set(states_in_order)
+    assert {"standing", "teetering", "recovering", "fell"} <= seen
+
+    # Once 'recovering' appears, 'standing' must not reappear.
+    first_recovering = states_in_order.index("recovering")
+    assert "standing" not in states_in_order[first_recovering:]
+
+
+def test_stumble_controller_has_bug_class_tag(stumble_artifacts: dict[str, Path]) -> None:
+    src = stumble_artifacts["controller_source"].read_text(encoding="utf-8")
+    assert "bug_class: state_machine_deadlock" in src
+
+
+def test_stumble_videos_decode(stumble_artifacts: dict[str, Path]) -> None:
+    _assert_valid_video(stumble_artifacts["top_video"])
+    _assert_valid_video(stumble_artifacts["bottom_video"])

--- a/tests/test_nao6_snapshot.py
+++ b/tests/test_nao6_snapshot.py
@@ -1,0 +1,89 @@
+"""Tests for scripts/snapshot_controllers.py."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "snapshot_controllers.py"
+CONTROLLERS_DIR = REPO_ROOT / "src" / "black_box" / "platforms" / "nao6" / "controllers"
+
+
+def test_snapshot_produces_valid_manifest_and_copies(tmp_path: Path) -> None:
+    out_dir = tmp_path / "nao6_case"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-key",
+            "test_case",
+            "--out",
+            str(out_dir),
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"snapshot script failed: stdout={result.stdout} stderr={result.stderr}"
+    )
+
+    assert out_dir.is_dir()
+    snapshot_dir = out_dir / "controllers_snapshot"
+    assert snapshot_dir.is_dir()
+
+    manifest_path = out_dir / "snapshot_manifest.json"
+    assert manifest_path.is_file()
+    manifest = json.loads(manifest_path.read_text())
+
+    for key in ("case_key", "timestamp_utc", "git_sha", "python_version", "controllers"):
+        assert key in manifest, f"missing manifest key: {key}"
+    assert manifest["case_key"] == "test_case"
+    assert isinstance(manifest["controllers"], list)
+    assert len(manifest["controllers"]) >= 3
+
+    source_files = {p.name for p in CONTROLLERS_DIR.glob("*.py")}
+    copied_files = {p.name for p in snapshot_dir.glob("*.py")}
+    assert source_files.issubset(copied_files), (
+        f"not all controllers copied: missing {source_files - copied_files}"
+    )
+
+    for entry in manifest["controllers"]:
+        for key in ("filename", "sha256", "size_bytes", "line_count"):
+            assert key in entry, f"manifest entry missing {key}: {entry}"
+        copied_path = snapshot_dir / entry["filename"]
+        assert copied_path.is_file()
+        recomputed = hashlib.sha256(copied_path.read_bytes()).hexdigest()
+        assert recomputed == entry["sha256"], (
+            f"sha256 mismatch for {entry['filename']}: "
+            f"manifest={entry['sha256']} actual={recomputed}"
+        )
+        assert entry["size_bytes"] == copied_path.stat().st_size
+
+
+def test_snapshot_prints_summary_line(tmp_path: Path) -> None:
+    out_dir = tmp_path / "summary_case"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--case-key",
+            "summary_case",
+            "--out",
+            str(out_dir),
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "snapshotted" in result.stdout
+    assert "controllers" in result.stdout
+    assert str(out_dir) in result.stdout

--- a/tests/test_nao6_taxonomy.py
+++ b/tests/test_nao6_taxonomy.py
@@ -1,0 +1,99 @@
+"""Tests for the NAO6-specific bug taxonomy and its mapping to the global set."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from black_box.platforms.nao6.taxonomy import (
+    NAO6_TAXONOMY,
+    NAO6BugClass,
+    by_slug,
+    to_global,
+)
+
+ALLOWED_GLOBAL = {
+    "pid_saturation",
+    "sensor_timeout",
+    "state_machine_deadlock",
+    "bad_gain_tuning",
+    "missing_null_check",
+    "calibration_drift",
+    "latency_spike",
+    "other",
+}
+
+
+def test_taxonomy_has_five_entries() -> None:
+    assert len(NAO6_TAXONOMY) == 5
+
+
+def test_every_global_class_is_allowed() -> None:
+    for entry in NAO6_TAXONOMY:
+        assert entry.global_class in ALLOWED_GLOBAL, entry.slug
+
+
+def test_all_slugs_unique() -> None:
+    slugs = [e.slug for e in NAO6_TAXONOMY]
+    assert len(slugs) == len(set(slugs))
+
+
+def test_expected_slugs_present() -> None:
+    expected = {
+        "joint_pid_saturation",
+        "com_estimation_drift",
+        "fall_recovery_deadlock",
+        "bad_gait_gains",
+        "contact_sensor_timeout",
+    }
+    assert {e.slug for e in NAO6_TAXONOMY} == expected
+
+
+def test_by_slug_hit() -> None:
+    entry = by_slug("joint_pid_saturation")
+    assert entry is not None
+    assert entry.slug == "joint_pid_saturation"
+    assert entry.global_class == "pid_saturation"
+    assert entry.display_name == "Joint PID Saturation"
+
+
+def test_by_slug_miss_returns_none() -> None:
+    assert by_slug("nonexistent") is None
+
+
+def test_to_global_hit() -> None:
+    assert to_global("com_estimation_drift") == "calibration_drift"
+    assert to_global("fall_recovery_deadlock") == "state_machine_deadlock"
+    assert to_global("bad_gait_gains") == "bad_gain_tuning"
+    assert to_global("contact_sensor_timeout") == "sensor_timeout"
+
+
+def test_to_global_miss_raises_key_error() -> None:
+    with pytest.raises(KeyError):
+        to_global("bogus")
+
+
+def test_each_entry_has_two_plus_signals_and_nontrivial_description() -> None:
+    for entry in NAO6_TAXONOMY:
+        assert len(entry.example_signals) >= 2, entry.slug
+        for sig in entry.example_signals:
+            assert sig.strip(), entry.slug
+        assert len(entry.description.strip()) >= 40, entry.slug
+
+
+def test_pydantic_rejects_invalid_global_class() -> None:
+    with pytest.raises(ValidationError):
+        NAO6BugClass(
+            slug="made_up",
+            display_name="Made Up",
+            global_class="not_a_real_class",  # type: ignore[arg-type]
+            description="intentionally invalid entry for validation test",
+            example_signals=["signal a", "signal b"],
+        )
+
+
+def test_display_names_nonempty_and_capitalized() -> None:
+    for entry in NAO6_TAXONOMY:
+        name = entry.display_name
+        assert name, entry.slug
+        assert name[0].isupper(), entry.slug


### PR DESCRIPTION
## Summary
The three prep items you flagged so tomorrow's recording session is pure capture, no side-dev:

### 1. Controller code artifacts (src/black_box/platforms/nao6/controllers/)
Realistic-looking NAO6 controllers that become the "code artifact" the tool analyzes when a fall happens. Each has one subtle latent bug that maps onto a global bug class:
| file | latent bug | global class |
|---|---|---|
| `walking_gait.py` | HipPitch Kp=18.0 drives overshoot | `bad_gain_tuning` |
| `balance.py` | RECOVERING has no timeout | `state_machine_deadlock` |
| `fall_detector.py` | no IMU staleness check | `sensor_timeout` |

`scripts/snapshot_controllers.py` — auto-grabs all controllers + git SHA + sha256 manifest at fall-trigger time. Pure stdlib. Fires tomorrow.

### 2. Fixture variants (src/black_box/platforms/nao6/_fixture.py)
Original `generate_fall_fixture` untouched. Two new scenarios added:
- `generate_lateral_tip_fixture()` — roll-axis tip (Kp_roll=0.8 too low) → `bad_gain_tuning`
- `generate_stumble_recovery_fail_fixture()` — oscillates, then topples with RECOVERING state never exiting → `state_machine_deadlock`

Deterministic (no RNG), 320×240 @ 10fps, 100Hz telemetry, same output shape as the original.

### 3. Humanoid-specific taxonomy (src/black_box/platforms/nao6/taxonomy.py)
`NAO6BugClass` pydantic model + `NAO6_TAXONOMY` with 5 entries mapped onto the global closed-set:
| slug | global |
|---|---|
| `joint_pid_saturation` | `pid_saturation` |
| `com_estimation_drift` | `calibration_drift` |
| `fall_recovery_deadlock` | `state_machine_deadlock` |
| `bad_gait_gains` | `bad_gain_tuning` |
| `contact_sensor_timeout` | `sensor_timeout` |

`example_signals` grounded in real NAOqi/ALMemory key paths + numeric thresholds. Module-load assertion rejects any entry whose `global_class` falls outside the closed 8-value set, so a typo can't silently break the schema contract.

## Test plan
- [x] `pytest -q` → **104/104 green** (22 new tests across 3 modules)
- [x] Snapshot script smoke-run: 4 controllers captured, real git SHA, manifest validates
- [x] Fixture variants decode: 30 frames, 320×240, telemetry CSV has expected keys + 300 samples per numeric key

## Tomorrow
3 falls recorded with `scripts/capture_nao6.py` → `snapshot_controllers.py` auto-fires per fall → adapter + taxonomy consume both. End-to-end proven before the real data hits.

## Dispatch note
Built in a single branch via 3 parallel agents (controllers / fixtures / taxonomy), disjoint file sets, no conflicts. Consolidated into one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)