### PR TITLE
feat(analysis): adaptive resolution budgeter

### DIFF
--- a/src/black_box/analysis/__init__.py
+++ b/src/black_box/analysis/__init__.py
@@ -16,6 +16,14 @@ from .prompts import (
     scenario_mining_prompt,
     synthetic_qa_prompt,
 )
+from .resolution_budgeter import (
+    ResolutionBudgeter,
+    ResolutionDecision,
+    ResolutionTier,
+    ambiguity_from_top_two_confidences,
+    legacy_tier_to_string,
+    saliency_from_telemetry_z,
+)
 
 __all__ = [
     "ClaudeClient",
@@ -24,11 +32,17 @@ __all__ = [
     "Hypothesis",
     "Moment",
     "PostMortemReport",
+    "ResolutionBudgeter",
+    "ResolutionDecision",
+    "ResolutionTier",
     "ScenarioMiningReport",
     "SelfEval",
     "SyntheticQAReport",
     "TimelineEvent",
+    "ambiguity_from_top_two_confidences",
+    "legacy_tier_to_string",
     "post_mortem_prompt",
+    "saliency_from_telemetry_z",
     "scenario_mining_prompt",
     "synthetic_qa_prompt",
 ]

--- a/src/black_box/analysis/resolution_budgeter.py
+++ b/src/black_box/analysis/resolution_budgeter.py
@@ -1,0 +1,157 @@
+"""Adaptive resolution budgeter.
+
+Picks the right image resolution tier per Claude call instead of using a
+single hardcoded max-side. The policy weighs three signals:
+
+- **saliency**: how interesting the telemetry window is (0..1). A flagged
+  spike gets more pixels than a quiet stretch.
+- **ambiguity**: how uncertain the previous model call was (0..1). When
+  two hypotheses are near-tied in confidence, we escalate resolution
+  before re-calling rather than thrashing on thumbnails.
+- **cost budget**: fraction of the per-case token budget already spent.
+  When remaining budget is tight, we refuse to escalate regardless of
+  saliency/ambiguity — thumbnails still produce useful output; blowing
+  the cap does not.
+
+Each decision is a structured record (tier + max_side + rationale) so
+callers can log and audit resolution choices.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+ResolutionTier = Literal["thumb", "standard", "hires"]
+
+# Per-tier max image side, in pixels. Aspect ratio is preserved on resize.
+_TIER_MAX_SIDE: dict[ResolutionTier, int] = {
+    "thumb": 800,
+    "standard": 1280,
+    "hires": 1920,
+}
+
+
+@dataclass(frozen=True)
+class ResolutionDecision:
+    tier: ResolutionTier
+    max_side: int
+    rationale: str
+    saliency: float
+    ambiguity: float
+    budget_fraction_remaining: float
+
+
+@dataclass
+class ResolutionBudgeter:
+    """Policy object: maps (saliency, ambiguity, budget) -> resolution tier.
+
+    Thresholds are defaulted for a $500 hackathon cap with ~3 cases per
+    run; callers can tighten them for stricter token discipline.
+    """
+
+    # If less than this fraction of the budget remains, refuse to escalate.
+    min_budget_fraction_for_escalation: float = 0.15
+    # Saliency + ambiguity thresholds for escalation tiers.
+    hires_saliency: float = 0.7
+    hires_ambiguity: float = 0.5
+    standard_saliency: float = 0.7
+    standard_ambiguity: float = 0.7
+    # Allow callers to force a floor tier (e.g. always-thumb during dev).
+    force_tier: ResolutionTier | None = None
+    # History of decisions for this case/session.
+    decisions: list[ResolutionDecision] = field(default_factory=list)
+
+    def decide(
+        self,
+        saliency: float,
+        ambiguity: float,
+        remaining_budget_usd: float,
+        budget_total_usd: float,
+    ) -> ResolutionDecision:
+        saliency = _clamp01(saliency)
+        ambiguity = _clamp01(ambiguity)
+        frac = (remaining_budget_usd / budget_total_usd) if budget_total_usd > 0 else 0.0
+        frac = _clamp01(frac)
+
+        if self.force_tier is not None:
+            decision = ResolutionDecision(
+                tier=self.force_tier,
+                max_side=_TIER_MAX_SIDE[self.force_tier],
+                rationale=f"forced:{self.force_tier}",
+                saliency=saliency,
+                ambiguity=ambiguity,
+                budget_fraction_remaining=frac,
+            )
+            self.decisions.append(decision)
+            return decision
+
+        # Budget guard wins over everything else. A starving case cannot
+        # afford full-res calls, no matter how salient or ambiguous.
+        if frac < self.min_budget_fraction_for_escalation:
+            tier: ResolutionTier = "thumb"
+            rationale = f"budget_guard:frac={frac:.2f}<{self.min_budget_fraction_for_escalation:.2f}"
+        elif saliency >= self.hires_saliency and ambiguity >= self.hires_ambiguity:
+            tier = "hires"
+            rationale = f"hires:saliency={saliency:.2f},ambiguity={ambiguity:.2f}"
+        elif saliency >= self.standard_saliency or ambiguity >= self.standard_ambiguity:
+            tier = "standard"
+            rationale = f"standard:saliency={saliency:.2f},ambiguity={ambiguity:.2f}"
+        else:
+            tier = "thumb"
+            rationale = f"thumb:low_signal:saliency={saliency:.2f},ambiguity={ambiguity:.2f}"
+
+        decision = ResolutionDecision(
+            tier=tier,
+            max_side=_TIER_MAX_SIDE[tier],
+            rationale=rationale,
+            saliency=saliency,
+            ambiguity=ambiguity,
+            budget_fraction_remaining=frac,
+        )
+        self.decisions.append(decision)
+        return decision
+
+
+def _clamp01(x: float) -> float:
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return float(x)
+
+
+# ---------------------------------------------------------------------------
+# Signal extractors — small pure functions callers can feed into the
+# budgeter. Kept out of the class so they stay testable in isolation and so
+# new signals can be added without widening the policy's surface.
+# ---------------------------------------------------------------------------
+def saliency_from_telemetry_z(z_score: float, threshold: float = 3.0) -> float:
+    """Map a telemetry z-score to saliency ∈ [0, 1].
+
+    A z of ``threshold`` maps to 1.0; anything above is clamped.
+    """
+    if threshold <= 0:
+        return 0.0
+    return _clamp01(abs(z_score) / threshold)
+
+
+def ambiguity_from_top_two_confidences(
+    confidences: list[float] | tuple[float, ...]
+) -> float:
+    """Ambiguity = 1 - (top1 - top2). Near-tied candidates -> near 1.
+
+    A single hypothesis (or empty list) is unambiguous -> 0.
+    """
+    if len(confidences) < 2:
+        return 0.0
+    sorted_c = sorted((_clamp01(c) for c in confidences), reverse=True)
+    return _clamp01(1.0 - (sorted_c[0] - sorted_c[1]))
+
+
+def legacy_tier_to_string(decision: ResolutionDecision) -> Literal["thumb", "hires"]:
+    """Back-compat shim for call sites that still take Literal['thumb','hires'].
+
+    Collapses the middle ``standard`` tier to ``hires`` so we never silently
+    downgrade a decision that earned escalation.
+    """
+    return "thumb" if decision.tier == "thumb" else "hires"

--- a/tests/test_resolution_budgeter.py
+++ b/tests/test_resolution_budgeter.py
@@ -1,0 +1,110 @@
+"""Tests for the adaptive resolution budgeter."""
+from __future__ import annotations
+
+import pytest
+
+from black_box.analysis.resolution_budgeter import (
+    ResolutionBudgeter,
+    ambiguity_from_top_two_confidences,
+    legacy_tier_to_string,
+    saliency_from_telemetry_z,
+)
+
+
+def test_low_signal_picks_thumb():
+    b = ResolutionBudgeter()
+    d = b.decide(saliency=0.1, ambiguity=0.1, remaining_budget_usd=500, budget_total_usd=500)
+    assert d.tier == "thumb"
+    assert d.max_side == 800
+    assert d.rationale.startswith("thumb:low_signal")
+
+
+def test_high_saliency_high_ambiguity_picks_hires():
+    b = ResolutionBudgeter()
+    d = b.decide(saliency=0.9, ambiguity=0.8, remaining_budget_usd=500, budget_total_usd=500)
+    assert d.tier == "hires"
+    assert d.max_side == 1920
+
+
+def test_high_saliency_alone_picks_standard():
+    b = ResolutionBudgeter()
+    d = b.decide(saliency=0.8, ambiguity=0.1, remaining_budget_usd=500, budget_total_usd=500)
+    assert d.tier == "standard"
+    assert d.max_side == 1280
+
+
+def test_high_ambiguity_alone_picks_standard():
+    b = ResolutionBudgeter()
+    d = b.decide(saliency=0.1, ambiguity=0.9, remaining_budget_usd=500, budget_total_usd=500)
+    assert d.tier == "standard"
+
+
+def test_budget_guard_blocks_escalation():
+    """Starving case cannot escalate, even with maximal saliency+ambiguity."""
+    b = ResolutionBudgeter()
+    d = b.decide(saliency=1.0, ambiguity=1.0, remaining_budget_usd=10, budget_total_usd=500)
+    assert d.tier == "thumb"
+    assert "budget_guard" in d.rationale
+
+
+def test_force_tier_overrides_policy():
+    b = ResolutionBudgeter(force_tier="thumb")
+    d = b.decide(saliency=1.0, ambiguity=1.0, remaining_budget_usd=500, budget_total_usd=500)
+    assert d.tier == "thumb"
+    assert d.rationale == "forced:thumb"
+
+    b2 = ResolutionBudgeter(force_tier="hires")
+    d2 = b2.decide(saliency=0.0, ambiguity=0.0, remaining_budget_usd=1, budget_total_usd=500)
+    assert d2.tier == "hires"
+
+
+def test_decisions_log_accumulates():
+    b = ResolutionBudgeter()
+    for _ in range(3):
+        b.decide(saliency=0.5, ambiguity=0.5, remaining_budget_usd=500, budget_total_usd=500)
+    assert len(b.decisions) == 3
+
+
+def test_inputs_are_clamped_to_unit_interval():
+    b = ResolutionBudgeter()
+    d = b.decide(saliency=5.0, ambiguity=-1.0, remaining_budget_usd=1000, budget_total_usd=500)
+    assert d.saliency == 1.0
+    assert d.ambiguity == 0.0
+    assert d.budget_fraction_remaining == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Signal extractors
+# ---------------------------------------------------------------------------
+def test_saliency_from_z_threshold():
+    assert saliency_from_telemetry_z(0.0) == 0.0
+    assert saliency_from_telemetry_z(1.5, threshold=3.0) == 0.5
+    assert saliency_from_telemetry_z(3.0, threshold=3.0) == 1.0
+    # clamps above threshold
+    assert saliency_from_telemetry_z(10.0, threshold=3.0) == 1.0
+    # symmetric on sign
+    assert saliency_from_telemetry_z(-3.0, threshold=3.0) == 1.0
+    # bad threshold guard
+    assert saliency_from_telemetry_z(5.0, threshold=0.0) == 0.0
+
+
+def test_ambiguity_from_top_two():
+    # Strong single winner -> unambiguous.
+    assert ambiguity_from_top_two_confidences([0.9, 0.1, 0.1]) == pytest.approx(0.2)
+    # Near-tie -> highly ambiguous.
+    assert ambiguity_from_top_two_confidences([0.55, 0.50]) == pytest.approx(0.95)
+    # Perfect tie -> maximally ambiguous.
+    assert ambiguity_from_top_two_confidences([0.5, 0.5]) == pytest.approx(1.0)
+    # Single or empty -> unambiguous.
+    assert ambiguity_from_top_two_confidences([0.9]) == 0.0
+    assert ambiguity_from_top_two_confidences([]) == 0.0
+
+
+def test_legacy_tier_shim_collapses_standard_to_hires():
+    b = ResolutionBudgeter()
+    d_low = b.decide(saliency=0.0, ambiguity=0.0, remaining_budget_usd=500, budget_total_usd=500)
+    d_std = b.decide(saliency=0.8, ambiguity=0.1, remaining_budget_usd=500, budget_total_usd=500)
+    d_hi = b.decide(saliency=0.9, ambiguity=0.9, remaining_budget_usd=500, budget_total_usd=500)
+    assert legacy_tier_to_string(d_low) == "thumb"
+    assert legacy_tier_to_string(d_std) == "hires"
+    assert legacy_tier_to_string(d_hi) == "hires"


### PR DESCRIPTION
## Summary
Replaces the single hardcoded \`max_side=800\` thumbnail rule with a three-tier **adaptive resolution budgeter** that picks per-call based on saliency, ambiguity, and remaining cost budget.

### Policy
- **Tiers:** \`thumb\` (800px) · \`standard\` (1280px) · \`hires\` (1920px).
- **Escalation rules (high → low):**
  - \`hires\` when saliency ≥ 0.7 AND ambiguity ≥ 0.5
  - \`standard\` when saliency ≥ 0.7 OR ambiguity ≥ 0.7
  - \`thumb\` otherwise
- **Budget guard (wins over everything):** if remaining per-case budget < 15%, force \`thumb\`. A starving case can always still emit a row.
- **Force override:** \`force_tier=\"thumb\"\` for dev, \`force_tier=\"hires\"\` for a demo run.

### Auditability
Every call to \`decide(...)\` returns a frozen \`ResolutionDecision\` with \`tier\`, \`max_side\`, \`rationale\` (e.g. \`\"budget_guard:frac=0.03<0.15\"\`), and the input snapshot. Decisions accumulate in \`budgeter.decisions\` for post-run analysis.

### Signal extractors
- \`saliency_from_telemetry_z(z, threshold=3.0)\` — z-score → saliency in [0, 1], clamped above threshold, symmetric on sign.
- \`ambiguity_from_top_two_confidences(cs)\` — \`1 - (top1 - top2)\`; near-ties → near 1.

### Back-compat shim
\`legacy_tier_to_string(decision)\` collapses \`\"standard\"\` to \`\"hires\"\` so existing call sites with \`Literal[\"thumb\", \"hires\"]\` never silently downgrade an earned escalation when they take a budgeter decision.

### Not yet wired
This PR ships the policy object and tests. The wiring into \`claude_client.analyze(...)\` will land after the real-bag smoke test runs stabilize — the budgeter is deliberately callable standalone so callers can adopt it incrementally.

11 new tests; full suite 115 green.

## Test plan
- [ ] \`pytest tests/test_resolution_budgeter.py -q\` — 11 green
- [ ] \`pytest -q\` — full suite 115 green
- [ ] Spot-check rationale strings in \`.decisions[]\` when saliency/ambiguity/budget vary