### PR TITLE
feat(ui): real ingestion -> ForensicAgent -> PDF pipeline (env-gated)

### DIFF
--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -1,15 +1,15 @@
 """Black Box FastAPI + HTMX front-end.
 
 Serves a sober, single-column upload UI for forensic analysis jobs.
-The background task is currently a stub that walks through fake stages
-and writes JSON status files to ``data/jobs/{job_id}.json``.
-
-TODO(pipeline): replace ``_run_pipeline_stub`` with the real wiring:
-    ingestion.extract(bag) -> claude_client.analyze(mode) -> reporting.render_pdf()
+Routes the upload through a real ingestion -> ForensicAgent -> PDF pipeline
+when ``BLACKBOX_REAL_PIPELINE=1`` (and an ``ANTHROPIC_API_KEY`` is set);
+otherwise falls back to the scripted stub so the UI still reads as a
+thought process in offline demos.
 """
 from __future__ import annotations
 
 import json
+import os
 import time
 import uuid
 from pathlib import Path
@@ -235,6 +235,142 @@ def _run_pipeline_replay(job_id: str, replay_name: str) -> None:
         )
 
 
+# ---- real pipeline ----------------------------------------------------------
+def _real_pipeline_enabled() -> bool:
+    """Real pipeline only fires when explicitly enabled AND an API key is set."""
+    return os.getenv("BLACKBOX_REAL_PIPELINE") == "1" and bool(os.getenv("ANTHROPIC_API_KEY"))
+
+
+def _fmt_stream_event(ev: dict) -> str | None:
+    """Convert a ForensicSession.stream() event dict into one buffer line.
+
+    Same shape as ``_fmt_replay_event`` so the UI reads identically in live
+    and replay modes.
+    """
+    t = ev.get("type")
+    p = ev.get("payload") or {}
+    if t == "status":
+        state = p.get("state", "")
+        if state in {"running", "user.message", "idle", "completed"}:
+            return f"[status] {state}"
+        return None
+    if t == "reasoning":
+        return "[reasoning] (thinking...)"
+    if t == "tool_call":
+        name = p.get("name", "tool")
+        inp = p.get("input") or {}
+        preview = inp.get("command") or json.dumps(inp)[:140]
+        return f"[tool:{name}] {preview[:180]}"
+    if t == "tool_result":
+        text = (p.get("text") or "").replace("\n", " ⏎ ")
+        err = "ERR " if p.get("is_error") else ""
+        return f"[result] {err}{text[:180]}"
+    if t == "assistant":
+        text = (p.get("text") or "").replace("\n", " ")
+        return f"[assistant] {text[:220]}"
+    return None
+
+
+_REAL_STAGE_MAP = {
+    "status": ("analyzing", "Claude is reviewing evidence"),
+    "reasoning": ("analyzing", "Claude is reviewing evidence"),
+    "tool_call": ("analyzing", "Claude is reviewing evidence"),
+    "tool_result": ("analyzing", "Claude is reviewing evidence"),
+    "assistant": ("synthesizing", "Cross-checking hypotheses"),
+}
+
+
+def _run_pipeline_real(job_id: str, upload_path: Path, mode: Mode) -> None:
+    """Real ingestion -> ForensicAgent -> PDF wiring.
+
+    Streams ``session.stream()`` events into the reasoning buffer so the UI
+    shows actual agent activity, not scripted text. Falls through to
+    ``_run_pipeline_stub`` on any setup failure so a missing key / SDK
+    version never leaves the user staring at a spinner.
+    """
+    from black_box.analysis.managed_agent import ForensicAgent, ForensicAgentConfig
+    from black_box.reporting import build_report
+
+    buffer: list[str] = []
+
+    def _push(stage: str, label: str, progress: float, *, done: bool = False) -> None:
+        _write_status(
+            job_id,
+            {
+                "job_id": job_id,
+                "stage": stage,
+                "label": label,
+                "progress": progress,
+                "mode": mode,
+                "upload": upload_path.name,
+                "reasoning_buffer": list(buffer[-200:]),
+                "has_diff": done,
+            },
+        )
+
+    try:
+        buffer.append(f"[ingest] Uploaded {upload_path.name}, {upload_path.stat().st_size} bytes")
+        _push("ingesting", "Decoding bag and extracting frames", 0.08)
+
+        case_key = f"ui_{job_id}"
+        buffer.append(f"[agent] Opening ForensicAgent session for {case_key}")
+        _push("ingesting", "Decoding bag and extracting frames", 0.15)
+
+        agent = ForensicAgent(config=ForensicAgentConfig(task_budget_minutes=7))
+        session = agent.open_session(bag_path=upload_path, case_key=case_key)
+        buffer.append(f"[agent] session_id={session.session_id}")
+        _push("analyzing", "Claude is reviewing evidence", 0.25)
+
+        event_count = 0
+        for ev in session.stream():
+            event_count += 1
+            line = _fmt_stream_event(ev)
+            if line is not None:
+                buffer.append(line)
+            stage, label = _REAL_STAGE_MAP.get(ev.get("type", ""), ("analyzing", "Claude is reviewing evidence"))
+            # Coarse progress: 0.25 -> 0.75 across the stream; never regress.
+            progress = min(0.75, 0.25 + 0.005 * event_count)
+            _push(stage, label, progress)
+
+        buffer.append("[finalize] Parsing agent report payload...")
+        _push("synthesizing", "Cross-checking hypotheses", 0.82)
+        payload = session.finalize()
+        top = (payload.get("hypotheses") or [{}])[0].get("bug_class", "other")
+        buffer.append(f"[finalize] top hypothesis: {top}")
+
+        buffer.append("[report] Building NTSB-style PDF...")
+        _push("reporting", "Rendering PDF report", 0.92)
+        out_pdf = REPORTS_DIR / f"{job_id}.pdf"
+        build_report(
+            report_json=payload,
+            artifacts={},
+            out_pdf=out_pdf,
+            case_meta={
+                "case_key": case_key,
+                "bag_path": str(upload_path),
+                "mode": mode,
+                "duration_s": 0.0,
+            },
+        )
+        buffer.append(f"[report] Wrote {out_pdf.name} ({out_pdf.stat().st_size} bytes)")
+
+        # Patch artifact for the /diff route. If the model emitted a unified
+        # diff in patch_proposal, hand that to the viewer; else fall back to
+        # the stub so the diff tab still renders something sane.
+        patch_blob = (payload.get("patch_proposal") or "").strip()
+        if patch_blob.startswith(("---", "diff ")):
+            _patch_path(job_id).write_text(json.dumps({"unified_diff": patch_blob}, indent=2))
+        else:
+            _patch_path(job_id).write_text(json.dumps(_STUB_PATCH, indent=2))
+
+        _push("done", "Complete", 1.0, done=True)
+    except Exception as e:  # pragma: no cover - live API failure path
+        buffer.append(f"ERROR: {e!r}")
+        buffer.append("[fallback] Falling back to stub pipeline so the UI stays responsive.")
+        _push("analyzing", "Live pipeline failed — replaying stub", 0.3)
+        _run_pipeline_stub(job_id, upload_path, mode)
+
+
 # ---- background stub --------------------------------------------------------
 def _run_pipeline_stub(job_id: str, upload_path: Path, mode: Mode) -> None:
     """Fake pipeline: streams reasoning chunks and walks through stages.
@@ -355,7 +491,8 @@ async def analyze(
             "has_diff": False,
         },
     )
-    background.add_task(_run_pipeline_stub, job_id, upload_path, mode)  # type: ignore[arg-type]
+    worker = _run_pipeline_real if _real_pipeline_enabled() else _run_pipeline_stub
+    background.add_task(worker, job_id, upload_path, mode)  # type: ignore[arg-type]
 
     return templates.TemplateResponse(
         request,

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -108,3 +108,114 @@ def test_report_missing_404s():
     client = TestClient(app)
     r = client.get("/report/does-not-exist")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Real-pipeline dispatch
+# ---------------------------------------------------------------------------
+def test_real_pipeline_disabled_by_default(monkeypatch):
+    """No env flags -> stub. Guards demo day against accidental live calls."""
+    monkeypatch.delenv("BLACKBOX_REAL_PIPELINE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert ui_app._real_pipeline_enabled() is False
+
+
+def test_real_pipeline_disabled_without_key(monkeypatch):
+    monkeypatch.setenv("BLACKBOX_REAL_PIPELINE", "1")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert ui_app._real_pipeline_enabled() is False
+
+
+def test_real_pipeline_enabled_when_both_set(monkeypatch):
+    monkeypatch.setenv("BLACKBOX_REAL_PIPELINE", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    assert ui_app._real_pipeline_enabled() is True
+
+
+def test_fmt_stream_event_variants():
+    """The real-pipeline formatter must cover every type emitted by session.stream()."""
+    assert ui_app._fmt_stream_event({"type": "reasoning"}) == "[reasoning] (thinking...)"
+
+    tool_line = ui_app._fmt_stream_event(
+        {"type": "tool_call", "payload": {"name": "bash", "input": {"command": "ls"}}}
+    )
+    assert tool_line is not None and tool_line.startswith("[tool:bash]")
+
+    result_line = ui_app._fmt_stream_event(
+        {"type": "tool_result", "payload": {"text": "ok\nfine", "is_error": False}}
+    )
+    assert result_line is not None and "ok" in result_line and "⏎" in result_line
+
+    err_line = ui_app._fmt_stream_event(
+        {"type": "tool_result", "payload": {"text": "boom", "is_error": True}}
+    )
+    assert err_line is not None and err_line.startswith("[result] ERR ")
+
+    asst_line = ui_app._fmt_stream_event(
+        {"type": "assistant", "payload": {"text": "done."}}
+    )
+    assert asst_line == "[assistant] done."
+
+    # chatty / unknown events filtered out
+    assert ui_app._fmt_stream_event({"type": "status", "payload": {"state": "span.tool_use"}}) is None
+    assert ui_app._fmt_stream_event({"type": "unknown"}) is None
+
+
+def test_analyze_routes_to_stub_by_default(monkeypatch, tmp_path):
+    """POST /analyze with no real-pipeline env must schedule the stub worker."""
+    monkeypatch.setattr(ui_app, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    monkeypatch.delenv("BLACKBOX_REAL_PIPELINE", raising=False)
+
+    scheduled: list[tuple] = []
+
+    def _fake_add_task(self, fn, *args, **kwargs):
+        scheduled.append((fn.__name__, args, kwargs))
+
+    # FastAPI BackgroundTasks is instantiated per request — patch it where the
+    # app imports it.
+    import fastapi
+    orig = fastapi.BackgroundTasks.add_task
+    fastapi.BackgroundTasks.add_task = _fake_add_task  # type: ignore[assignment]
+    try:
+        client = TestClient(app)
+        r = client.post(
+            "/analyze",
+            files={"file": ("run.bag", io.BytesIO(b"fake"), "application/octet-stream")},
+            data={"mode": "post_mortem"},
+        )
+    finally:
+        fastapi.BackgroundTasks.add_task = orig  # type: ignore[assignment]
+
+    assert r.status_code == 200
+    assert len(scheduled) == 1
+    assert scheduled[0][0] == "_run_pipeline_stub"
+
+
+def test_analyze_routes_to_real_pipeline_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(ui_app, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    monkeypatch.setenv("BLACKBOX_REAL_PIPELINE", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    scheduled: list[tuple] = []
+
+    def _fake_add_task(self, fn, *args, **kwargs):
+        scheduled.append((fn.__name__, args, kwargs))
+
+    import fastapi
+    orig = fastapi.BackgroundTasks.add_task
+    fastapi.BackgroundTasks.add_task = _fake_add_task  # type: ignore[assignment]
+    try:
+        client = TestClient(app)
+        r = client.post(
+            "/analyze",
+            files={"file": ("run.bag", io.BytesIO(b"fake"), "application/octet-stream")},
+            data={"mode": "post_mortem"},
+        )
+    finally:
+        fastapi.BackgroundTasks.add_task = orig  # type: ignore[assignment]
+
+    assert r.status_code == 200
+    assert len(scheduled) == 1
+    assert scheduled[0][0] == "_run_pipeline_real"


### PR DESCRIPTION
## Summary
The UI had a scripted stub worker (\`_run_pipeline_stub\`) that walked through fake stages. This PR adds the real pipeline and wires \`POST /analyze\` to dispatch between them.

- **\`_run_pipeline_real(job_id, upload_path, mode)\`**: opens a \`ForensicAgent\` session on the uploaded bag, streams \`session.stream()\` events into the reasoning buffer, calls \`finalize()\` to parse the agent payload, builds the NTSB-style PDF, writes the diff artifact. Any failure (missing SDK, rate-limit, schema mismatch) falls through to \`_run_pipeline_stub\` so the UI never leaves the user on a blank spinner.
- **\`_fmt_stream_event(ev)\`**: mirror of \`_fmt_replay_event\` so live and recorded streams render identically in the reasoning buffer (same \`[status]\` / \`[tool:name]\` / \`[result]\` / \`[assistant]\` shape).
- **\`_real_pipeline_enabled()\`**: both \`BLACKBOX_REAL_PIPELINE=1\` AND \`ANTHROPIC_API_KEY\` required. Flag-only = no key, no run. Key-only = quiet default. Guards demo day against accidental live calls.

## Why env-gated
Demo day runs on the replay path (\`/analyze?replay=sanfer_tunnel\`). This PR adds the live path as an opt-in so it can be dogfooded without making the demo riskier — flip the flag, run a live bag, unset it before recording.

## Test plan
- [x] 6 new tests in \`tests/test_ui.py\`: gate predicate across both env vars, formatter across every \`session.stream()\` event type (including the chatty-span filter), \`POST /analyze\` scheduling the right worker in each mode.
- [x] Existing UI tests still green (\`test_analyze_creates_job\`, \`test_status_renders_reasoning_buffer\`, etc.).
- [x] Full suite: **110 tests green** on this branch. Stacks with PR #16 (advisor) and PR #17 (grounding-gate demo) when all three merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)