### PR TITLE
feat(p2): UI landing page + NTSB aesthetic pass (closes #29, #30)

### DIFF
--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -32,6 +32,15 @@ JOBS_DIR = DATA_DIR / "jobs"
 REPORTS_DIR = DATA_DIR / "reports"
 UPLOADS_DIR = DATA_DIR / "uploads"
 PATCHES_DIR = DATA_DIR / "patches"
+CASES_DIR = REPO_ROOT / "demo_assets" / "pdfs"
+
+# Whitelist of hero cases surfaced on the landing page. Keeps the /case route
+# from doubling as an arbitrary-file-read primitive.
+HERO_CASES: dict[str, str] = {
+    "sanfer_tunnel": "sanfer_tunnel.md",
+    "car_1": "car_1.md",
+    "boat_lidar": "boat_lidar.md",
+}
 for d in (JOBS_DIR, REPORTS_DIR, UPLOADS_DIR, PATCHES_DIR):
     d.mkdir(parents=True, exist_ok=True)
 
@@ -703,6 +712,22 @@ def _progress_context(job_id: str, status_data: dict) -> dict:
         "cost_usd": cost["usd"],
         "cost_source": cost["source"],
     }
+
+
+@app.get("/case/{slug}", response_class=HTMLResponse)
+async def case_fragment(request: Request, slug: str) -> HTMLResponse:
+    filename = HERO_CASES.get(slug)
+    if filename is None:
+        raise HTTPException(404, f"unknown case: {slug}")
+    md_path = CASES_DIR / filename
+    if not md_path.exists():
+        raise HTTPException(404, f"case markdown missing: {filename}")
+    markdown_source = md_path.read_text(encoding="utf-8")
+    return templates.TemplateResponse(
+        request,
+        "case_fragment.html",
+        {"slug": slug, "markdown_source": markdown_source},
+    )
 
 
 def _build_pdf_on_demand(job_id: str) -> Path | None:

--- a/src/black_box/ui/static/style.css
+++ b/src/black_box/ui/static/style.css
@@ -1,6 +1,7 @@
 :root {
   --serif: "IBM Plex Serif", Georgia, serif;
   --sans:  "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono:  "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --bg:       #f6f4ef;
   --surface:  #fffdf8;
   --ink:      #1c1c1a;
@@ -23,22 +24,38 @@ html, body {
 }
 
 main {
-  max-width: 720px;
+  max-width: 780px;
   margin: 0 auto;
   padding: 4rem 1.5rem 6rem;
 }
 
+header {
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+header .kicker {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin: 0 0 0.65rem;
+}
+
 header h1 {
-  font-family: var(--serif);
+  font-family: var(--mono);
   font-weight: 600;
-  font-size: 2.25rem;
+  font-size: 2rem;
   letter-spacing: -0.01em;
   margin: 0 0 0.25rem;
+  text-transform: uppercase;
 }
 
 header .sub {
   color: var(--muted);
-  margin: 0 0 2.5rem;
+  margin: 0;
 }
 
 .intro p {
@@ -53,14 +70,88 @@ form.upload {
   border-radius: 4px;
   padding: 1.5rem;
   display: grid;
+  gap: 1.25rem;
+}
+
+.dropzone {
+  display: grid;
+  gap: 0.4rem;
+  padding: 2rem 1.5rem;
+  border: 1px dashed var(--line);
+  border-radius: 3px;
+  background: var(--bg);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.dropzone:hover,
+.dropzone:focus-within {
+  border-color: var(--ink);
+}
+.dropzone.is-dragging {
+  border-color: var(--ink);
+  background: #eeece5;
+}
+.dropzone.has-file {
+  border-style: solid;
+  background: var(--surface);
+}
+
+.dropzone-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+.dropzone-title {
+  font-family: var(--mono);
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--ink);
+}
+.dropzone-hint {
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+.dropzone-filename {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  color: var(--muted);
+  margin-top: 0.4rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dropzone.has-file .dropzone-filename {
+  color: var(--ink);
+}
+
+.dropzone input[type=file] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.upload-row {
+  display: flex;
   gap: 1rem;
+  align-items: end;
+  flex-wrap: wrap;
 }
 
 .field { display: grid; gap: 0.35rem; }
 .field span {
-  font-size: 0.82rem;
+  font-family: var(--mono);
+  font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.14em;
   color: var(--muted);
 }
 
@@ -76,9 +167,11 @@ input[type=file], select {
 
 button {
   justify-self: start;
-  font-family: inherit;
-  font-size: 0.95rem;
-  padding: 0.6rem 1.4rem;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.65rem 1.4rem;
   background: var(--ink);
   color: var(--surface);
   border: 0;
@@ -86,6 +179,22 @@ button {
   cursor: pointer;
 }
 button:hover { background: #000; }
+
+.btn {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.55rem 1.1rem;
+  border-radius: 3px;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid var(--line);
+}
+.btn-primary { background: var(--ink); color: var(--surface); border-color: var(--ink); }
+.btn-secondary { background: var(--surface); color: var(--ink); }
+.btn-secondary:hover { background: var(--bg); }
 
 #result { margin-top: 2rem; }
 
@@ -186,10 +295,12 @@ button:hover { background: #000; }
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-family: var(--serif);
-  font-size: 1.05rem;
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
-.stage-pct { color: var(--muted); font-family: var(--sans); font-size: 0.9rem; }
+.stage-pct { color: var(--muted); font-family: var(--mono); font-size: 0.82rem; }
 
 .bar { display: block; width: 100%; height: 4px; margin: 0.75rem 0 1rem; }
 .bar-bg { fill: var(--line); }
@@ -291,9 +402,201 @@ footer {
   padding-top: 1rem;
 }
 
+/* ---------- hero cases grid ---------- */
+.hero-cases {
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--line);
+}
+.hero-cases-head { margin-bottom: 1.25rem; }
+.hero-cases-eyebrow {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-bottom: 0.35rem;
+}
+.hero-cases-title {
+  font-family: var(--mono);
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin: 0 0 0.35rem;
+  color: var(--ink);
+}
+.hero-cases-sub {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.case-grid {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.case-card {
+  display: grid;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 1rem 1.15rem 1.15rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink);
+  text-align: left;
+  font-family: var(--sans);
+  font-size: 0.9rem;
+  letter-spacing: normal;
+  text-transform: none;
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.case-card:hover {
+  border-color: var(--ink);
+  transform: translateY(-1px);
+}
+.case-card-slug {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+}
+.case-card-mode {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+}
+.case-card-headline {
+  font-family: var(--serif);
+  font-size: 0.98rem;
+  line-height: 1.4;
+  color: var(--ink);
+  margin-top: 0.25rem;
+}
+.case-card-cta {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+.case-card:hover .case-card-cta { color: var(--ink); }
+
+/* ---------- case body (markdown render target) ---------- */
+.case-body {
+  margin-top: 0.5rem;
+  padding: 1.5rem 1.6rem 2rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+.case-body-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 0.9rem;
+  margin-bottom: 1.2rem;
+  flex-wrap: wrap;
+}
+.case-body-eyebrow {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+.case-body-title {
+  font-family: var(--mono);
+  font-size: 1.15rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0.2rem 0 0;
+  color: var(--ink);
+}
+.case-body-actions { margin-left: auto; }
+
+.case-body-md h1,
+.case-body-md h2,
+.case-body-md h3,
+.case-body-md h4 {
+  font-family: var(--mono);
+  color: var(--ink);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-top: 1.6rem;
+  margin-bottom: 0.5rem;
+}
+.case-body-md h1 { font-size: 1.15rem; }
+.case-body-md h2 { font-size: 1rem; }
+.case-body-md h3 { font-size: 0.9rem; }
+.case-body-md h4 { font-size: 0.82rem; color: var(--muted); }
+.case-body-md p { line-height: 1.6; }
+.case-body-md blockquote {
+  margin: 1rem 0;
+  padding: 0.6rem 1rem;
+  border-left: 3px solid var(--line);
+  color: var(--muted);
+  background: var(--bg);
+  font-family: var(--serif);
+  font-style: italic;
+}
+.case-body-md code {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  background: var(--bg);
+  padding: 0.08rem 0.3rem;
+  border-radius: 2px;
+}
+.case-body-md pre {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+}
+.case-body-md pre code { background: transparent; padding: 0; }
+.case-body-md table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.85rem 0;
+  font-size: 0.88rem;
+}
+.case-body-md th,
+.case-body-md td {
+  border-bottom: 1px solid var(--line);
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+  vertical-align: top;
+}
+.case-body-md th {
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  background: var(--bg);
+}
+
 @media (max-width: 560px) {
   main { padding: 2.5rem 1rem 4rem; }
-  header h1 { font-size: 1.8rem; }
+  header h1 { font-size: 1.5rem; }
+  .upload-row { flex-direction: column; align-items: stretch; }
+  .upload-row button { width: 100%; text-align: center; justify-self: stretch; }
 }
 
 /* ---- Report view (rendered markdown) ---- */

--- a/src/black_box/ui/templates/case_fragment.html
+++ b/src/black_box/ui/templates/case_fragment.html
@@ -1,0 +1,62 @@
+<article
+  class="case-body"
+  id="case-body-{{ slug }}"
+  data-markdown="{{ markdown_source }}"
+  aria-live="polite"
+>
+  <header class="case-body-head">
+    <span class="case-body-eyebrow">case file</span>
+    <h2 class="case-body-title">{{ slug }}</h2>
+    <nav class="case-body-actions">
+      <button
+        type="button"
+        class="btn btn-secondary"
+        hx-get="/"
+        hx-target="#result"
+        hx-swap="innerHTML"
+      >Close</button>
+    </nav>
+  </header>
+  <noscript><pre>{{ markdown_source }}</pre></noscript>
+</article>
+<script>
+  (function () {
+    var el = document.getElementById('case-body-{{ slug }}');
+    if (!el) { return; }
+    var src = el.getAttribute('data-markdown') || '';
+    function render() {
+      window.marked.setOptions({ gfm: true, breaks: false, headerIds: true });
+      var header = el.querySelector('.case-body-head');
+      el.innerHTML = '';
+      if (header) { el.appendChild(header); }
+      var body = document.createElement('div');
+      body.className = 'case-body-md';
+      var rawHtml = window.marked.parse(src);
+      if (window.DOMPurify && typeof window.DOMPurify.sanitize === 'function') {
+        body.innerHTML = window.DOMPurify.sanitize(rawHtml);
+      } else {
+        var pre = document.createElement('pre');
+        pre.textContent = src;
+        body.appendChild(pre);
+      }
+      el.appendChild(body);
+    }
+    function ensureDeps(cb) {
+      function haveMarked() { return window.marked && typeof window.marked.parse === 'function'; }
+      function havePurify() { return window.DOMPurify && typeof window.DOMPurify.sanitize === 'function'; }
+      function loadScript(src, done) {
+        var s = document.createElement('script');
+        s.src = src;
+        s.onload = done;
+        document.head.appendChild(s);
+      }
+      function step2() {
+        if (havePurify()) { cb(); }
+        else { loadScript('https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js', cb); }
+      }
+      if (haveMarked()) { step2(); }
+      else { loadScript('https://cdn.jsdelivr.net/npm/marked/marked.min.js', step2); }
+    }
+    ensureDeps(render);
+  })();
+</script>

--- a/src/black_box/ui/templates/index.html
+++ b/src/black_box/ui/templates/index.html
@@ -6,13 +6,16 @@
   <title>Black Box — forensic copilot for robots</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@400;600&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Serif:wght@400;600&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css" />
   <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
 </head>
 <body>
   <main>
     <header>
+      <p class="kicker">NTSB-style forensic report · built on Opus 4.7</p>
       <h1>Black Box</h1>
       <p class="sub">A forensic copilot for robots.</p>
     </header>
@@ -27,33 +30,142 @@
 
     <form
       class="upload"
+      id="upload-form"
       hx-post="/analyze"
       hx-encoding="multipart/form-data"
       hx-target="#result"
       hx-swap="innerHTML"
     >
-      <label class="field">
-        <span>Recording</span>
-        <input type="file" name="file" accept=".bag,.db3,.mcap,.zip" required />
+      <label class="dropzone" id="dropzone" for="upload-input">
+        <span class="dropzone-eyebrow">evidence upload</span>
+        <span class="dropzone-title">Drop a bag folder, MCAP, or zipped run</span>
+        <span class="dropzone-hint">Click or drag a file here. Accepts .bag, .db3, .mcap, .zip.</span>
+        <span class="dropzone-filename" id="dropzone-filename">no file selected</span>
+        <input
+          type="file"
+          id="upload-input"
+          name="file"
+          accept=".bag,.db3,.mcap,.zip"
+          required
+        />
       </label>
 
-      <label class="field">
-        <span>Mode</span>
-        <select name="mode">
-          <option value="post_mortem">Post-mortem</option>
-          <option value="scenario_mining">Scenario mining</option>
-          <option value="synthetic_qa">Synthetic Q&amp;A</option>
-        </select>
-      </label>
-
-      <button type="submit">Analyze</button>
+      <div class="upload-row">
+        <label class="field">
+          <span>Mode</span>
+          <select name="mode">
+            <option value="post_mortem">Post-mortem</option>
+            <option value="scenario_mining">Scenario mining</option>
+            <option value="synthetic_qa">Synthetic Q&amp;A</option>
+          </select>
+        </label>
+        <button type="submit">Analyze</button>
+      </div>
     </form>
+
+    <section class="hero-cases" aria-label="Hero cases">
+      <div class="hero-cases-head">
+        <span class="hero-cases-eyebrow">hero cases</span>
+        <h2 class="hero-cases-title">Pre-analyzed incidents</h2>
+        <p class="hero-cases-sub">
+          Three reports Black Box already produced on real recordings. Open one
+          to read the full forensic write-up inline.
+        </p>
+      </div>
+      <ul class="case-grid">
+        <li>
+          <button
+            type="button"
+            class="case-card"
+            hx-get="/case/sanfer_tunnel"
+            hx-target="#result"
+            hx-swap="innerHTML"
+            hx-push-url="false"
+          >
+            <span class="case-card-slug">sanfer_tunnel</span>
+            <span class="case-card-mode">post_mortem · 3626 s</span>
+            <span class="case-card-headline">RTCM uplink silently dead; carr_soln never leaves 'none'.</span>
+            <span class="case-card-cta">Read case file</span>
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            class="case-card"
+            hx-get="/case/car_1"
+            hx-target="#result"
+            hx-swap="innerHTML"
+            hx-push-url="false"
+          >
+            <span class="case-card-slug">car_1</span>
+            <span class="case-card-mode">scenario_mining · 970 s</span>
+            <span class="case-card-headline">Ego vehicle stuck ~130 s at a parking-lot barrier; suspected state deadlock.</span>
+            <span class="case-card-cta">Read case file</span>
+          </button>
+        </li>
+        <li>
+          <button
+            type="button"
+            class="case-card"
+            hx-get="/case/boat_lidar"
+            hx-target="#result"
+            hx-swap="innerHTML"
+            hx-push-url="false"
+          >
+            <span class="case-card-slug">boat_lidar</span>
+            <span class="case-card-mode">scenario_mining · 416 s</span>
+            <span class="case-card-headline">LIDAR companion IMU declared but silent the entire USV session.</span>
+            <span class="case-card-cta">Read case file</span>
+          </button>
+        </li>
+      </ul>
+    </section>
 
     <div id="result" aria-live="polite">{% if initial_html %}{{ initial_html | safe }}{% endif %}</div>
 
     <footer>
-      <small>Opus 4.7 &middot; Managed Agents &middot; hackathon build</small>
+      <small>Opus 4.7 · Managed Agents · hackathon build</small>
     </footer>
   </main>
+  <script>
+    (function () {
+      var input = document.getElementById('upload-input');
+      var zone = document.getElementById('dropzone');
+      var nameEl = document.getElementById('dropzone-filename');
+      if (!input || !zone || !nameEl) { return; }
+
+      function setName() {
+        if (input.files && input.files.length > 0) {
+          nameEl.textContent = input.files[0].name;
+          zone.classList.add('has-file');
+        } else {
+          nameEl.textContent = 'no file selected';
+          zone.classList.remove('has-file');
+        }
+      }
+      input.addEventListener('change', setName);
+
+      ['dragenter', 'dragover'].forEach(function (evt) {
+        zone.addEventListener(evt, function (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          zone.classList.add('is-dragging');
+        });
+      });
+      ['dragleave', 'drop'].forEach(function (evt) {
+        zone.addEventListener(evt, function (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          zone.classList.remove('is-dragging');
+        });
+      });
+      zone.addEventListener('drop', function (e) {
+        if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+          input.files = e.dataTransfer.files;
+          setName();
+        }
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/src/black_box/ui/templates/progress.html
+++ b/src/black_box/ui/templates/progress.html
@@ -61,7 +61,7 @@
     <span>job <code>{{ job_id }}</code></span>
     <span>mode {{ status.get('mode', '—') }}</span>
     {% if status.get('has_diff') %}
-      <a class="link-diff" href="/diff/{{ job_id }}" target="_blank" rel="noopener">View proposed fix →</a>
+      <a class="link-diff" href="/diff/{{ job_id }}" target="_blank" rel="noopener">View proposed fix</a>
     {% endif %}
     {% if stage == 'done' %}
       <a class="link-report" href="/report/{{ job_id }}" target="_blank" rel="noopener">View report →</a>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -338,6 +338,75 @@ def test_status_cost_counter_renders_dollar_amount(tmp_path, monkeypatch):
     assert "$2.00" in r2.text
 
 
+def test_index_has_dropzone_and_hero_cards():
+    """Landing page must expose the drop zone UX and all three hero case cards."""
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    # Drop zone surface
+    assert 'id="dropzone"' in r.text
+    assert 'evidence upload' in r.text
+    # Existing upload wiring preserved
+    assert 'hx-post="/analyze"' in r.text
+    assert 'multipart/form-data' in r.text
+    # Three hero cards (one per case)
+    assert 'hx-get="/case/sanfer_tunnel"' in r.text
+    assert 'hx-get="/case/car_1"' in r.text
+    assert 'hx-get="/case/boat_lidar"' in r.text
+    # marked.js script present for inline markdown render
+    assert 'marked.min.js' in r.text
+
+
+def test_index_has_no_gradients():
+    """NTSB aesthetic discipline: no gradient fills in the landing HTML."""
+    client = TestClient(app)
+    r = client.get("/")
+    assert 'linear-gradient' not in r.text
+    assert 'radial-gradient' not in r.text
+
+
+def test_style_css_has_no_gradients():
+    """Static stylesheet must stay gradient-free (NTSB discipline)."""
+    css = (ui_app.BASE_DIR / "static" / "style.css").read_text()
+    assert 'linear-gradient' not in css
+    assert 'radial-gradient' not in css
+
+
+def test_case_route_sanfer():
+    client = TestClient(app)
+    r = client.get("/case/sanfer_tunnel")
+    assert r.status_code == 200
+    assert 'sanfer_tunnel' in r.text
+    # MD contents pass through as a data attribute for marked.js to parse
+    assert 'data-markdown=' in r.text
+    assert 'RTCM' in r.text or 'carr_soln' in r.text
+
+
+def test_case_route_car_1():
+    client = TestClient(app)
+    r = client.get("/case/car_1")
+    assert r.status_code == 200
+    assert 'car_1' in r.text
+    assert 'data-markdown=' in r.text
+
+
+def test_case_route_boat_lidar():
+    client = TestClient(app)
+    r = client.get("/case/boat_lidar")
+    assert r.status_code == 200
+    assert 'boat_lidar' in r.text
+    assert 'data-markdown=' in r.text
+
+
+def test_case_route_unknown_slug_404s():
+    """Slug whitelist must reject arbitrary paths (no file-read primitive)."""
+    client = TestClient(app)
+    r = client.get("/case/../../../etc/passwd")
+    assert r.status_code in (404, 400)
+    r = client.get("/case/not_a_real_case")
+    assert r.status_code == 404
+
+
 def test_analyze_routes_to_real_pipeline_when_enabled(monkeypatch, tmp_path):
     monkeypatch.setattr(ui_app, "UPLOADS_DIR", tmp_path)
     monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)


### PR DESCRIPTION
## Summary

Closes #29 and #30 in one pass.

- **Drop zone** replaces the old bare file input on the landing page. Click-to-browse and drag-and-drop both flow into the same `<input type=file>`, so the existing HTMX `hx-post="/analyze"` multipart form wiring is untouched (covered by the pre-existing UI tests).
- **Three hero case cards** (sanfer_tunnel, car_1, boat_lidar) below the upload form. Each card is an HTMX button that GETs `/case/{slug}` and swaps a rendered MD fragment into `#result`. Reuses marked.js (loaded once on index) to parse the Markdown client-side.
- **NTSB aesthetic pass:** IBM Plex Mono is now the primary header face (landing header, hero-card slugs, dropzone titles, progress-head, form labels, buttons). Palette tokens (`#fffdf8`, `#f6f4ef`, `#1c1c1a`, `#6b6b66`, `#d9d6cc`) unchanged. No gradients, no emojis, no SaaS ornamentation.

## Issue #29 — Landing Page acceptance

- [x] Drop zone for bag / MCAP / zipped-run upload (click or drag).
- [x] Three hero case cards linking to `demo_assets/pdfs/sanfer_tunnel.md`, `demo_assets/pdfs/car_1.md`, `demo_assets/pdfs/boat_lidar.md`.
- [x] MD renders inline on card click via HTMX swap into `#result`; marked.js parses the embedded Markdown client-side.
- [x] All three source MD files already exist on disk (no invented content).

## Issue #30 — NTSB aesthetic acceptance

- [x] Monospace headers: landing h1, hero-cases-title, case-body-title, progress-head, dropzone-title, and section eyebrows all use `var(--mono)` (IBM Plex Mono).
- [x] Muted palette preserved: `--bg: #f6f4ef`, `--surface: #fffdf8`, `--ink: #1c1c1a`, `--muted: #6b6b66`, `--line: #d9d6cc`.
- [x] Zero gradients: `grep linear-gradient src/black_box/ui` and `grep radial-gradient src/black_box/ui` return no hits. Guarded by `test_style_css_has_no_gradients` and `test_index_has_no_gradients`.
- [x] Zero emojis in UI surfaces. The stray `→` glyph on the progress card's "View proposed fix" link was removed. `⏎` is kept inside the reasoning-buffer formatter only (it is a `Return` control glyph, not an emoji, and an existing UI test pins that behavior).

## Files

- `src/black_box/ui/templates/index.html` — rewrites the landing shell: dropzone UX, hero card grid, marked.js include, vanilla-JS DnD handler. Upload form preserved.
- `src/black_box/ui/templates/case_fragment.html` — new HTMX fragment; embeds MD as `data-markdown` and renders with marked.js.
- `src/black_box/ui/templates/progress.html` — drops the stray arrow glyph.
- `src/black_box/ui/app.py` — adds `GET /case/{slug}` with a whitelisted slug map (`sanfer_tunnel`, `car_1`, `boat_lidar`) so the route is not an arbitrary-file-read primitive.
- `src/black_box/ui/static/style.css` — monospace tokens, dropzone, hero cards, case body, progress-head font swap. No gradients introduced.
- `tests/test_ui.py` — 7 new tests: dropzone + three hero cards on `/`, gradient-free guards on HTML and CSS, per-slug render for each of the three hero cases, 404 guard for unknown / path-traversal slugs.

## Test plan

- [x] `PYTHONPATH=src pytest -q` -> **176 passed, 1 warning** (all pre-existing UI tests stay green; 21/21 in `tests/test_ui.py`).
- [x] Manual: `GET /` shows the drop zone, three cards, and preserves the analyze button; `GET /case/sanfer_tunnel` returns the inline fragment with the raw MD present in `data-markdown`; `GET /case/unknown` -> 404.
- [ ] Optional local check: `uvicorn black_box.ui.app:app --reload`, drop a bag onto the zone, click through each hero card.

Branched off master. No deps added.