### PR TITLE
feat(p2): report endpoint renders markdown in-browser (closes #28)

### DIFF
--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -521,6 +521,9 @@ def _run_pipeline_real(job_id: str, upload_path: Path, mode: Mode) -> None:
                 "duration_s": 0.0,
             },
         )
+        # Persist the raw JSON payload so /report/{id}?format=pdf can build
+        # a PDF on demand without re-running the pipeline.
+        (JOBS_DIR / f"{job_id}_report.json").write_text(json.dumps(payload, indent=2))
         buffer.append(f"[report] Wrote {out_pdf.name} ({out_pdf.stat().st_size} bytes)")
 
         # Patch artifact for the /diff route. If the model emitted a unified
@@ -702,12 +705,58 @@ def _progress_context(job_id: str, status_data: dict) -> dict:
     }
 
 
-@app.get("/report/{job_id}")
-async def report(job_id: str) -> FileResponse:
-    md = REPORTS_DIR / f"{job_id}.md"
-    if not md.exists():
+def _build_pdf_on_demand(job_id: str) -> Path | None:
+    """Render PDF from saved JSON payload. Fallback when no pre-built PDF on disk."""
+    payload_path = JOBS_DIR / f"{job_id}_report.json"
+    if not payload_path.exists():
+        return None
+    try:
+        payload = json.loads(payload_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    from black_box.reporting import build_pdf_report
+
+    out_pdf = REPORTS_DIR / f"{job_id}.pdf"
+    build_pdf_report(
+        report_json=payload,
+        artifacts={},
+        out_pdf=out_pdf,
+        case_meta={"case_key": f"ui_{job_id}", "mode": "post_mortem"},
+    )
+    return out_pdf
+
+
+@app.get("/report/{job_id}", response_class=HTMLResponse)
+async def report(
+    request: Request,
+    job_id: str,
+    format: str | None = Query(None, description="'pdf' to download the PDF, default renders markdown in-browser"),
+):
+    """Render forensic report. Default = HTML+marked.js; ?format=pdf = raw PDF."""
+    md_path = REPORTS_DIR / f"{job_id}.md"
+    pdf_path = REPORTS_DIR / f"{job_id}.pdf"
+
+    if format == "pdf":
+        if not pdf_path.exists():
+            built = _build_pdf_on_demand(job_id)
+            if built is None or not built.exists():
+                raise HTTPException(404, "pdf not available")
+            pdf_path = built
+        return FileResponse(
+            str(pdf_path),
+            media_type="application/pdf",
+            filename=pdf_path.name,
+        )
+
+    if not md_path.exists():
         raise HTTPException(404, "report not ready")
-    return FileResponse(str(md), media_type="text/markdown", filename=md.name)
+
+    markdown_source = md_path.read_text(encoding="utf-8")
+    return templates.TemplateResponse(
+        request,
+        "report.html",
+        {"job_id": job_id, "markdown_source": markdown_source},
+    )
 
 
 @app.get("/diff/{job_id}", response_class=HTMLResponse)

--- a/src/black_box/ui/static/style.css
+++ b/src/black_box/ui/static/style.css
@@ -295,3 +295,126 @@ footer {
   main { padding: 2.5rem 1rem 4rem; }
   header h1 { font-size: 1.8rem; }
 }
+
+/* ---- Report view (rendered markdown) ---- */
+.report-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 1rem;
+}
+.report-head h1 {
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: 1.8rem;
+  margin: 0 0 0.2rem;
+}
+.report-head .sub { color: var(--muted); margin: 0; font-size: 0.92rem; }
+.report-head .sub code { font-size: 0.88rem; color: var(--ink); }
+
+.report-actions { display: flex; gap: 0.6rem; flex-wrap: wrap; }
+.btn {
+  font-family: inherit;
+  font-size: 0.9rem;
+  padding: 0.5rem 0.95rem;
+  border-radius: 3px;
+  text-decoration: none;
+  border: 1px solid var(--ink);
+  display: inline-block;
+  line-height: 1.2;
+}
+.btn-primary { background: var(--ink); color: var(--surface); }
+.btn-primary:hover { background: #000; }
+.btn-secondary {
+  background: var(--surface);
+  color: var(--ink);
+  border-color: var(--line);
+}
+.btn-secondary:hover { border-color: var(--ink); }
+
+.report-body {
+  font-family: var(--serif);
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--ink);
+}
+.report-body h1, .report-body h2, .report-body h3 {
+  font-family: var(--serif);
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  margin: 2rem 0 0.6rem;
+}
+.report-body h1 { font-size: 1.7rem; border-bottom: 1px solid var(--line); padding-bottom: 0.4rem; }
+.report-body h2 { font-size: 1.3rem; }
+.report-body h3 { font-size: 1.08rem; }
+.report-body p { margin: 0.65rem 0; }
+.report-body blockquote {
+  border-left: 3px solid var(--ink);
+  margin: 1rem 0;
+  padding: 0.3rem 1rem;
+  background: var(--surface);
+  color: #2a2a27;
+}
+.report-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  font-family: var(--sans);
+  font-size: 0.92rem;
+}
+.report-body th, .report-body td {
+  border: 1px solid var(--line);
+  padding: 0.5rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+.report-body th {
+  background: var(--surface);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+.report-body code {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.88em;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  padding: 0.05rem 0.3rem;
+}
+.report-body pre {
+  background: #141412;
+  color: #e7e4db;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 0.9rem 1rem;
+  overflow: auto;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+.report-body pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+.report-body img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--line);
+  margin: 0.75rem 0;
+}
+.report-body hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin: 2rem 0;
+}
+.report-body ul, .report-body ol { padding-left: 1.4rem; }
+.report-body li { margin: 0.25rem 0; }

--- a/src/black_box/ui/templates/progress.html
+++ b/src/black_box/ui/templates/progress.html
@@ -64,7 +64,7 @@
       <a class="link-diff" href="/diff/{{ job_id }}" target="_blank" rel="noopener">View proposed fix →</a>
     {% endif %}
     {% if stage == 'done' %}
-      <a class="link-report" href="/report/{{ job_id }}">Download report</a>
+      <a class="link-report" href="/report/{{ job_id }}" target="_blank" rel="noopener">View report →</a>
     {% endif %}
   </div>
 </div>

--- a/src/black_box/ui/templates/report.html
+++ b/src/black_box/ui/templates/report.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Black Box — Report {{ job_id }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@400;600&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+</head>
+<body>
+  <main>
+    <header class="report-head">
+      <div>
+        <h1>Black Box</h1>
+        <p class="sub">Forensic report · <code>{{ job_id }}</code></p>
+      </div>
+      <nav class="report-actions">
+        <a class="btn btn-primary" href="/">← New analysis</a>
+        <a class="btn btn-secondary" href="/report/{{ job_id }}?format=pdf">Download PDF</a>
+      </nav>
+    </header>
+
+    <article
+      id="report-body"
+      class="report-body"
+      aria-live="polite"
+      data-markdown="{{ markdown_source }}"
+    >
+      <noscript><pre>{{ markdown_source }}</pre></noscript>
+    </article>
+
+    <footer>
+      <small>Opus 4.7 · Managed Agents · hackathon build</small>
+    </footer>
+  </main>
+  <script>
+    (function () {
+      var target = document.getElementById('report-body');
+      var src = target.getAttribute('data-markdown') || '';
+      if (window.marked && typeof window.marked.parse === 'function') {
+        window.marked.setOptions({ gfm: true, breaks: false, headerIds: true });
+        var rawHtml = window.marked.parse(src);
+        if (window.DOMPurify && typeof window.DOMPurify.sanitize === 'function') {
+          target.innerHTML = window.DOMPurify.sanitize(rawHtml);
+        } else {
+          var pre = document.createElement('pre');
+          pre.textContent = src;
+          target.innerHTML = '';
+          target.appendChild(pre);
+        }
+      } else {
+        var pre = document.createElement('pre');
+        pre.textContent = src;
+        target.innerHTML = '';
+        target.appendChild(pre);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -113,6 +113,58 @@ def test_report_missing_404s():
 
 
 # ---------------------------------------------------------------------------
+# /report/{job_id} — rendered markdown page + PDF variant (issue #28)
+# ---------------------------------------------------------------------------
+def test_report_renders_markdown_html(tmp_path, monkeypatch):
+    """Default GET serves an HTML shell that renders the MD via marked.js."""
+    monkeypatch.setattr(ui_app, "REPORTS_DIR", tmp_path)
+    job_id = "renderjob"
+    md_body = (
+        "# Black Box — Forensic Report\n\n"
+        "**Case:** `ui_renderjob`\n\n"
+        "> pid_saturation detected at t=1.82s\n"
+    )
+    (tmp_path / f"{job_id}.md").write_text(md_body)
+
+    client = TestClient(app)
+    r = client.get(f"/report/{job_id}")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    # marked.js is wired into the page
+    assert "marked" in r.text
+    # The raw markdown is embedded for client-side rendering
+    assert "pid_saturation detected" in r.text
+    # Secondary PDF download button is present
+    assert f"/report/{job_id}?format=pdf" in r.text
+    assert "Download PDF" in r.text
+
+
+def test_report_pdf_variant_returns_pdf_bytes(tmp_path, monkeypatch):
+    """?format=pdf serves pre-built PDF with application/pdf content-type."""
+    monkeypatch.setattr(ui_app, "REPORTS_DIR", tmp_path)
+    job_id = "pdfjob"
+    # Minimal valid PDF header — enough for the route to echo the bytes.
+    pdf_bytes = b"%PDF-1.4\n%EOF\n"
+    (tmp_path / f"{job_id}.pdf").write_bytes(pdf_bytes)
+
+    client = TestClient(app)
+    r = client.get(f"/report/{job_id}?format=pdf")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/pdf"
+    assert r.content.startswith(b"%PDF-")
+
+
+def test_report_pdf_variant_missing_404s(tmp_path, monkeypatch):
+    """?format=pdf with no pre-built PDF and no JSON payload -> 404."""
+    monkeypatch.setattr(ui_app, "REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+
+    client = TestClient(app)
+    r = client.get("/report/nope-not-here?format=pdf")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # Real-pipeline dispatch
 # ---------------------------------------------------------------------------
 def test_real_pipeline_disabled_by_default(monkeypatch):


### PR DESCRIPTION
## Summary
- `GET /report/{job_id}` now returns an HTML page that renders the saved Markdown client-side via marked.js (CDN). No forced download.
- Adds `?format=pdf` variant on the same route. Serves a pre-built `{job_id}.pdf` if present, otherwise builds one on demand from the persisted JSON payload via the existing `build_pdf_report`. Old `/report/{id}` PDF consumers can migrate to `/report/{id}?format=pdf`.
- Real pipeline now persists `{job_id}_report.json` in `JOBS_DIR` alongside the MD so the PDF-on-demand path works without re-running the pipeline.
- Styling reuses existing `static/style.css` tokens (IBM Plex Serif, muted surface palette, no gradients, no emojis) and adds `.report-head`, `.report-body`, `.btn`/`.btn-primary`/`.btn-secondary` scoped rules.

## Acceptance (issue #28)
- [x] Visiting `/report/{id}` shows a rendered markdown page (not a download).
- [x] "Download PDF" button present on the rendered page.
- [x] Old download path still accessible via `/report/{id}?format=pdf`.
- [x] NTSB aesthetic preserved (Plex Serif + monospace, no gradients, no emojis).

## Test plan
- [x] `PYTHONPATH=src pytest -q` → **172 passed, 1 warning**.
- [x] New tests in `tests/test_ui.py`:
  - `test_report_renders_markdown_html` — default GET returns HTML, embeds markdown source, wires marked.js, shows "Download PDF" button.
  - `test_report_pdf_variant_returns_pdf_bytes` — `?format=pdf` serves `application/pdf` bytes.
  - `test_report_pdf_variant_missing_404s` — `?format=pdf` with no pre-built PDF and no JSON payload returns 404.
- [ ] Manual: drop an `.md` file into `data/reports/`, hit `/report/<id>` in a browser, confirm tables/blockquotes/code fences render under Plex Serif with the dark code block inversion.