### PR TITLE
feat(ui): HITL approve/reject gate before patch application (closes #23)

### DIFF
--- a/src/black_box/reporting/diff.py
+++ b/src/black_box/reporting/diff.py
@@ -184,6 +184,7 @@ def demo_side_by_side_html(
     file_path: str = "patch",
     case_key: str = "",
     title: str = "Proposed Fix",
+    footer_html: str = "",
 ) -> str:
     """Large-font side-by-side diff designed for the 2:00–2:20 demo beat.
 
@@ -323,6 +324,7 @@ def demo_side_by_side_html(
     <span class="pill" style="background:{added_bg};color:{added_marker};">+ added</span>
     &middot; {case_tag}
   </div>
+  {footer_html}
 </main>
 </body>
 </html>

--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -12,6 +12,7 @@ import json
 import os
 import time
 import uuid
+from html import escape as html_escape
 from pathlib import Path
 from typing import Literal
 
@@ -109,6 +110,97 @@ def _job_path(job_id: str) -> Path:
 
 def _patch_path(job_id: str) -> Path:
     return PATCHES_DIR / f"{job_id}.json"
+
+
+def _decision_path(job_id: str) -> Path:
+    return PATCHES_DIR / f"{job_id}.decision.json"
+
+
+def _load_decision(job_id: str) -> dict:
+    p = _decision_path(job_id)
+    if not p.exists():
+        return {"status": "pending"}
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError:
+        return {"status": "pending"}
+
+
+def _save_decision(job_id: str, status: str, note: str = "") -> dict:
+    from datetime import datetime, timezone
+    decision = {
+        "status": status,
+        "decided_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "note": note,
+    }
+    _decision_path(job_id).write_text(json.dumps(decision, indent=2))
+    return decision
+
+
+_GATE_STYLE = """<style>
+.gate { margin-top: 1.5rem; padding: 1.1rem 1.25rem; border: 1px solid #d9d6cc;
+  border-radius: 4px; background: #fffdf8; font-family: "IBM Plex Sans", sans-serif; }
+.gate-headline { font-family: "IBM Plex Serif", Georgia, serif; font-weight: 600;
+  font-size: 1.05rem; letter-spacing: 0.03em; margin-bottom: 0.25rem; }
+.gate-sub, .gate-meta, .gate-note { font-family: ui-monospace, monospace;
+  font-size: 0.82rem; color: #6b6b66; }
+.gate-form { margin-top: 0.9rem; display: flex; flex-direction: column; gap: 0.7rem; }
+.gate-input { padding: 0.45rem 0.6rem; border: 1px solid #d9d6cc; border-radius: 3px;
+  font-family: ui-monospace, monospace; font-size: 0.85rem; background: #faf8f2; }
+.gate-actions { display: flex; gap: 0.6rem; }
+.gate-btn { padding: 0.55rem 1rem; border: 1px solid #1c1c1a; border-radius: 3px;
+  background: #1c1c1a; color: #fffdf8; font-family: ui-monospace, monospace;
+  font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.08em; cursor: pointer; }
+.gate-approve { background: #2f855a; border-color: #2f855a; }
+.gate-reject  { background: #b33; border-color: #b33; }
+.gate-approved { border-left: 4px solid #2f855a; }
+.gate-rejected { border-left: 4px solid #b33; }
+.gate-approved .gate-headline { color: #2f855a; }
+.gate-rejected .gate-headline { color: #b33; }
+</style>"""
+
+
+def _gate_footer_html(job_id: str, decision: dict) -> str:
+    """Approve/reject buttons (pending) or locked-decision banner (decided)."""
+    status = decision.get("status", "pending")
+    if status == "approved":
+        decided = html_escape(decision.get("decided_at", ""))
+        note = html_escape(decision.get("note", ""))
+        note_line = f'<div class="gate-note">{note}</div>' if note else ""
+        return (
+            f'{_GATE_STYLE}'
+            '<section class="gate gate-approved" data-status="approved">'
+            '<div class="gate-headline">PATCH APPROVED — CLEARED FOR INTEGRATION</div>'
+            f'<div class="gate-meta">decided {decided}</div>'
+            f'{note_line}'
+            '</section>'
+        )
+    if status == "rejected":
+        decided = html_escape(decision.get("decided_at", ""))
+        note = html_escape(decision.get("note", ""))
+        note_line = f'<div class="gate-note">{note}</div>' if note else ""
+        return (
+            f'{_GATE_STYLE}'
+            '<section class="gate gate-rejected" data-status="rejected">'
+            '<div class="gate-headline">PATCH REJECTED — BLOCKED FROM APPLICATION</div>'
+            f'<div class="gate-meta">decided {decided}</div>'
+            f'{note_line}'
+            '</section>'
+        )
+    return (
+        f'{_GATE_STYLE}'
+        '<section class="gate gate-pending" data-status="pending">'
+        '<div class="gate-headline">HUMAN APPROVAL REQUIRED</div>'
+        '<div class="gate-sub">Patch will NOT be applied until an engineer decides below.</div>'
+        f'<form method="post" action="/decide/{html_escape(job_id)}" class="gate-form">'
+        '<input type="text" name="note" placeholder="optional note (why)" class="gate-input" />'
+        '<div class="gate-actions">'
+        '<button type="submit" name="decision" value="approve" class="gate-btn gate-approve">Approve patch</button>'
+        '<button type="submit" name="decision" value="reject" class="gate-btn gate-reject">Reject patch</button>'
+        '</div>'
+        '</form>'
+        '</section>'
+    )
 
 
 def _write_status(job_id: str, payload: dict) -> None:
@@ -542,11 +634,37 @@ async def diff_view(job_id: str) -> HTMLResponse:
         proposal = rep.get("patch_proposal", "")
         file_path, old, new = parse_patch_proposal(proposal)
 
-    html = demo_side_by_side_html(
+    decision = _load_decision(job_id)
+    footer = _gate_footer_html(job_id, decision)
+    page = demo_side_by_side_html(
         old=old,
         new=new,
         file_path=file_path,
         case_key=job_id,
         title="Proposed Fix",
+        footer_html=footer,
     )
-    return HTMLResponse(html)
+    return HTMLResponse(page)
+
+
+@app.post("/decide/{job_id}", response_class=HTMLResponse)
+async def decide_patch(
+    job_id: str,
+    decision: str = Form(...),
+    note: str = Form(""),
+) -> HTMLResponse:
+    """Human-in-the-loop gate: record approve/reject before any patch applies.
+
+    Idempotent only on the first write — re-posting to a decided job 409s so
+    the decision log stays truthful.
+    """
+    if decision not in ("approve", "reject"):
+        raise HTTPException(400, "decision must be approve or reject")
+    if not _patch_path(job_id).exists():
+        raise HTTPException(404, "no patch artifact for job")
+    existing = _load_decision(job_id)
+    if existing.get("status") in ("approved", "rejected"):
+        raise HTTPException(409, f"already {existing['status']}")
+    status = "approved" if decision == "approve" else "rejected"
+    saved = _save_decision(job_id, status=status, note=note.strip())
+    return HTMLResponse(_gate_footer_html(job_id, saved))

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -219,3 +219,75 @@ def test_analyze_routes_to_real_pipeline_when_enabled(monkeypatch, tmp_path):
     assert r.status_code == 200
     assert len(scheduled) == 1
     assert scheduled[0][0] == "_run_pipeline_real"
+
+
+# ---- HITL approve/reject gate (#23) ----------------------------------------
+
+def _seed_patch(tmp_path, monkeypatch, job_id="gatejob"):
+    monkeypatch.setattr(ui_app, "PATCHES_DIR", tmp_path)
+    (tmp_path / f"{job_id}.json").write_text(json.dumps({
+        "file_path": "src/pid.cpp",
+        "old": "integral += error;\n",
+        "new": "integral += error;\nintegral = clamp(integral, -1, 1);\n",
+    }))
+    return job_id
+
+
+def test_diff_pending_shows_approve_and_reject_buttons(tmp_path, monkeypatch):
+    job_id = _seed_patch(tmp_path, monkeypatch)
+    client = TestClient(app)
+    r = client.get(f"/diff/{job_id}")
+    assert r.status_code == 200
+    assert 'data-status="pending"' in r.text
+    assert "HUMAN APPROVAL REQUIRED" in r.text
+    assert f'action="/decide/{job_id}"' in r.text
+    assert 'value="approve"' in r.text
+    assert 'value="reject"' in r.text
+
+
+def test_decide_approve_writes_decision_and_renders_banner(tmp_path, monkeypatch):
+    job_id = _seed_patch(tmp_path, monkeypatch)
+    client = TestClient(app)
+    r = client.post(f"/decide/{job_id}", data={"decision": "approve", "note": "looks safe"})
+    assert r.status_code == 200
+    assert "PATCH APPROVED" in r.text
+    assert "looks safe" in r.text
+    saved = json.loads((tmp_path / f"{job_id}.decision.json").read_text())
+    assert saved["status"] == "approved"
+    assert saved["note"] == "looks safe"
+    # Subsequent GET /diff reflects the locked state and drops the form.
+    r2 = client.get(f"/diff/{job_id}")
+    assert 'data-status="approved"' in r2.text
+    assert 'action="/decide/' not in r2.text
+
+
+def test_decide_reject_blocks_and_banners(tmp_path, monkeypatch):
+    job_id = _seed_patch(tmp_path, monkeypatch)
+    client = TestClient(app)
+    r = client.post(f"/decide/{job_id}", data={"decision": "reject", "note": "scope too broad"})
+    assert r.status_code == 200
+    assert "PATCH REJECTED" in r.text
+    saved = json.loads((tmp_path / f"{job_id}.decision.json").read_text())
+    assert saved["status"] == "rejected"
+
+
+def test_decide_is_one_shot_and_409s_on_redecision(tmp_path, monkeypatch):
+    job_id = _seed_patch(tmp_path, monkeypatch)
+    client = TestClient(app)
+    client.post(f"/decide/{job_id}", data={"decision": "approve"})
+    r = client.post(f"/decide/{job_id}", data={"decision": "reject"})
+    assert r.status_code == 409
+
+
+def test_decide_rejects_invalid_decision_value(tmp_path, monkeypatch):
+    job_id = _seed_patch(tmp_path, monkeypatch)
+    client = TestClient(app)
+    r = client.post(f"/decide/{job_id}", data={"decision": "maybe"})
+    assert r.status_code == 400
+
+
+def test_decide_404s_when_patch_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(ui_app, "PATCHES_DIR", tmp_path)
+    client = TestClient(app)
+    r = client.post("/decide/no-such-job", data={"decision": "approve"})
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

Closes the last missing piece of [#23] — an explicit human-in-the-loop gate between \"here is the proposed patch\" and \"this patch is integrated.\"

Visiting \`GET /diff/{job_id}\` still renders the NTSB-styled side-by-side diff, but the view now carries a gate banner underneath:

- **Pending** → headline \"HUMAN APPROVAL REQUIRED\" with Approve/Reject buttons + optional note field. Form POSTs to \`/decide/{job_id}\`.
- **Approved** → green-left-bar banner \"PATCH APPROVED — CLEARED FOR INTEGRATION\", buttons gone.
- **Rejected** → red-left-bar banner \"PATCH REJECTED — BLOCKED FROM APPLICATION\", buttons gone.

Decision is persisted to \`data/patches/{job_id}.decision.json\` with UTC ISO timestamp + optional note. Re-decision returns **409** on the server so the log stays truthful — a decision is a one-shot, not a toggle.

## How this relates to the grounding gate (#17)

Two independent filters, intentionally stacked:
1. **Grounding gate** — decides whether the model's hypothesis has enough evidence to propose a patch at all. If not: \"no anomaly detected with sufficient evidence\" — no diff view surfaced.
2. **HITL gate (this PR)** — for patches that *do* surface, the human decides whether to apply. System never reaches \"integrated\" without that click.

## Acceptance (from #23)

- [x] Streaming reasoning view — shipped in PR #18
- [x] Diff viewer renders unified + side-by-side — already in \`demo_side_by_side_html\`
- [x] Approve/reject buttons block patch application — **this PR**
- [x] Grounding gate wired and documented — PR #17 + \`demo_assets/grounding_gate/\`

## Changes

- \`src/black_box/reporting/diff.py\` — added \`footer_html=\"\"\` kwarg so the UI can inject the gate without the diff generator owning decision logic
- \`src/black_box/ui/app.py\` — new \`_decision_path\`, \`_load_decision\`, \`_save_decision\`, \`_gate_footer_html\` helpers; new \`POST /decide/{job_id}\` route; \`GET /diff/{job_id}\` now loads the decision and renders the gate
- \`tests/test_ui.py\` — 6 new tests covering pending render, approve path, reject path, one-shot 409, invalid-value 400, missing-patch 404

## Test plan

- [x] \`.venv/bin/python -m pytest tests/test_ui.py -q\` → 20 passed
- [x] \`.venv/bin/python -m pytest tests/ -q\` → 166 passed
- [ ] Manual: run \`uvicorn black_box.ui.app:app\`, upload a bag, watch the diff page, click Approve, verify the banner shows + form disappears + \`data/patches/{id}.decision.json\` has the right contents