### PR TITLE
docs(p3): README pitch audit (closes #33)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,37 @@
+name: link-check
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "README.md"
+      - "docs/**/*.md"
+      - "demo_assets/**/*.md"
+      - ".github/workflows/link-check.yml"
+  pull_request:
+    paths:
+      - "README.md"
+      - "docs/**/*.md"
+      - "demo_assets/**/*.md"
+      - ".github/workflows/link-check.yml"
+  schedule:
+    - cron: "0 12 * * 1"  # weekly Monday noon UTC
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link check (README + docs)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-concurrency 4
+            --accept 200,203,206,429
+            README.md
+            docs/**/*.md
+            demo_assets/**/*.md
+          fail: true
+          jobSummary: true

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![ci](https://github.com/LucasErcolano/BlackBox/actions/workflows/ci.yml/badge.svg)](https://github.com/LucasErcolano/BlackBox/actions/workflows/ci.yml)
 
+**Built with Claude Opus 4.7** — vision + reasoning + Managed Agents (long-horizon session replay). Model ID: `claude-opus-4-7`. No downgrades.
+
 Forensic copilot for robots. Feed it a robot recording, get back a root-cause hypothesis, cross-modal evidence, and a scoped code patch.
 
-> **Pitch placeholder.** When a robot crashes, the flight data recorder tells you *what* happened. Black Box tells you *why* — and hands you the diff.
-
-Built with **Claude Opus 4.7** (vision + reasoning) + **Managed Agents** (long-horizon session replay).
+> When a robot crashes, the flight data recorder tells you *what* happened. Black Box tells you *why*, and hands you the diff.
 
 ## Hero case
 
@@ -73,6 +73,12 @@ pip install -e .
 export ANTHROPIC_API_KEY=...    # or put in .env
 python -m black_box.eval.runner --case-dir black-box-bench/cases
 ```
+
+Verified on this commit (2026-04-23, Python 3.13.9):
+
+- `pytest -q` -> **169 passed** in 20.65s (2 deprecation warnings, no failures).
+- `python scripts/cost_report.py` -> **TOTAL $30.56** across 90 entries (29 real Opus 4.7 calls: $26.97; 61 test fixtures: $3.59).
+- `lychee README.md` -> **11/11 links OK, 0 errors** (enforced in CI via `.github/workflows/link-check.yml`).
 
 ## System overview
 


### PR DESCRIPTION
## Summary
- Promotes "Built with Claude Opus 4.7" to line 3 so it lands above the fold on GitHub and on narrow screens.
- Adds three verified one-line quickstart results (pytest, cost_report, lychee) with numbers measured on this commit.
- Adds `.github/workflows/link-check.yml` running `lychee` on push, PR, and a weekly cron, so broken links fail CI before merge.

## Measured numbers (2026-04-23, Python 3.13.9)
- `pytest -q` -> **169 passed** in 20.65s (2 deprecation warnings, no failures).
- `python scripts/cost_report.py` -> **TOTAL $30.56** across 90 entries (29 real Opus 4.7 calls: $26.97; 61 test fixtures: $3.59).
- `lychee --no-progress README.md 'docs/**/*.md' 'demo_assets/**/*.md'` -> **17 total, 16 OK, 1 redirect, 0 errors**.

## Scope
- Only `README.md` and the new workflow file. No source changes.
- Did not touch the token-discipline / cost-curve content (shipped separately in #48).

## Acceptance (from #33)
- [x] Link check passes in CI. Workflow added and validated locally with `lychee 0.23.0`; zero errors across README + docs + demo_assets.
- [x] Quickstart numbers present. Three concrete one-liners added under the Quickstart code block.
- [x] Opus 4.7 tag above the fold. Now on line 3 of the rendered README.

## Test plan
- [x] Local: `pytest -q` -> 169 passed.
- [x] Local: `python scripts/cost_report.py` -> TOTAL $30.56.
- [x] Local: `lychee` run over README + docs + demo_assets -> 0 errors.
- [ ] CI: `link-check` workflow passes on the PR head (will run on push).

Closes #33.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>