### PR TITLE
fix(analysis): purge legacy thinking-budget payload (closes #59)

### DIFF
--- a/tests/test_claude_payload.py
+++ b/tests/test_claude_payload.py
@@ -1,0 +1,123 @@
+"""Regression: Opus 4.7 request payload must not carry legacy extended-thinking keys.
+
+Opus 4.7 rejects `thinking={"type": "enabled", "budget_tokens": N}` with HTTP 400.
+Adaptive Thinking is native and takes no client-side parameter. These tests lock that
+invariant at both the call-site level (mocked Anthropic client) and the source level
+(static sweep of `src/`).
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from black_box.analysis import ClaudeClient
+from black_box.analysis.prompts import post_mortem_prompt
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src"
+
+
+def _make_mock_response() -> MagicMock:
+    usage = MagicMock()
+    usage.input_tokens = 10
+    usage.cache_read_input_tokens = 0
+    usage.cache_creation_input_tokens = 0
+    usage.output_tokens = 5
+
+    content = MagicMock()
+    content.text = (
+        '{"timeline": [], "hypotheses": [], '
+        '"root_cause_idx": 0, "patch_proposal": ""}'
+    )
+
+    response = MagicMock()
+    response.content = [content]
+    response.usage = usage
+    return response
+
+
+class TestClaudePayloadNoThinkingKey:
+    """The real payload constructed by ClaudeClient.analyze must omit `thinking`."""
+
+    def test_messages_create_kwargs_omit_thinking_and_budget(self):
+        with patch("black_box.analysis.claude_client.Anthropic") as mock_anthropic:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                mock_client = MagicMock()
+                mock_anthropic.return_value = mock_client
+                mock_client.messages.create.return_value = _make_mock_response()
+
+                with patch.object(
+                    ClaudeClient, "_find_repo_root", return_value=Path(tmpdir)
+                ):
+                    client = ClaudeClient()
+                    spec = post_mortem_prompt()
+                    spec["name"] = "regression_payload"
+                    client.analyze(
+                        spec,
+                        user_fields={
+                            "bag_summary": "",
+                            "synced_frames_description": "",
+                            "code_snippets": "",
+                        },
+                        apply_grounding=False,
+                    )
+
+                assert mock_client.messages.create.called, (
+                    "expected analyze() to invoke messages.create"
+                )
+
+                for call in mock_client.messages.create.call_args_list:
+                    kwargs = call.kwargs
+                    assert "thinking" not in kwargs, (
+                        "legacy extended-thinking key `thinking` must not be sent "
+                        "to Opus 4.7 (HTTP 400 trigger)"
+                    )
+                    assert "extended_thinking" not in kwargs
+                    assert "budget_tokens" not in kwargs
+                    for v in kwargs.values():
+                        if isinstance(v, dict):
+                            assert "budget_tokens" not in v
+                            assert "thinking" not in v
+
+    def test_model_is_opus_4_7(self):
+        """Defense in depth: make sure we are actually targeting Opus 4.7."""
+        with patch("black_box.analysis.claude_client.Anthropic"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with patch.object(
+                    ClaudeClient, "_find_repo_root", return_value=Path(tmpdir)
+                ):
+                    client = ClaudeClient()
+                    assert client.model == "claude-opus-4-7"
+
+
+class TestSourceTreeNoLegacyThinking:
+    """Static sweep: no legacy extended-thinking keys anywhere under src/.
+
+    Benign matches (e.g. the `agent.thinking` Managed Agents event-type string,
+    and UI placeholder text) are not parameter payloads, so we only forbid the
+    legacy *parameter* patterns.
+    """
+
+    LEGACY_PARAM_PATTERNS = [
+        re.compile(r"\bbudget_tokens\b"),
+        re.compile(r"\bextended_thinking\b"),
+        re.compile(r"thinking\s*=\s*\{[^}]*(enabled|budget_tokens)"),
+        re.compile(r"[\"']thinking[\"']\s*:\s*\{[^}]*(enabled|budget_tokens)"),
+    ]
+
+    def test_src_tree_has_no_legacy_thinking_payload(self):
+        offenders: list[tuple[str, int, str]] = []
+        for path in SRC_DIR.rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                for pat in self.LEGACY_PARAM_PATTERNS:
+                    if pat.search(line):
+                        offenders.append((str(path), lineno, line.strip()))
+        assert not offenders, (
+            "legacy extended-thinking payload found under src/:\n"
+            + "\n".join(f"  {p}:{ln}: {src}" for p, ln, src in offenders)
+        )


### PR DESCRIPTION
## Summary
- Repo sweep confirmed zero call-sites under `src/` or `scripts/` pass the legacy `thinking={"type": "enabled", "budget_tokens": N}` payload (Opus 4.7 HTTP 400 trigger). `ClaudeClient.messages.create` already calls with only `model`, `max_tokens`, `system`, `messages`.
- Added `tests/test_claude_payload.py` to lock the invariant:
  - Mocks `Anthropic`, runs `ClaudeClient.analyze`, asserts `thinking`, `extended_thinking`, and `budget_tokens` are absent from every `messages.create` kwargs dict (top-level and one-level nested).
  - Static sweep of `src/**/*.py` for the legacy parameter patterns (`budget_tokens`, `extended_thinking`, `thinking={...enabled|budget_tokens...}`). Benign matches (the `agent.thinking` Managed Agents event-type string and UI placeholder text) are intentionally not flagged.

## Acceptance
- [x] Zero matches for `budget_tokens` under `src/`.
- [x] Zero matches for `thinking.*enabled` under `src/`.
- [x] Regression test added under `tests/test_claude_payload.py`.
- [ ] Live smoke call to the API returns HTTP 200 — **pending manual run** (cost-gated; mocked client covers the payload-shape regression).

## Test plan
- [x] `pytest tests/test_claude_payload.py -v` → 3 passed
- [ ] Manual: one live `ClaudeClient.analyze` call on a small fixture, confirm HTTP 200 and append trimmed log to `data/costs.jsonl`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>