### PR TITLE
ci: GitHub Actions workflow + README badge (closes #31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Test
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Black Box
 
+[![ci](https://github.com/LucasErcolano/BlackBox/actions/workflows/ci.yml/badge.svg)](https://github.com/LucasErcolano/BlackBox/actions/workflows/ci.yml)
+
 Forensic copilot for robots. Feed it a robot recording, get back a root-cause hypothesis, cross-modal evidence, and a scoped code patch.
 
 > **Pitch placeholder.** When a robot crashes, the flight data recorder tells you *what* happened. Black Box tells you *why* — and hands you the diff.


### PR DESCRIPTION
## Summary

Closes #31. Adds \`.github/workflows/ci.yml\` running on every push to master + every PR.

- Matrix: \`{python 3.10, 3.11} × ubuntu-latest\`
- Steps: \`pip install -e .[dev] && pytest -q\`
- Pip cache keyed to pyproject.toml

README gets the standard GitHub Actions badge right under the title — judge eye-candy per the issue.

## Test plan

- [x] \`.venv/bin/python -m pytest tests/ -q\` passes locally (166 tests on feat/hitl-approve-reject branch base)
- [ ] CI goes green on this PR