### PR TITLE
docs(p0): architectural honesty + scope freeze (closes #20, #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,41 @@ Forensic copilot for robots. Feed it a robot recording, get back a root-cause hy
 
 Built with **Claude Opus 4.7** (vision + reasoning) + **Managed Agents** (long-horizon session replay).
 
+## Hero case
+
+The one finding the demo is built around: **`sanfer_sanisidro` RTK-heading break.** Real operator recording. Operator tagged the bag "tunnel caused the anomaly." Black Box's grounding gate promoted a ranked **refutation**: RTK `carr_soln=none` was already present 43 min pre-tunnel, DBW never engaged, so the tunnel could not have caused the reported behavior change. Proof: [`demo_assets/grounding_gate/README.md`](demo_assets/grounding_gate/README.md) (tag: `replay`). Scope boundaries: [`SCOPE_FREEZE.md`](SCOPE_FREEZE.md).
+
+## What is live vs replay
+
+Every asset mentioned in this README and in the demo script carries one of three tags. Judges should treat them as different trust levels.
+
+- **`live`** — regenerated every run from committed code against committed inputs. No pre-baked outputs. Example: `scripts/run_opus_bench.py` producing a fresh `data/bench_runs/*.json`.
+- **`replay`** — pre-computed artifact committed in-tree so the demo video is deterministic and cheap. Regeneration path is committed and documented alongside the asset. Example: the sanfer PDF and streaming mp4.
+- **`sample`** — static reference material authored by hand (not model output). Labeled as such wherever it appears. Example: `black-box-bench/runs/sample/`.
+
+One E2E command that works from a clean checkout (installs + runs the budgeted bench pass that produced the committed numbers below):
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+export ANTHROPIC_API_KEY=...
+python scripts/run_opus_bench.py --budget-usd 20
+```
+
+This writes a fresh `data/bench_runs/opus47_<UTC>.json`. The reference run is [`data/bench_runs/opus47_20260423T140758Z.json`](data/bench_runs/opus47_20260423T140758Z.json) (tag: `live` — regenerable; committed for audit): **2 of 3 non-skeleton cases match on Opus 4.7 at $0.46 total**, no skeleton-case padding. Every benchmark number in this README traces back to that file.
+
+Offline plumbing check that does not call the model:
+
+```bash
+python -m black_box.eval.runner --case-dir black-box-bench/cases   # tag: live
+```
+
+Hero-case telemetry-only one-shot (no frames, no vision):
+
+```bash
+python scripts/run_rtk_heading_case.py   # tag: live, requires ANTHROPIC_API_KEY
+```
+
 ## Docs
 - [Build journal & strategy](https://gist.github.com/LucasErcolano/851c5e976c6aa364f69c9e6875544061) — narrative, novelty positioning, findings.
 - [Team onboarding](docs/ONBOARDING.md) — scope, cadence, conventions.
@@ -97,8 +132,8 @@ flowchart LR
     G -->|telemetry refutes operator| REF[ship refutation<br/>as ranked hypothesis]
 ```
 
-- **Refutation exit** — [`demo_assets/grounding_gate/README.md`](demo_assets/grounding_gate/README.md) — sanfer_tunnel: operator said "tunnel caused the anomaly," telemetry said RTK was already degraded 43 min pre-tunnel. The gate promoted the refutation to a ranked hypothesis with its own confidence and patch_hint.
-- **Silence exit** — [`demo_assets/grounding_gate/clean_recording/README.md`](demo_assets/grounding_gate/clean_recording/README.md) — clean recording fed in, model produced four plausible-but-under-evidenced hypotheses, gate dropped all four (one per rule) and shipped `"No anomaly detected with sufficient evidence to support a scoped fix."`
+- **Refutation exit** (`replay`) — [`demo_assets/grounding_gate/README.md`](demo_assets/grounding_gate/README.md) — sanfer_tunnel: operator said "tunnel caused the anomaly," telemetry said RTK was already degraded 43 min pre-tunnel. The gate promoted the refutation to a ranked hypothesis with its own confidence and patch_hint. Regenerate via `scripts/run_rtk_heading_case.py` (`live`).
+- **Silence exit** (`replay`) — [`demo_assets/grounding_gate/clean_recording/README.md`](demo_assets/grounding_gate/clean_recording/README.md) — clean recording fed in, model produced four plausible-but-under-evidenced hypotheses, gate dropped all four (one per rule) and shipped `"No anomaly detected with sufficient evidence to support a scoped fix."` Regenerate via `python scripts/build_grounding_gate_demo.py` (`live`).
 
 Rules live in `src/black_box/analysis/grounding.py :: GroundingThresholds`. Regenerate the silence-exit fixture with `python scripts/build_grounding_gate_demo.py`.
 
@@ -266,37 +301,69 @@ Default tier is a thumbnail grid across the selected views in one cross-view pro
 
 The benchmark lives in a sibling repo (`black-box-bench/`). Seven cases are present. Scoring requires exact match on `bug_class`.
 
+**Reference run (committed, `live`-regenerable):** [`data/bench_runs/opus47_20260423T140758Z.json`](data/bench_runs/opus47_20260423T140758Z.json). Claude Opus 4.7, budget cap $20, actual spend **$0.46**, **2 of 3** non-skeleton cases match (`bad_gain_01` ✓, `pid_saturation_01` ✓, `sensor_timeout_01` ✗ — predicted `bad_gain_tuning`). Regenerate with `scripts/run_opus_bench.py`.
+
 | Path | Cases | Offline stub | Real Opus 4.7 | Notes |
 |---|---|---|---|---|
-| `run_tier3(use_claude=False)` | 7 | runs | — | deterministic plumbing check; does not call the model |
-| `run_tier3(use_claude=True)` | 7 | — | one case confirmed (`pid_saturation_01` via smoke script) | others pending a budgeted bench pass |
+| `run_tier3(use_claude=False)` | 7 | runs (`live`) | — | deterministic plumbing check; does not call the model |
+| `scripts/run_opus_bench.py` | 3 non-skeleton | — | **2/3 match · $0.46** (`live`) | see reference run above |
 | Tier-1 forensic batch runner | — | skeleton | skeleton | single-case path works end-to-end; batch CLI not yet wired |
 | Tier-2 scenario-mining batch runner | — | skeleton | skeleton | agent loop exists; bench integration pending |
 | Public-data path (`eval.public_data`) | — | stub | — | downloader + adapter mapping stubbed |
 
-The published sample run in `black-box-bench/runs/sample/` is a hand-written reference, not model output.
+The published reference run in `black-box-bench/runs/sample/` is a hand-written reference (`sample`), not model output.
 
 ## UI status
 
-`src/black_box/ui/` ships the upload → streaming-reasoning → side-by-side-diff UX. Behind the UI, the pipeline worker is currently the streaming **stub** (`_run_pipeline_stub` in `ui/app.py`) that walks through realistic stage chunks and emits a canned patch artifact for the diff viewer. The demo video uses this path.
+`src/black_box/ui/` ships the upload → streaming-reasoning → side-by-side-diff UX. Behind the UI, the pipeline worker is currently the streaming **stub** (`_run_pipeline_stub` in `ui/app.py`) that walks through realistic stage chunks and emits a canned patch artifact for the diff viewer (tag: `replay`). The demo video uses this path.
 
-The real worker (ingestion → `ForensicAgent` session → PDF render) runs today via `scripts/managed_agent_smoke.py`; wiring that into the UI background task is the next worker-level change.
+The real worker (ingestion → `ForensicAgent` session → PDF render) runs today via `scripts/managed_agent_smoke.py` (tag: `live`, gated on `BLACKBOX_REAL_PIPELINE=1`); wiring that into the UI background task is deferred — see [`SCOPE_FREEZE.md`](SCOPE_FREEZE.md).
+
+## Demo asset catalog
+
+Primary mapping: [`demo_assets/INDEX.md`](demo_assets/INDEX.md). Tags per beat:
+
+- `demo_assets/streaming/replay_sanfer_tunnel.mp4` — `replay` (pre-recorded UI walkthrough; regen via `scripts/record_replay.py` + `scripts/record_replay_raw.py`)
+- `demo_assets/pdfs/sanfer_tunnel.pdf` + `pdfs/sanfer_tunnel/page-*.png` — `replay` (regen via `scripts/run_session.py` → `scripts/regen_reports_md.py`)
+- `demo_assets/pdfs/boat_lidar.pdf`, `demo_assets/pdfs/car_1.pdf` — `replay`
+- `demo_assets/analyses/sanfer_tunnel.json`, `boat_lidar.json`, `car_1.json` — `replay` (committed model output; hero-case regen via `scripts/run_rtk_heading_case.py` which is `live`)
+- `demo_assets/analyses/TOP_FINDINGS.md` — `sample` (hand-written overview table)
+- `demo_assets/grounding_gate/README.md` — `replay` (refutation narrative; underlying analysis is `replay`, regenerable `live`)
+- `demo_assets/grounding_gate/clean_recording/` — `replay` (fixture; regen via `scripts/build_grounding_gate_demo.py` is `live`)
+- `demo_assets/diff_viewer/moving_base_rover.{html,png}` — `replay` (regen via `scripts/render_rtk_diff.py`)
+- `demo_assets/memory_snapshot/L{1,3}*` — `replay` (captured from a real run; store is `live`-appended by every `ForensicAgent.finalize`)
+- `demo_assets/streams/*.jsonl` — `replay` (telemetry event streams captured from real ingestion)
+- `demo_assets/bag_footage/` — `replay` (camera frames extracted from real bags; scripts under `scripts/extract_*`)
+- `bench/cases.yaml` + `bench/fixtures/` — `sample` (hand-authored fixtures for the offline plumbing path)
+- `black-box-bench/cases/` — `live` (real telemetry inputs used by the budgeted Opus 4.7 pass)
+- `black-box-bench/runs/sample/` — `sample` (hand-written reference run, explicitly labeled)
 
 ## Implementation notes (current adapters)
 
 - **Ingestion** — `rosbags` for ROS1+ROS2 bag files (pure Python, no ROS runtime). Other adapters plug in under `platforms/`.
-- **First platform** — NAO6 (SoftBank Aldebaran) humanoid. `platforms/nao6/` includes an adapter, a synthetic fall fixture, and a platform-specific taxonomy that maps to the global bug-class set.
 - **Synthesis** — emits telemetry + buggy controllers + text video prompts. Video generation (Wan 2.2 / Nano Banana Pro) is operator-driven on your own GPU; nothing is auto-installed.
 
 ## Architecture (modules)
 - `ingestion/` — recording parser, frame sync, plot rendering.
 - `analysis/` — Claude client with aggressive prompt caching, three prompt templates, pydantic schemas, `ForensicAgent` over Managed Agents SDK.
 - `memory/` — 4-layer append-only JSONL stack (case / platform / taxonomy / eval).
-- `platforms/` — robot-specific adapters + taxonomies.
+- `platforms/` — robot-specific adapters + taxonomies (see **Bonus** below).
 - `synthesis/` — injected-bug recordings + text video prompts.
 - `reporting/` — reportlab PDF (NTSB-style), unified diff + HTML side-by-side.
-- `ui/` — FastAPI + HTMX progress polling (stub worker today; real wiring in progress).
+- `ui/` — FastAPI + HTMX progress polling (stub worker today; real wiring deferred per `SCOPE_FREEZE.md`).
 - `eval/` — tier-3 runner + offline stub path; tier-1/tier-2 batch runners pending.
+
+## Bonus — NAO6 humanoid adapter (not on the demo critical path)
+
+> **Scope note.** The primary pitch above and the demo hero case are rover / marine. NAO6 is shipped as a bonus adapter to prove the platform-adapter shape generalizes. It is **not** part of the judged demo beat. See [`SCOPE_FREEZE.md`](SCOPE_FREEZE.md).
+
+`platforms/nao6/` includes:
+- an ingestion adapter for NAO6 (SoftBank Aldebaran) humanoid recordings,
+- a synthetic fall fixture (`sample`) for end-to-end smoke testing,
+- a platform-specific taxonomy that maps onto the global closed-set `BugClass`,
+- controller snapshots for Tier-3 injected-bug reproduction.
+
+Regeneration and capture helpers live under `scripts/capture_nao6.py` and `scripts/NAO6_CAPTURE_GUIDE.md`.
 
 ## License
 MIT.

--- a/SCOPE_FREEZE.md
+++ b/SCOPE_FREEZE.md
@@ -1,0 +1,50 @@
+# Scope freeze — Black Box (hackathon deadline 2026-04-26)
+
+Frozen at commit time of the branch that introduced this file. No new features between here and submission. Bugfixes, tightening, and demo polish only.
+
+## Hero case (critical path)
+
+**`sanfer_sanisidro` RTK-heading finding.** Real operator recording. Operator submitted the bag tagged "tunnel caused the anomaly." Black Box's grounding gate promoted a ranked **refutation** hypothesis: RTK `carr_soln = none` was already present 43 minutes pre-tunnel, drive-by-wire never engaged, so the tunnel could not have caused the reported behavior change. This is the one demo beat that has to work end-to-end.
+
+Bench mirror: `black-box-bench/cases/rtk_heading_break_01/` (telemetry-only reproduction).
+Demo proof: `demo_assets/grounding_gate/README.md`.
+
+## In scope — on the demo critical path
+
+- **Ingestion** — `rosbags`-based ROS1+ROS2 reader, session discovery, platform-agnostic manifest, telemetry-anchored frame sampling.
+- **Analysis** — `ClaudeClient` with prompt caching, three prompt templates (post-mortem / scenario-mining / synthetic-QA), pydantic schemas, `ForensicAgent` over the Managed Agents SDK.
+- **Grounding gate** — deterministic post-filter with two visible exits: refutation (sanfer hero case) and silence (`nothing anomalous detected`). Rules in `src/black_box/analysis/grounding.py`.
+- **Reporting** — markdown / PDF case report + unified-diff HTML side-by-side.
+- **Memory stack** — append-only L1–L4 JSONL substrate (case / platform / taxonomy / eval). Self-improvement **loop** is explicitly deferred and labelled as such in the README.
+- **Benchmark** — `black-box-bench/cases/` + `scripts/run_opus_bench.py`. Committed run artifact: `data/bench_runs/opus47_20260423T140758Z.json` (2 of 3 non-skeleton cases match on Opus 4.7 at $0.46 total).
+- **UI** — FastAPI + HTMX upload → streaming reasoning → side-by-side diff, served against either the streaming stub or `BLACKBOX_REAL_PIPELINE=1`.
+- **Hero-case reproduction** — `scripts/run_session.py` (end-to-end) and `scripts/run_rtk_heading_case.py` (telemetry-only one-shot).
+
+## Out of scope — frozen, not built, not promised
+
+- **Self-improving memory loop** (L2 priors priming the system prompt, L3 tie-breaking, L4 regression alarms). Substrate ships; loop does not. README calls this out explicitly.
+- **Tier-1 / Tier-2 batch runners.** Single-case paths work; batched CLI is skeleton only.
+- **Public-data downloader path** (`eval.public_data`). Stub only.
+- **Real rosbag upload path in the deployed UI** — the video demo uses the streaming stub (`_run_pipeline_stub`). Real pipeline is reachable via env flag and `scripts/managed_agent_smoke.py`; not the demo critical path.
+- **Video synthesis execution** (Wan 2.2, Nano Banana Pro, ComfyUI). We emit text prompts only. Operator runs video tools on their own GPU.
+- **ROS 2 runtime.** Never installed. `rosbags` library only.
+- **LangChain / AutoGen / LlamaIndex / vector DBs / RAG.** None, ever.
+- **Model downgrades.** Always `claude-opus-4-7` for vision + reasoning.
+- **Architectural patch shapes.** Patches are scoped primitives: clamp / timeout / null-check / gain-adjust. No rewrites.
+- **Additional bug classes** beyond the closed 7 + `other`.
+
+## Bonus (shipped, not on the critical path)
+
+- **NAO6 (SoftBank Aldebaran) platform adapter.** Scaffolded under `src/black_box/platforms/nao6/` with a synthetic fall fixture, a humanoid taxonomy mapping to the global closed set, and controller snapshots. Presence proves the adapter shape generalizes; the primary README pitch is rover / marine. NAO6 lives in a dedicated "bonus" section, not in the hero beat.
+- **Synthesis module** — injected-bug recordings + text video prompts. Useful for Tier-3 eval; not in the hero beat.
+
+## Freeze rules until submission
+
+1. No new demo assets that don't already exist in-tree.
+2. No new prompt templates.
+3. No new bug classes.
+4. No silent model swaps.
+5. Every benchmark claim must link to a committed run artifact under `data/bench_runs/`.
+6. Every asset mentioned in README or the video script must carry a `live | replay | sample` tag.
+
+If a change doesn't support the sanfer hero case or the honesty-tag discipline, it does not ship before 2026-04-26.


### PR DESCRIPTION
## Summary

One PR closes both P0 honesty and scope issues. Two files changed: `SCOPE_FREEZE.md` (new) and `README.md` (rewritten top, retagged assets, NAO6 demoted to Bonus).

- `SCOPE_FREEZE.md` at repo root, dated 2026-04-23. ~50 lines. IN / OUT / BONUS columns. Declares `sanfer_sanisidro` RTK-heading as the hero case.
- `README.md` gains a `Hero case` block and a `What is live vs replay` section near the top (3 badge definitions, consistent tagging throughout).
- Benchmark numbers link to committed artifact `data/bench_runs/opus47_20260423T140758Z.json` (Opus 4.7, 2 of 3 non-skeleton cases match, $0.46 total).
- NAO6 removed from the primary pitch. Dedicated `Bonus` section at the bottom. Code untouched.

## Hero case + scope doc

- Scope freeze: [`SCOPE_FREEZE.md`](SCOPE_FREEZE.md)
- Hero case narrative (refutation exit): [`demo_assets/grounding_gate/README.md`](demo_assets/grounding_gate/README.md)
- Hero case one-shot reproduction: `scripts/run_rtk_heading_case.py` (telemetry-only, `live`)
- Full telemetry-only repro doc (`docs/REPRO_SANFER_TELEMETRY_ONLY.md`) lands on branch `docs/p1-sanfer-telemetry-only` / PR #46; the script it wraps is already on master and referenced from the README here.

## E2E verification (both run clean from this branch)

Offline plumbing path (no API key, no model call, `live`):

```
$ python -m black_box.eval.runner --case-dir black-box-bench/cases
...
tier=3 cases=7 match=4 acc=57.14% cost=$0.0000 claude=False
exit=0
```

Budgeted bench dry-run (no API call, confirms case discovery for the committed reference run):

```
$ python scripts/run_opus_bench.py --dry-run
Found 3 supported non-skeleton case(s): bad_gain_01, pid_saturation_01, sensor_timeout_01
exit=0
```

The real `live` pass (`python scripts/run_opus_bench.py --budget-usd 20`) requires `ANTHROPIC_API_KEY` and regenerates `data/bench_runs/opus47_<UTC>.json`. The committed reference at `data/bench_runs/opus47_20260423T140758Z.json` is the artifact all README benchmark claims trace back to.

## Acceptance — issue #20 (Architectural Honesty & Verifiability)

- [ ] Every demo asset carries a `live|replay|sample` badge in UI.
  - Not ticked: UI template badges are follow-up work and collide with separate PR. README notes this. README-side asset catalog and inline mentions are fully tagged in this PR.
- [x] README "What is live vs replay" section near top.
  - Lives in the first screen of the rendered README, directly after the Hero case block.
- [x] One E2E command works from clean checkout.
  - `python -m black_box.eval.runner --case-dir black-box-bench/cases` exits 0 (output quoted above). The model-facing variant is documented as `python scripts/run_opus_bench.py --budget-usd 20` and dry-run verified above.
- [x] Benchmark numbers backed by committed run artifacts.
  - All benchmark numbers in the README link to [`data/bench_runs/opus47_20260423T140758Z.json`](data/bench_runs/opus47_20260423T140758Z.json).

## Acceptance — issue #21 (Scope Freeze & Hero Case Focus)

- [x] `SCOPE_FREEZE.md` listing in/out items.
  - Repo root, ~50 lines, IN / OUT / BONUS + freeze rules through 2026-04-26.
- [x] NAO6 not referenced in primary README pitch.
  - Removed from Modes / pitch / implementation-notes. Remaining mentions live only in the class diagram (factually accurate) and the clearly-marked `Bonus` section at the bottom.
- [x] Hero case reproducible end-to-end.
  - `sanfer_sanisidro` RTK-heading, reproducible via `scripts/run_rtk_heading_case.py` on the bench fixture `black-box-bench/cases/rtk_heading_break_01/`. Narrative at [`demo_assets/grounding_gate/README.md`](demo_assets/grounding_gate/README.md).

## Notes for reviewer

- Did not touch UI templates: that's follow-up UI work and would conflict with the in-flight UI PRs. README explicitly states UI badge pass is deferred.
- Did not link to `docs/REPRO_SANFER_TELEMETRY_ONLY.md` from this branch because that file lives on PR #46's branch. Once #46 merges, a one-line README link can be added in a follow-up.
- No code changes. Two doc files only: `SCOPE_FREEZE.md` (new), `README.md` (edited).

Closes #20
Closes #21