### PR TITLE
feat(analysis): self-improving policy advisor (L2 priors + L3 tie-break + L4 alarms)

### DIFF
--- a/src/black_box/analysis/managed_agent.py
+++ b/src/black_box/analysis/managed_agent.py
@@ -33,7 +33,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Iterator, Literal
+from typing import Any, Iterable, Iterator, Literal
 
 from anthropic import Anthropic
 from pydantic import ValidationError
@@ -301,10 +301,18 @@ class ForensicAgent:
         config: ForensicAgentConfig | None = None,
         client: Anthropic | None = None,
         memory: MemoryStack | None = None,
+        platform: str | None = None,
     ) -> None:
         self.config = config or ForensicAgentConfig()
         self._client: Anthropic = client or Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
         self._memory = memory
+        self._platform = platform
+        # Lazily build the advisor so agents constructed without memory stay
+        # zero-overhead. Advisor is safe to build once per agent because it
+        # only reads from the memory stack.
+        from .policy import PolicyAdvisor
+
+        self._advisor = PolicyAdvisor(memory, platform=platform) if memory is not None else None
 
     def open_session(self, bag_path: Path, case_key: str) -> "ForensicSession":
         beta = self._client.beta
@@ -379,6 +387,12 @@ class ForensicAgent:
         _CREATE_LIMITER.acquire()
         session = _wrap_call("sessions.create", beta.sessions.create, **session_kwargs)
 
+        priors_block = ""
+        if self._advisor is not None:
+            try:
+                priors_block = self._advisor.prime_prompt_block() or ""
+            except Exception:
+                priors_block = ""
         seed_text = (
             f"Case key: {case_key}\n"
             f"Mode: post_mortem\n"
@@ -389,6 +403,8 @@ class ForensicAgent:
             "validates against the PostMortemReport schema: keys timeline, "
             "hypotheses, root_cause_idx, patch_proposal."
         )
+        if priors_block:
+            seed_text = seed_text + "\n\n" + priors_block
         _CREATE_LIMITER.acquire()
         _wrap_call(
             "sessions.events.send",
@@ -410,6 +426,7 @@ class ForensicAgent:
             _environment_id=environment.id,
             _started_at=time.monotonic(),
             _memory=self._memory,
+            _advisor=self._advisor,
         )
 
 
@@ -428,6 +445,7 @@ class ForensicSession:
     _started_at: float = field(default_factory=time.monotonic)
     _final_text: str | None = field(default=None, repr=False)
     _memory: MemoryStack | None = field(default=None, repr=False)
+    _advisor: Any = field(default=None, repr=False)
 
     # -- event stream --------------------------------------------------------
     def stream(self) -> Iterator[dict]:
@@ -577,7 +595,44 @@ class ForensicSession:
                 f"assistant JSON did not match PostMortemReport: {exc}"
             ) from exc
         payload = report.model_dump()
+        payload = self._apply_advisor(payload)
         self._record_memory(payload)
+        return payload
+
+    def _apply_advisor(self, payload: dict) -> dict:
+        """Fold L3 tie-break into hypotheses and L4 regression alarms into the payload.
+
+        No-op when no advisor is bound. Runs before memory writes so the
+        tie-broken ordering is what persists in L1 and drives L3 counts.
+        """
+        if self._advisor is None:
+            return payload
+        try:
+            hyps = payload.get("hypotheses") or []
+            if hyps:
+                reordered = self._advisor.apply_tie_break(hyps)
+                if reordered and reordered[0] is not hyps[0]:
+                    # Tie-break changed the winner — rewrite root_cause_idx
+                    # to point at the new top-ranked hypothesis.
+                    payload["hypotheses"] = reordered
+                    payload["root_cause_idx"] = 0
+                    payload["advisor_tie_break_applied"] = True
+                else:
+                    payload["hypotheses"] = reordered
+            alarms = self._advisor.regression_alarms()
+            if alarms:
+                payload["regression_alarms"] = [
+                    {
+                        "bug_class": a.bug_class,
+                        "accuracy": a.accuracy,
+                        "n_samples": a.n_samples,
+                        "threshold": a.threshold,
+                    }
+                    for a in alarms
+                ]
+        except Exception:
+            # Advisor must never take down finalize. Silent by design.
+            pass
         return payload
 
     def _record_memory(self, report: dict) -> None:

--- a/src/black_box/analysis/policy.py
+++ b/src/black_box/analysis/policy.py
@@ -1,0 +1,160 @@
+"""Self-improving policy advisor backed by the 4-layer memory stack.
+
+The memory substrate (L1..L4) has been shipped for a while; this module is
+the visible policy loop that actually *consumes* it:
+
+- **L2 priors -> prime the prompt.** ``prime_prompt_block(platform, k)``
+  returns a short, cache-friendly snippet of the top-k highest-confidence
+  signature->bug_class mappings for the current platform.
+- **L3 frequency -> tie-break.** ``apply_tie_break(hypotheses)`` breaks
+  near-ties in model confidence by global L3 frequency. A clear winner
+  is left alone; ties shift to the historically more common class.
+- **L4 accuracy -> regression alarm.** ``regression_alarms()`` surfaces
+  bug classes whose per-class accuracy has fallen below a threshold with
+  enough samples, so the agent can flag a suspected regression in its
+  own finalize payload.
+
+The advisor is stateless beyond the memory stack it reads from, so it is
+safe to construct once per session.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from ..memory import MemoryStack, PlatformPrior
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    """Duck-typed attr/item accessor for dicts, pydantic models, dataclasses."""
+    if obj is None:
+        return default
+    if isinstance(obj, Mapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@dataclass
+class RegressionAlarm:
+    bug_class: str
+    accuracy: float
+    n_samples: int
+    threshold: float
+
+
+class PolicyAdvisor:
+    """Reads memory, writes nothing. Callers fold its output into prompts/reports."""
+
+    def __init__(
+        self,
+        memory: MemoryStack,
+        platform: str | None = None,
+        tie_delta: float = 0.1,
+        regression_threshold: float = 0.6,
+        regression_min_samples: int = 3,
+    ) -> None:
+        self.memory = memory
+        self.platform = platform
+        self.tie_delta = tie_delta
+        self.regression_threshold = regression_threshold
+        self.regression_min_samples = regression_min_samples
+
+    # ------------------------------------------------------------------
+    # L2: prime the prompt with platform priors
+    # ------------------------------------------------------------------
+    def prime_prompt_block(self, top_k: int = 5) -> str:
+        """Return a prompt fragment describing the top-k L2 priors.
+
+        Empty string when no platform is set or the platform has no priors.
+        The format is designed to be appended to the cached system preamble
+        without breaking prompt cache boundaries.
+        """
+        if not self.platform:
+            return ""
+        priors = self.memory.platform.top_signatures(self.platform, k=top_k)
+        if not priors:
+            return ""
+        return _render_priors(self.platform, priors)
+
+    # ------------------------------------------------------------------
+    # L3: break near-ties with global frequency
+    # ------------------------------------------------------------------
+    def apply_tie_break(self, hypotheses: list[Any]) -> list[Any]:
+        """Reorder hypotheses when the top-2 are within ``tie_delta`` in confidence.
+
+        Only the top-2 are inspected. If they are a clear pair (Δ >= tie_delta)
+        the list is returned sorted by confidence, unchanged semantics. If
+        they are near-tied, the hypothesis whose bug_class has the higher
+        L3 global count is promoted; the other drops to second. All other
+        hypotheses follow in descending confidence order.
+        """
+        if len(hypotheses) < 2:
+            return list(hypotheses)
+
+        ordered = sorted(
+            hypotheses,
+            key=lambda h: float(_get(h, "confidence", 0.0) or 0.0),
+            reverse=True,
+        )
+        top = ordered[0]
+        runner = ordered[1]
+
+        c_top = float(_get(top, "confidence", 0.0) or 0.0)
+        c_run = float(_get(runner, "confidence", 0.0) or 0.0)
+        if c_top - c_run >= self.tie_delta:
+            return ordered  # clear winner, no tie-break needed
+
+        totals = self.memory.taxonomy.totals_by_class()
+        top_freq = totals.get(str(_get(top, "bug_class", "") or ""), 0)
+        run_freq = totals.get(str(_get(runner, "bug_class", "") or ""), 0)
+        if run_freq > top_freq:
+            return [runner, top] + ordered[2:]
+        return ordered
+
+    # ------------------------------------------------------------------
+    # L4: raise alarms when per-class accuracy regresses
+    # ------------------------------------------------------------------
+    def regression_alarms(self) -> list[RegressionAlarm]:
+        """Return per-class regressions below the configured threshold.
+
+        A class is reported only when it has at least
+        ``regression_min_samples`` eval rows; one-off misses don't alarm.
+        """
+        by_class = self.memory.eval.accuracy_by_bug_class()
+        records = self.memory.eval.all()
+        counts: dict[str, int] = {}
+        for r in records:
+            counts[r.ground_truth_bug] = counts.get(r.ground_truth_bug, 0) + 1
+
+        alarms: list[RegressionAlarm] = []
+        for bug_class, acc in by_class.items():
+            n = counts.get(bug_class, 0)
+            if n >= self.regression_min_samples and acc < self.regression_threshold:
+                alarms.append(
+                    RegressionAlarm(
+                        bug_class=bug_class,
+                        accuracy=acc,
+                        n_samples=n,
+                        threshold=self.regression_threshold,
+                    )
+                )
+        alarms.sort(key=lambda a: (a.accuracy, a.bug_class))
+        return alarms
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers. Kept as module-level functions so tests can snapshot the
+# exact string shape without constructing an advisor + memory stack.
+# ---------------------------------------------------------------------------
+def _render_priors(platform: str, priors: list[PlatformPrior]) -> str:
+    lines = [f"Historical priors for platform `{platform}` (top {len(priors)}):"]
+    for p in priors:
+        lines.append(
+            f"- signature `{p.signature}` -> `{p.bug_class}` "
+            f"(confidence {p.confidence:.2f}, {p.hits} hit{'s' if p.hits != 1 else ''})"
+        )
+    lines.append(
+        "Treat these as weak evidence only. Do not match a hypothesis to a prior "
+        "without independent telemetry + frame corroboration in the current case."
+    )
+    return "\n".join(lines)

--- a/tests/test_managed_agent.py
+++ b/tests/test_managed_agent.py
@@ -379,6 +379,151 @@ def test_finalize_without_memory_is_a_noop():
     session._record_memory(report_json)
 
 
+def test_finalize_applies_advisor_tie_break_and_regression_alarms(
+    tmp_path: Path, monkeypatch
+):
+    """Finalize should fold the PolicyAdvisor's tie-break + alarms into the payload.
+
+    Given an L3 taxonomy that overwhelmingly favors pid_saturation and an L4
+    eval history where sensor_timeout is regressing, a near-tied top-2 must
+    be reordered so pid_saturation wins, root_cause_idx must be rewritten to
+    0, and regression_alarms must surface sensor_timeout.
+    """
+    from black_box.analysis.policy import PolicyAdvisor
+    from black_box.memory import EvalRecord, MemoryStack, TaxonomyCount
+
+    mem = MemoryStack.open(tmp_path / "mem")
+    # L3: pid_saturation is much more common than bad_gain_tuning.
+    mem.taxonomy.log(TaxonomyCount(bug_class="pid_saturation", signature="s", count=50))
+    mem.taxonomy.log(TaxonomyCount(bug_class="bad_gain_tuning", signature="t", count=2))
+    # L4: sensor_timeout regressing — 1/4 correct, below 0.6.
+    mem.eval.log(EvalRecord(case_key="c1", predicted_bug="sensor_timeout",
+                            ground_truth_bug="sensor_timeout", match=True))
+    for i in range(3):
+        mem.eval.log(EvalRecord(case_key=f"c{i+2}", predicted_bug="other",
+                                ground_truth_bug="sensor_timeout", match=False))
+
+    # Top-2 near-tied: bad_gain_tuning (0.55) vs pid_saturation (0.52). Advisor
+    # should promote pid_saturation because its L3 count dwarfs bad_gain_tuning.
+    report_json = {
+        "timeline": [{"t_ns": 1, "label": "boot", "cross_view": False}],
+        "hypotheses": [
+            {
+                "bug_class": "bad_gain_tuning",
+                "confidence": 0.55,
+                "summary": "Kp too high on LHipPitch",
+                "evidence": [],
+                "patch_hint": "reduce Kp 30%",
+            },
+            {
+                "bug_class": "pid_saturation",
+                "confidence": 0.52,
+                "summary": "Integral wind-up during step initiation",
+                "evidence": [
+                    {
+                        "source": "telemetry",
+                        "topic_or_file": "/cmd_vel",
+                        "t_ns": 12000,
+                        "snippet": "max u for 3s",
+                    }
+                ],
+                "patch_hint": "clamp output to +/-1.0",
+            },
+        ],
+        "root_cause_idx": 0,
+        "patch_proposal": "clamp in control_loop.py",
+    }
+    events = _FakeEvents()
+    events._listed = [
+        _make_event(
+            "agent.message",
+            id="m1",
+            content=[_make_text_block(f"```json\n{json.dumps(report_json)}\n```")],
+        )
+    ]
+    client = _FakeClient(events)
+    session = ForensicSession(
+        session_id="session_123",
+        case_key="c1_faceplant",
+        _client=client,
+        _memory=mem,
+        _advisor=PolicyAdvisor(
+            mem,
+            platform="nao6",
+            tie_delta=0.1,
+            regression_threshold=0.6,
+            regression_min_samples=3,
+        ),
+    )
+    monkeypatch.setattr(ma, "_costs_file", lambda: tmp_path / "costs.jsonl")
+
+    payload = session.finalize()
+
+    # Tie-break flipped the winner.
+    assert payload["advisor_tie_break_applied"] is True
+    assert payload["root_cause_idx"] == 0
+    assert payload["hypotheses"][0]["bug_class"] == "pid_saturation"
+    assert payload["hypotheses"][1]["bug_class"] == "bad_gain_tuning"
+
+    # L4 regression alarm surfaced in the finalize payload.
+    alarms = payload.get("regression_alarms") or []
+    bug_classes = {a["bug_class"] for a in alarms}
+    assert "sensor_timeout" in bug_classes
+    st = next(a for a in alarms if a["bug_class"] == "sensor_timeout")
+    assert st["n_samples"] == 4
+    assert st["accuracy"] == pytest.approx(0.25)
+    assert st["threshold"] == 0.6
+
+    # L1 persisted the tie-broken ordering (root cause was rewritten before write).
+    case_rows = mem.case.for_case("c1_faceplant")
+    assert len(case_rows) == 1
+    assert case_rows[0].payload["hypotheses"][0]["bug_class"] == "pid_saturation"
+
+
+def test_finalize_without_advisor_leaves_payload_alone(tmp_path: Path, monkeypatch):
+    """No advisor bound -> payload matches the parsed report verbatim."""
+    report_json = {
+        "timeline": [],
+        "hypotheses": [
+            {
+                "bug_class": "bad_gain_tuning",
+                "confidence": 0.55,
+                "summary": "x",
+                "evidence": [],
+                "patch_hint": "",
+            },
+            {
+                "bug_class": "pid_saturation",
+                "confidence": 0.52,
+                "summary": "y",
+                "evidence": [],
+                "patch_hint": "",
+            },
+        ],
+        "root_cause_idx": 0,
+        "patch_proposal": "",
+    }
+    events = _FakeEvents()
+    events._listed = [
+        _make_event(
+            "agent.message",
+            id="m1",
+            content=[_make_text_block(json.dumps(report_json))],
+        )
+    ]
+    client = _FakeClient(events)
+    session = ForensicSession(
+        session_id="s", case_key="c", _client=client, _advisor=None
+    )
+    monkeypatch.setattr(ma, "_costs_file", lambda: tmp_path / "costs.jsonl")
+
+    payload = session.finalize()
+
+    assert payload["hypotheses"][0]["bug_class"] == "bad_gain_tuning"  # untouched
+    assert "advisor_tie_break_applied" not in payload
+    assert "regression_alarms" not in payload
+
+
 def test_rate_limiter_sleeps_after_burst():
     limiter = _RateLimiter(max_per_window=60, window_seconds=60.0)
     # Pre-fill 60 slots in the limiter's deque at monotonic() time.

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,195 @@
+"""Tests for the self-improving policy advisor."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from black_box.analysis.policy import PolicyAdvisor, RegressionAlarm
+from black_box.memory import (
+    EvalRecord,
+    MemoryStack,
+    PlatformPrior,
+    TaxonomyCount,
+)
+
+
+@pytest.fixture()
+def mem(tmp_path: Path) -> MemoryStack:
+    return MemoryStack.open(tmp_path / "mem")
+
+
+# ---------------------------------------------------------------------------
+# L2 prime_prompt_block
+# ---------------------------------------------------------------------------
+def test_prime_block_empty_when_no_platform(mem):
+    advisor = PolicyAdvisor(mem, platform=None)
+    assert advisor.prime_prompt_block() == ""
+
+
+def test_prime_block_empty_when_no_priors(mem):
+    advisor = PolicyAdvisor(mem, platform="nao6")
+    assert advisor.prime_prompt_block() == ""
+
+
+def test_prime_block_renders_top_k_priors_sorted_by_confidence(mem):
+    mem.platform.log(PlatformPrior(platform="nao6", signature="ramp",
+                                   bug_class="bad_gain_tuning", confidence=0.9, hits=5))
+    mem.platform.log(PlatformPrior(platform="nao6", signature="deadlock",
+                                   bug_class="state_machine_deadlock", confidence=0.8, hits=2))
+    mem.platform.log(PlatformPrior(platform="nao6", signature="stale",
+                                   bug_class="sensor_timeout", confidence=0.6, hits=10))
+    # Different platform — must not leak in.
+    mem.platform.log(PlatformPrior(platform="ur5", signature="other",
+                                   bug_class="pid_saturation", confidence=0.95))
+
+    advisor = PolicyAdvisor(mem, platform="nao6")
+    block = advisor.prime_prompt_block(top_k=2)
+
+    assert "nao6" in block
+    assert "ur5" not in block
+    # Top 2 by confidence: 0.9 (ramp) then 0.8 (deadlock). 0.6 excluded.
+    assert "ramp" in block and "deadlock" in block
+    assert "stale" not in block
+    # The warning footer must be present so the prompt never lets a prior
+    # short-circuit case-local evidence.
+    assert "weak evidence" in block
+
+
+# ---------------------------------------------------------------------------
+# L3 tie-break
+# ---------------------------------------------------------------------------
+def test_tie_break_leaves_clear_winner_alone(mem):
+    mem.taxonomy.log(TaxonomyCount(bug_class="pid_saturation", signature="s", count=100))
+    mem.taxonomy.log(TaxonomyCount(bug_class="bad_gain_tuning", signature="t", count=1))
+
+    advisor = PolicyAdvisor(mem)
+    hyps = [
+        {"bug_class": "bad_gain_tuning", "confidence": 0.85},  # clear winner
+        {"bug_class": "pid_saturation", "confidence": 0.50},
+    ]
+    out = advisor.apply_tie_break(hyps)
+    assert out[0]["bug_class"] == "bad_gain_tuning"  # not promoted despite higher L3
+    assert out[1]["bug_class"] == "pid_saturation"
+
+
+def test_tie_break_promotes_more_frequent_class_on_near_tie(mem):
+    mem.taxonomy.log(TaxonomyCount(bug_class="pid_saturation", signature="s", count=20))
+    mem.taxonomy.log(TaxonomyCount(bug_class="bad_gain_tuning", signature="t", count=2))
+
+    advisor = PolicyAdvisor(mem)
+    hyps = [
+        {"bug_class": "bad_gain_tuning", "confidence": 0.55},
+        {"bug_class": "pid_saturation", "confidence": 0.52},  # near-tie
+    ]
+    out = advisor.apply_tie_break(hyps)
+    # pid_saturation has much higher L3 frequency — should be promoted.
+    assert out[0]["bug_class"] == "pid_saturation"
+    assert out[1]["bug_class"] == "bad_gain_tuning"
+
+
+def test_tie_break_does_not_promote_when_frequencies_also_tie(mem):
+    mem.taxonomy.log(TaxonomyCount(bug_class="a", signature="s", count=5))
+    mem.taxonomy.log(TaxonomyCount(bug_class="b", signature="t", count=5))
+
+    advisor = PolicyAdvisor(mem)
+    hyps = [
+        {"bug_class": "a", "confidence": 0.50},
+        {"bug_class": "b", "confidence": 0.48},
+    ]
+    out = advisor.apply_tie_break(hyps)
+    assert out[0]["bug_class"] == "a"  # original order kept
+
+
+def test_tie_break_custom_delta(mem):
+    mem.taxonomy.log(TaxonomyCount(bug_class="b", signature="t", count=99))
+
+    advisor = PolicyAdvisor(mem, tie_delta=0.3)
+    hyps = [
+        {"bug_class": "a", "confidence": 0.80},
+        {"bug_class": "b", "confidence": 0.60},  # Δ = 0.20 < 0.30 -> still near-tie
+    ]
+    out = advisor.apply_tie_break(hyps)
+    assert out[0]["bug_class"] == "b"  # higher L3 wins under larger tie_delta
+
+
+def test_tie_break_handles_short_lists(mem):
+    advisor = PolicyAdvisor(mem)
+    assert advisor.apply_tie_break([]) == []
+    solo = [{"bug_class": "x", "confidence": 0.9}]
+    assert advisor.apply_tie_break(solo) == solo
+
+
+def test_tie_break_accepts_attr_objects(mem):
+    mem.taxonomy.log(TaxonomyCount(bug_class="b", signature="t", count=50))
+
+    class H:
+        def __init__(self, bug_class, confidence):
+            self.bug_class = bug_class
+            self.confidence = confidence
+
+    advisor = PolicyAdvisor(mem)
+    hyps = [H("a", 0.55), H("b", 0.53)]
+    out = advisor.apply_tie_break(hyps)
+    assert out[0].bug_class == "b"
+
+
+# ---------------------------------------------------------------------------
+# L4 regression alarms
+# ---------------------------------------------------------------------------
+def test_no_alarm_under_min_samples(mem):
+    mem.eval.log(EvalRecord(case_key="c1", predicted_bug="x",
+                            ground_truth_bug="pid_saturation", match=False))
+    mem.eval.log(EvalRecord(case_key="c2", predicted_bug="y",
+                            ground_truth_bug="pid_saturation", match=False))
+
+    advisor = PolicyAdvisor(mem, regression_threshold=0.6, regression_min_samples=3)
+    assert advisor.regression_alarms() == []
+
+
+def test_alarm_fires_below_threshold_with_enough_samples(mem):
+    # 1 hit, 3 misses -> 25% accuracy, 4 samples, below 0.6 threshold.
+    mem.eval.log(EvalRecord(case_key="c1", predicted_bug="pid_saturation",
+                            ground_truth_bug="pid_saturation", match=True))
+    for i in range(3):
+        mem.eval.log(EvalRecord(case_key=f"c{i+2}", predicted_bug="bad_gain_tuning",
+                                ground_truth_bug="pid_saturation", match=False))
+    # Healthy class: 3/3.
+    for i in range(3):
+        mem.eval.log(EvalRecord(case_key=f"s{i}", predicted_bug="sensor_timeout",
+                                ground_truth_bug="sensor_timeout", match=True))
+
+    advisor = PolicyAdvisor(mem, regression_threshold=0.6, regression_min_samples=3)
+    alarms = advisor.regression_alarms()
+    assert len(alarms) == 1
+    alarm = alarms[0]
+    assert isinstance(alarm, RegressionAlarm)
+    assert alarm.bug_class == "pid_saturation"
+    assert alarm.accuracy == pytest.approx(0.25)
+    assert alarm.n_samples == 4
+    assert alarm.threshold == 0.6
+
+
+def test_alarms_sorted_by_accuracy_ascending(mem):
+    # Class A: 0 / 3 = 0.00
+    for i in range(3):
+        mem.eval.log(EvalRecord(case_key=f"a{i}", predicted_bug="x",
+                                ground_truth_bug="A", match=False))
+    # Class B: 1 / 4 = 0.25
+    mem.eval.log(EvalRecord(case_key="b0", predicted_bug="B",
+                            ground_truth_bug="B", match=True))
+    for i in range(3):
+        mem.eval.log(EvalRecord(case_key=f"b{i+1}", predicted_bug="x",
+                                ground_truth_bug="B", match=False))
+
+    advisor = PolicyAdvisor(mem, regression_threshold=0.6, regression_min_samples=3)
+    alarms = advisor.regression_alarms()
+    assert [a.bug_class for a in alarms] == ["A", "B"]
+
+
+def test_no_alarm_when_class_is_healthy(mem):
+    for i in range(4):
+        mem.eval.log(EvalRecord(case_key=f"c{i}", predicted_bug="x",
+                                ground_truth_bug="x", match=True))
+    advisor = PolicyAdvisor(mem, regression_threshold=0.6, regression_min_samples=3)
+    assert advisor.regression_alarms() == []


### PR DESCRIPTION
## Summary
Turns the 4-layer memory stack into a visible policy loop. `PolicyAdvisor` reads from `MemoryStack` and nothing else — priors prime the seed, global frequency tie-breaks near-ties, and per-class accuracy regressions surface on every finalize.

- **L2 → prime.** `prime_prompt_block(top_k)` returns a short, cache-friendly block of the top-k highest-confidence signature→bug_class mappings for the current platform. Appended to the cached system preamble without crossing cache boundaries. Empty when no platform / no priors. `nao6` priors never leak into a `ur5` session.
- **L3 → tie-break.** `apply_tie_break(hypotheses, delta=0.1)` only reorders when the top-2 confidences are within `tie_delta`. A clear winner is never demoted. Near-tie promotes the class with higher global count. Duck-types dicts / dataclasses / pydantic models.
- **L4 → alarm.** `regression_alarms(threshold=0.6, min_samples=3)` returns per-class accuracy below threshold when the class has enough samples. Sorted ascending so the worst class reads first. One-off misses don't alarm.

Wired into `ForensicAgent` / `ForensicSession`:
- `ForensicAgent(platform=...)` lazily constructs an advisor when memory is bound.
- `open_session()` folds the priors block into the seed `user.message` so the agent sees historical context on turn one.
- `finalize()` runs `_apply_advisor()` **before** `_record_memory()` so L1 persists the tie-broken ordering and L3 counts follow. If the advisor flips the winner, `root_cause_idx` is rewritten to 0 and `advisor_tie_break_applied=True` lands on the payload. Alarms surface as `regression_alarms: [{bug_class, accuracy, n_samples, threshold}, ...]`.
- Advisor exceptions are silently swallowed — must never take down finalize.

## Test plan
- [x] 13 unit tests in `test_policy.py` — empty platform / empty priors, top-k rendering filtered by platform, clear-winner preserved, near-tie promotes frequent class, frequencies-also-tie keeps order, custom `tie_delta`, short lists, duck-typed attr objects, min-samples gate, threshold gate, ascending sort, healthy class silent.
- [x] 2 integration tests in `test_managed_agent.py` — `finalize()` with bound advisor flips winner + emits alarms + persists tie-broken ordering to L1; `finalize()` without advisor leaves payload untouched (no `advisor_tie_break_applied`, no `regression_alarms`).
- [x] Full suite: **119 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)