### PR TITLE
feat(ui): streaming progress page — sticky header, stage pills, live $ counter (closes #27)

### DIFF
--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -112,6 +112,11 @@ def _patch_path(job_id: str) -> Path:
 
 
 def _write_status(job_id: str, payload: dict) -> None:
+    """Write job status, stamping ``created_at`` once and preserving it."""
+    payload = dict(payload)
+    if "created_at" not in payload:
+        prev = _read_status(job_id) or {}
+        payload["created_at"] = prev.get("created_at") or time.time()
     _job_path(job_id).write_text(json.dumps(payload, indent=2))
 
 
@@ -123,6 +128,77 @@ def _read_status(job_id: str) -> dict | None:
         return json.loads(p.read_text())
     except json.JSONDecodeError:
         return None
+
+
+# ---- stage pills + cost counter --------------------------------------------
+# Internal STAGES ('ingesting', 'analyzing', 'synthesizing', 'reporting',
+# 'done') collapse into three user-facing phases. 'synthesizing' sits inside
+# analysis; 'done' highlights the final pill so the UI stays readable once the
+# job completes.
+_STAGE_PILL_MAP: dict[str, str] = {
+    "queued": "ingest",
+    "ingesting": "ingest",
+    "analyzing": "analyze",
+    "synthesizing": "analyze",
+    "reporting": "report",
+    "done": "report",
+    "failed": "report",
+}
+PILLS = ("ingest", "analyze", "report")
+
+
+def _pill_for(stage: str) -> str:
+    return _STAGE_PILL_MAP.get(stage, "analyze")
+
+
+def _case_name(status: dict) -> str:
+    """Derive the user-visible case label from whatever the job recorded."""
+    for key in ("case_name", "upload", "job_id"):
+        val = status.get(key)
+        if val:
+            return str(val)
+    return "—"
+
+
+def _elapsed_seconds(status: dict) -> int:
+    created = status.get("created_at")
+    if not created:
+        return 0
+    return max(0, int(time.time() - float(created)))
+
+
+def _fmt_elapsed(seconds: int) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m:02d}:{s:02d}"
+
+
+def _cost_summary(job_id: str) -> dict:
+    """Sum ``data/costs.jsonl`` into {'usd', 'source'} for the progress pill.
+
+    Falls back to 'empty' when the ledger is missing / unparseable so the UI
+    can render a zero-dollar value with a data-source attribute for tests.
+    """
+    path = DATA_DIR / "costs.jsonl"
+    if not path.exists():
+        return {"usd": 0.0, "source": "empty"}
+    total = 0.0
+    count = 0
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            total += float(entry.get("usd_cost", 0.0) or 0.0)
+            count += 1
+    except OSError:
+        return {"usd": 0.0, "source": "empty"}
+    if count == 0:
+        return {"usd": 0.0, "source": "empty"}
+    return {"usd": round(total, 2), "source": "session"}
 
 
 # ---- real stream replay -----------------------------------------------------
@@ -444,6 +520,7 @@ async def analyze_replay(
             "progress": 0.0,
             "mode": "post_mortem",
             "upload": f"replay:{replay}",
+            "case_name": replay,
             "reasoning_buffer": [f"Replaying recorded session: {replay}"],
             "has_diff": False,
         },
@@ -453,7 +530,7 @@ async def analyze_replay(
     # Render the full shell with the progress card already injected so the
     # demo link `?replay=...` loads a styled page, not a bare HTMX fragment.
     progress_html = templates.get_template("progress.html").render(
-        request=request, job_id=job_id, status=_read_status(job_id) or {}
+        request=request, **_progress_context(job_id, _read_status(job_id) or {})
     )
     return templates.TemplateResponse(
         request,
@@ -487,6 +564,7 @@ async def analyze(
             "progress": 0.0,
             "mode": mode,
             "upload": upload_path.name,
+            "case_name": file.filename or upload_path.name,
             "reasoning_buffer": ["Waiting for worker..."],
             "has_diff": False,
         },
@@ -497,7 +575,7 @@ async def analyze(
     return templates.TemplateResponse(
         request,
         "progress.html",
-        {"job_id": job_id, "status": _read_status(job_id) or {}},
+        _progress_context(job_id, _read_status(job_id) or {}),
     )
 
 
@@ -509,8 +587,26 @@ async def status(request: Request, job_id: str) -> HTMLResponse:
     return templates.TemplateResponse(
         request,
         "progress.html",
-        {"job_id": job_id, "status": data},
+        _progress_context(job_id, data),
     )
+
+
+def _progress_context(job_id: str, status_data: dict) -> dict:
+    stage = status_data.get("stage", "queued")
+    active_pill = _pill_for(stage)
+    elapsed = _elapsed_seconds(status_data)
+    cost = _cost_summary(job_id)
+    return {
+        "job_id": job_id,
+        "status": status_data,
+        "pills": PILLS,
+        "active_pill": active_pill,
+        "case_name": _case_name(status_data),
+        "elapsed_seconds": elapsed,
+        "elapsed_fmt": _fmt_elapsed(elapsed),
+        "cost_usd": cost["usd"],
+        "cost_source": cost["source"],
+    }
 
 
 @app.get("/report/{job_id}")

--- a/src/black_box/ui/static/style.css
+++ b/src/black_box/ui/static/style.css
@@ -98,6 +98,90 @@ button:hover { background: #000; }
 .progress-card.failed { border-color: var(--accent); }
 .progress-card.failed .bar-fg { fill: var(--accent); }
 
+.sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin: -1.25rem -1.5rem 1rem;
+  padding: 0.7rem 1.5rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+  font-size: 0.88rem;
+}
+.sticky-header .case-label,
+.sticky-header .meta-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-right: 0.4rem;
+}
+.sticky-header .case-name {
+  font-family: var(--serif);
+  font-weight: 600;
+  color: var(--ink);
+}
+.sticky-right {
+  display: flex;
+  gap: 1.2rem;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+.sticky-right .meta-value {
+  color: var(--ink);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.88rem;
+}
+.cost[data-source="empty"] .meta-value { color: var(--muted); }
+
+.stage-pills {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.stage-pills .pill {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #fffdf8;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.stage-pills .pill-index {
+  display: inline-flex;
+  width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--line);
+  color: var(--ink);
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+.stage-pills .pill.active {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--surface);
+}
+.stage-pills .pill.active .pill-index {
+  background: var(--surface);
+  color: var(--ink);
+}
+
 .progress-head {
   display: flex;
   justify-content: space-between;

--- a/src/black_box/ui/templates/progress.html
+++ b/src/black_box/ui/templates/progress.html
@@ -11,6 +11,32 @@
   hx-swap="outerHTML"
   {% endif %}
 >
+  <div class="sticky-header" data-case="{{ case_name }}">
+    <div class="sticky-left">
+      <span class="case-label">case</span>
+      <span class="case-name">{{ case_name }}</span>
+    </div>
+    <div class="sticky-right">
+      <span class="elapsed" data-elapsed-seconds="{{ elapsed_seconds }}">
+        <span class="meta-label">elapsed</span>
+        <span class="meta-value">{{ elapsed_fmt }}</span>
+      </span>
+      <span class="cost" data-source="{{ cost_source }}" data-usd="{{ '%.2f' | format(cost_usd) }}">
+        <span class="meta-label">spend</span>
+        <span class="meta-value">${{ '%.2f' | format(cost_usd) }}</span>
+      </span>
+    </div>
+  </div>
+
+  <ol class="stage-pills" aria-label="pipeline stages">
+    {% for pill in pills %}
+    <li class="pill {% if pill == active_pill %}active{% endif %}" data-pill="{{ pill }}">
+      <span class="pill-index">{{ loop.index }}</span>
+      <span class="pill-name">{{ pill }}</span>
+    </li>
+    {% endfor %}
+  </ol>
+
   <div class="progress-head">
     <span class="stage-label">{{ status.get('label', stage) }}</span>
     <span class="stage-pct">{{ pct }}%</span>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import io
 import json
+import re
+import time
 
 from fastapi.testclient import TestClient
 
@@ -190,6 +192,98 @@ def test_analyze_routes_to_stub_by_default(monkeypatch, tmp_path):
     assert r.status_code == 200
     assert len(scheduled) == 1
     assert scheduled[0][0] == "_run_pipeline_stub"
+
+
+# ---------------------------------------------------------------------------
+# P2 progress page — sticky header, stage pills, live $ counter (issue #27)
+# ---------------------------------------------------------------------------
+def test_status_sticky_header_has_case_and_elapsed(tmp_path, monkeypatch):
+    """Sticky header must render the case name + an elapsed-time readout."""
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    job_id = "hdrjob"
+    (tmp_path / f"{job_id}.json").write_text(json.dumps({
+        "job_id": job_id,
+        "stage": "analyzing",
+        "label": "Claude is reviewing evidence",
+        "progress": 0.4,
+        "mode": "post_mortem",
+        "upload": "nao_fall.bag",
+        "case_name": "nao_fall.bag",
+        "created_at": time.time() - 73,  # 1m13s ago
+        "reasoning_buffer": ["[analyzing] working..."],
+        "has_diff": False,
+    }))
+    client = TestClient(app)
+    r = client.get(f"/status/{job_id}")
+    assert r.status_code == 200
+    assert "sticky-header" in r.text
+    assert "nao_fall.bag" in r.text
+    # Elapsed renders as mm:ss and carries the numeric seconds in a data attr.
+    assert re.search(r'data-elapsed-seconds="\d+"', r.text)
+    assert re.search(r"\d{2}:\d{2}", r.text)
+
+
+def test_status_stage_pills_render_exactly_one_active(tmp_path, monkeypatch):
+    """Three pills (ingest / analyze / report); exactly one is active."""
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    job_id = "pilljob"
+    (tmp_path / f"{job_id}.json").write_text(json.dumps({
+        "job_id": job_id,
+        "stage": "analyzing",
+        "label": "Claude is reviewing evidence",
+        "progress": 0.4,
+        "mode": "post_mortem",
+        "upload": "case.bag",
+        "case_name": "case.bag",
+        "reasoning_buffer": ["[analyzing] ..."],
+        "has_diff": False,
+    }))
+    client = TestClient(app)
+    r = client.get(f"/status/{job_id}")
+    assert r.status_code == 200
+    # All three pill names render.
+    for name in ("ingest", "analyze", "report"):
+        assert f'data-pill="{name}"' in r.text
+    # Exactly one `pill active` badge — not zero, not two.
+    active_count = len(re.findall(r'class="pill active"', r.text))
+    assert active_count == 1, f"expected 1 active pill, got {active_count}"
+    # ...and it's the 'analyze' one for stage='analyzing'.
+    assert re.search(r'class="pill active" data-pill="analyze"', r.text)
+
+
+def test_status_cost_counter_renders_dollar_amount(tmp_path, monkeypatch):
+    """Cost counter must render a $ number, with data-source marking empty ledgers."""
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    # Point the cost ledger at an empty tmp dir so the stub render path is covered.
+    monkeypatch.setattr(ui_app, "DATA_DIR", tmp_path)
+    job_id = "costjob"
+    (tmp_path / f"{job_id}.json").write_text(json.dumps({
+        "job_id": job_id,
+        "stage": "analyzing",
+        "label": "Claude is reviewing evidence",
+        "progress": 0.4,
+        "mode": "post_mortem",
+        "upload": "case.bag",
+        "case_name": "case.bag",
+        "reasoning_buffer": ["[analyzing] ..."],
+        "has_diff": False,
+    }))
+    client = TestClient(app)
+    r = client.get(f"/status/{job_id}")
+    assert r.status_code == 200
+    # Empty ledger → $0.00 with data-source="empty".
+    assert 'data-source="empty"' in r.text
+    assert "$0.00" in r.text
+
+    # Populate the ledger and reassert — the number must update and source flips.
+    (tmp_path / "costs.jsonl").write_text(
+        json.dumps({"usd_cost": 1.23, "prompt_kind": "x"}) + "\n"
+        + json.dumps({"usd_cost": 0.77, "prompt_kind": "y"}) + "\n"
+    )
+    r2 = client.get(f"/status/{job_id}")
+    assert r2.status_code == 200
+    assert 'data-source="session"' in r2.text
+    assert "$2.00" in r2.text
 
 
 def test_analyze_routes_to_real_pipeline_when_enabled(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Closes #27 — UI Progress Page acceptance criteria.

- Sticky header: case name + elapsed time (mm:ss from job `created_at`)
- Stage pills: `ingest → analyze → report`, exactly one active, mapped from the internal 5-stage machine
- Live $ counter: reads `data/costs.jsonl`, renders `$0.00` with `data-source="empty"` when the ledger is missing/empty, session total otherwise
- Existing streaming reasoning buffer + cursor + diff/report links preserved — no regressions

## Implementation notes

- `_write_status` now stamps `created_at` once and preserves it across polls; replay + upload entry points set `case_name`
- New `_progress_context` helper feeds the template (pills, active pill, case name, elapsed, cost)
- `_STAGE_PILL_MAP` collapses internal stages (`ingesting/analyzing/synthesizing/reporting/done`) into three user-visible pills; `synthesizing` sits under `analyze`, `done/failed` highlight the `report` pill
- Cost summary is permissive: JSON parse errors per-line don't kill the page
- Pure CSS pill + sticky-header styling, no gradients / no spinners (NTSB aesthetic)

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_ui.py -q` → 17 passed (14 existing, 3 new)
- [x] Full suite: 172 passed
- [x] New tests:
  - `test_status_sticky_header_has_case_and_elapsed`
  - `test_status_stage_pills_render_exactly_one_active`
  - `test_status_cost_counter_renders_dollar_amount` (covers both empty + populated ledger)
- [x] HTMX polling behavior unchanged: same endpoint shape, HTML fragment, 1s trigger
- [x] `data-source="empty"` attribute asserted for tests where ledger is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)