### PR TITLE
docs(p1): sanfer telemetry-only E2E repro (closes #26)

### DIFF
--- a/data/bench_runs/sanfer_telemetry_2026-04-24/README.md
+++ b/data/bench_runs/sanfer_telemetry_2026-04-24/README.md
@@ -1,0 +1,51 @@
+# sanfer_telemetry 2026-04-24 — reference artifact
+
+Closes #26. Proof artifact for the telemetry-only E2E repro documented at
+`docs/REPRO_SANFER_TELEMETRY_ONLY.md`.
+
+## What is in this folder
+
+`rtk_heading_break_01.json` — reference `ForensicReport` JSON for the
+sanfer_sanisidro RTK-heading hero finding, produced by
+`scripts/run_rtk_heading_case.py` against the pre-extracted bench
+fixture at `black-box-bench/cases/rtk_heading_break_01/telemetry.npz`.
+This is telemetry-only (no camera frames, no cross-view pass). It is
+committed here as the **reference output** the repro doc verifies
+against.
+
+The three raw telemetry bags (`2_dataspeed.bag`, `2_diagnostics.bag`,
+`2_sensors.bag`) are not in the repo — only the operator has them. The
+bench case is the committed-in-repo replay fixture that reproduces the
+same finding without needing the bags on disk.
+
+## Hero signatures (grep-able)
+
+- `CARR_NONE=100.0%` — rover never achieves carrier-phase lock.
+- `FLAGS_REL_POS_VALID set on 0.0% of 18133 samples` — RTK heading
+  invalid for the entire 3626.8 s run.
+- `DIFF_SOLN set on only 15.0%` — base→rover RTCM link mostly absent.
+- Moving-base contrast: `FLOAT 63.6% / FIXED 30.7%` — sky + antenna
+  fine, only the inter-receiver link is broken.
+- Operator tunnel hypothesis refuted: top ranked hypothesis is
+  moving-base RTK misconfiguration, not a tunnel event.
+
+## Fresh-run reproduction
+
+From a clean checkout:
+
+```
+.venv/bin/python scripts/run_rtk_heading_case.py
+```
+
+Writes to `black-box-bench/runs/sample/rtk_heading_break_01.json`. Diff
+that output against this committed reference — the bug_class, ranked
+evidence, and refutation verdict should match. Cost and wall time will
+differ run-to-run (deterministic schema, nondeterministic phrasing).
+
+## Cost / runtime reference
+
+- Option A (telemetry-only one-shot): ~45 s, $0.04–$0.10 per run.
+- Option B (full `run_session.py` over three bags, stage 4 no-op):
+  3–7 min, $0.10–$0.40 per run.
+
+See `data/costs.jsonl` at repo root for appended cost rows.

--- a/data/bench_runs/sanfer_telemetry_2026-04-24/rtk_heading_break_01.json
+++ b/data/bench_runs/sanfer_telemetry_2026-04-24/rtk_heading_break_01.json
@@ -1,0 +1,76 @@
+{
+  "timeline": [
+    {
+      "t_ns": 0,
+      "label": "session_start_3D_fix_acquired_on_both_receivers",
+      "cross_view": false
+    },
+    {
+      "t_ns": 0,
+      "label": "navrelposned_REL_POS_VALID_never_asserted",
+      "cross_view": true
+    },
+    {
+      "t_ns": 0,
+      "label": "rover_carrier_phase_stuck_at_CARR_NONE_100pct",
+      "cross_view": true
+    },
+    {
+      "t_ns": 0,
+      "label": "moving_base_achieves_FLOAT_63pct_FIXED_31pct",
+      "cross_view": true
+    },
+    {
+      "t_ns": 0,
+      "label": "DIFF_SOLN_only_15pct_indicating_RTCM_link_from_base_to_rover_mostly_absent",
+      "cross_view": true
+    },
+    {
+      "t_ns": 3626400000000,
+      "label": "session_end_relPosLength_and_relPosHeading_identically_zero_for_entire_run",
+      "cross_view": false
+    }
+  ],
+  "hypotheses": [
+    {
+      "bug_class": "other",
+      "confidence": 0.9,
+      "summary": "Moving-base RTK link is misconfigured: the moving-base receiver is not streaming RTCM (type 4072 + 1077/1087/etc.) to the rover reliably. The rover therefore never computes a relative position, so REL_POS_VALID is 0% and relPosLength/relPosHeading are identically zero for the whole 1-hour run. This is a receiver configuration / wiring issue, not a sensor outage and not a tunnel.",
+      "evidence": [
+        {
+          "source": "telemetry",
+          "topic_or_file": "/ublox_rover/navrelposned",
+          "t_ns": null,
+          "snippet": "FLAGS_REL_POS_VALID set on 0.0% of 18133 samples; relPosLength min=max=0; relPosHeading min=max=0; accLength min=max=0"
+        },
+        {
+          "source": "telemetry",
+          "topic_or_file": "/ublox_rover/navrelposned",
+          "t_ns": null,
+          "snippet": "FLAGS_DIFF_SOLN set on only 15.0% of samples (rover is receiving RTCM corrections from base only 15% of the time)"
+        },
+        {
+          "source": "telemetry",
+          "topic_or_file": "/ublox_rover/navpvt",
+          "t_ns": null,
+          "snippet": "carrier-phase: CARR_NONE=100.0%, FLOAT=0.0%, FIXED=0.0% — rover never achieves any carrier-phase solution"
+        },
+        {
+          "source": "telemetry",
+          "topic_or_file": "/ublox_moving_base/navpvt",
+          "t_ns": null,
+          "snippet": "moving base reaches FLOAT 63.6% / FIXED 30.7% — the base itself sees usable carrier-phase from a *separate* RTK source, proving sky visibility and antenna are fine; only the base→rover link is broken"
+        },
+        {
+          "source": "telemetry",
+          "topic_or_file": "bag_rates",
+          "t_ns": null,
+          "snippet": "All topics publish at expected rate with no drop-outs — rules out ROS-level timeouts, tunnel blackouts, or sensor_timeout"
+        }
+      ],
+      "patch_hint": "On the node/driver owning the two ublox receivers: (1) Confirm the moving-base F9P is configured in 'moving base' mode (CFG-TMODE3 = 0, and UBX-CFG-VALSET enabling RTCM3 output 4072.0, 4072.1, 1077, 1087, 1097, 1127, 1230 on the UART/USB port wired to the rover). (2) Confirm the rover F9P is in 'rover' mode with that same port configured as RTCM input. (3) Verify the physical serial/UART bridge between the two receivers (baud rate, TX/RX not swapped, common ground). (4) As a runtime check, have the node that subscribes /ublox_rover/navrelposned refuse to publish heading unless FLAGS_REL_POS_VALID && FLAGS_DIFF_SOLN are both set, and log a warning when DIFF_SOLN drops below ~95%, which would have surfaced this on day one."
+    }
+  ],
+  "root_cause_idx": 0,
+  "patch_proposal": "Root cause is a moving-base RTK configuration/wiring failure between the two ZED-F9P receivers, not a GNSS outage. Remediation on the ublox driver node(s) owning /ublox_moving_base and /ublox_rover:\n\n1. Reconfigure the moving-base F9P to output RTCM3 messages 4072.0, 4072.1, 1077, 1087, 1097, 1127, 1230 on the port physically connected to the rover F9P (typical: UART2 ↔ UART2, matched baud e.g. 460800).\n2. Reconfigure the rover F9P to accept RTCM3 on that same port and enable UBX-NAV-RELPOSNED output at the navigation rate.\n3. Verify TX/RX orientation and common ground on the inter-receiver serial link; a swap is consistent with the observed 15% DIFF_SOLN floor (occasional noise-induced byte sync rather than a real stream).\n4. In the consumer of /ublox_rover/navrelposned (the heading-producing node), add a gating check before publishing heading:\n   - require (flags & REL_POS_VALID) && (flags & DIFF_SOLN) && (flags & GNSS_FIX_OK)\n   - additionally require carrSoln == FIXED (or at least FLOAT) from /ublox_rover/navpvt for cm-grade heading\n   - emit a WARN/ERROR if REL_POS_VALID stays false for >2 s, so this class of silent failure is detected immediately instead of after a 1-hour drive."
+}

--- a/docs/REPRO_SANFER_TELEMETRY_ONLY.md
+++ b/docs/REPRO_SANFER_TELEMETRY_ONLY.md
@@ -1,0 +1,153 @@
+# Sanfer telemetry-only E2E repro
+
+Proves the hero case end-to-end without the 356 GB `2_cam-lidar.bag`.
+Telemetry only: `2_dataspeed.bag`, `2_diagnostics.bag`, `2_sensors.bag`.
+No frame extraction, no cross-view vision pass, no stage-4 camera open.
+
+**Hero finding to reproduce**
+
+- `rover carr_soln = NONE` for 100% of NAV-PVT samples (session-wide).
+- `REL_POS_VALID` (bit 2 of `navrelposned.flags`) never asserted (0% of 18133 samples).
+- `relPosLength` / `relPosHeading` / `accLength` all identically zero for the full 3626.8 s run.
+- `DIFF_SOLN` (bit 1) set on only 15.0% of samples → base→rover RTCM link mostly absent.
+- Moving-base is healthy (FLOAT 63.6%, FIXED 30.7%) — proves sky / antenna fine, only the inter-receiver link is broken.
+- Operator "tunnel caused the anomaly" hypothesis must be **refuted** with confidence ≤ 0.2 (failure is session-wide, predates any tunnel transit).
+
+## Prerequisites
+
+```
+python3.10+
+git clone https://github.com/LucasErcolano/BlackBox.git
+cd BlackBox
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+cp .env.example .env   # or echo ANTHROPIC_API_KEY=sk-... > .env
+```
+
+Verify:
+```
+.venv/bin/python -c "from black_box.analysis import ClaudeClient; print('ok')"
+```
+
+## Bags needed vs skipped
+
+| bag                | size     | used | reason |
+|--------------------|---------:|:----:|--------|
+| `2_cam-lidar.bag`  | ~356 GB  | no   | cameras + lidar only; telemetry path skips it |
+| `2_dataspeed.bag`  | ~few MB  | yes  | `/vehicle/throttle_report`, `/brake_report` (DBW never engaged) |
+| `2_diagnostics.bag`| ~few MB  | yes  | `/diagnostics` (ekf_se_map, ublox TMODE3 warnings) |
+| `2_sensors.bag`    | ~500 MB  | yes  | `/ublox_rover/*`, `/ublox_moving_base/navpvt`, IMU |
+
+Place the three kept bags in a single folder — the session prefix `2_` is the key that `discover_session_assets()` groups on.
+
+```
+/path/to/sanfer_sanisidro_telemetry/
+├── 2_dataspeed.bag
+├── 2_diagnostics.bag
+└── 2_sensors.bag
+```
+
+## Single command (telemetry-only end-to-end)
+
+Option A — one-shot against the pre-extracted bench fixture (no raw bags
+needed; telemetry already on disk as `telemetry.npz`):
+
+```
+.venv/bin/python scripts/run_rtk_heading_case.py
+```
+
+Writes report JSON to `black-box-bench/runs/sample/rtk_heading_break_01.json`.
+
+Option B — full pipeline over the three telemetry bags (skips stage 4
+automatically because no bag exceeds `BIG_BAG_BYTES = 10 GiB`):
+
+```
+.venv/bin/python scripts/run_session.py \
+    /path/to/sanfer_sanisidro_telemetry \
+    --prompt "We think the GPS fails when the car drives through a tunnel." \
+    --out data/bench_runs/sanfer_telemetry_2026-04-24
+```
+
+Stage 4 (frames) prints `no cam connections found — nothing to extract`
+when the cam-lidar bag is absent; stage 5 (vision) becomes a no-op;
+stage 6 writes the markdown forensic report from telemetry-derived
+windows alone. Grounding gate enforces the refutation exit on the
+operator's tunnel claim.
+
+## Expected runtime + cost
+
+| path                           | wall time        | API cost       |
+|--------------------------------|-----------------:|---------------:|
+| Option A (`run_rtk_heading_case.py`) | ~45 s     | $0.04 – $0.10  |
+| Option B (`run_session.py`, tel-only)| 3 – 7 min | $0.10 – $0.40  |
+
+Both stay well under 1% of the $500 project cap. Reference point: the
+full camera+telemetry hero run (`managed_agent_postmortem` on
+`sanfer_tunnel`) costs $1.68 – $5.88 per session (see `data/costs.jsonl`).
+
+## Output locations
+
+Option A:
+```
+black-box-bench/runs/sample/rtk_heading_break_01.json   # pydantic ForensicReport
+data/costs.jsonl                                        # appended cost row
+```
+
+Option B:
+```
+data/bench_runs/sanfer_telemetry_2026-04-24/
+├── input.json
+├── session.json
+├── manifest.json
+├── windows.json
+├── frames_index.json   # empty, cam-lidar bag absent
+├── vision.json         # empty, no frames to analyze
+└── report.md
+```
+
+## Verifying the hero finding
+
+Grep the report JSON for the canonical signatures:
+
+```
+jq '.hypotheses[0].summary, .hypotheses[0].evidence[].snippet' \
+    black-box-bench/runs/sample/rtk_heading_break_01.json \
+    | grep -E "CARR_NONE|REL_POS_VALID|DIFF_SOLN|moving[-_ ]base"
+```
+
+Expect to see:
+- `CARR_NONE=100.0%` (or equivalent `carr_soln=none` phrasing)
+- `FLAGS_REL_POS_VALID set on 0.0%`
+- `DIFF_SOLN set on only 15.0%`
+- moving-base contrast (`FLOAT 63.6% / FIXED 30.7%`)
+
+Grounding gate check — the operator hypothesis must be rejected, not
+confirmed. Look for:
+
+```
+jq '.hypotheses[] | select(.confidence <= 0.2) | .summary' \
+    black-box-bench/runs/sample/rtk_heading_break_01.json
+```
+
+Expect a tunnel-hypothesis refutation with confidence ≤ 0.2, or absence
+of any tunnel hypothesis in the ranked output (silence-exit is also
+valid grounding behavior per `src/black_box/analysis/grounding.py`).
+
+Cost audit:
+
+```
+tail -n 5 data/costs.jsonl | jq '{prompt_kind, usd_cost, case_key}'
+```
+
+## Why this is honest
+
+- Telemetry-only — no frames → the doc can't accidentally depend on the
+  356 GB bag. The pipeline is the same code path; the big-bag branch is
+  skipped by `stage_frames()` when no bag exceeds `BIG_BAG_BYTES`.
+- The bench case `rtk_heading_break_01` is the same sanfer session
+  pre-extracted to `telemetry.npz`, so Option A is a deterministic
+  replay you can run without any real bag on disk.
+- The reference output committed at
+  `data/bench_runs/sanfer_telemetry_2026-04-24/rtk_heading_break_01.json`
+  is the artifact the acceptance criteria can verify against.


### PR DESCRIPTION
## Summary

- Adds `docs/REPRO_SANFER_TELEMETRY_ONLY.md` (153 lines) — step-by-step repro for the sanfer_sanisidro hero case using only the three telemetry bags (`2_dataspeed.bag`, `2_diagnostics.bag`, `2_sensors.bag`). Skips the 356 GB `2_cam-lidar.bag` entirely. Covers prereqs, bags used vs skipped, the single CLI command (`scripts/run_rtk_heading_case.py` for a one-shot replay, `scripts/run_session.py` for the full pipeline), expected runtime + cost, output locations, and the grep-able hero signatures (`CARR_NONE=100%`, `REL_POS_VALID` 0%, `DIFF_SOLN` 15%, moving-base `FLOAT 63.6% / FIXED 30.7%` contrast, operator tunnel hypothesis refuted).
- Adds `data/bench_runs/sanfer_telemetry_2026-04-24/` with the reference `ForensicReport` JSON the doc verifies against, plus a README explaining provenance.

## Honesty note

I did not regenerate the hero output in this PR — the three raw telemetry bags are only on the operator's machine, not in the repo. The committed artifact at `data/bench_runs/sanfer_telemetry_2026-04-24/rtk_heading_break_01.json` is the **reference output** from `scripts/run_rtk_heading_case.py` (copied from `black-box-bench/runs/sample/`) — a deterministic replay against the pre-extracted `telemetry.npz` bench fixture. The `README.md` in that folder labels it accordingly. Anyone with the raw bags can run Option B in the doc and diff their output against this reference; anyone without the bags can run Option A for the same finding.

No pipeline code changed — this is documentation + reference artifact only.

## Test plan

- [ ] `.venv/bin/python scripts/run_rtk_heading_case.py` on master produces a report whose top hypothesis matches the committed reference (bug_class `other`, evidence cites `REL_POS_VALID 0%` + `CARR_NONE 100%` + moving-base contrast).
- [ ] Operator tunnel hypothesis appears with confidence ≤ 0.2 or is absent from the ranked output (grounding gate refutation exit).
- [ ] `tail data/costs.jsonl | jq '.usd_cost'` shows a row in the $0.04–$0.10 range for Option A.
- [ ] Docs repro works from a clean `git clone` (prereqs block is self-contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)