### PR TITLE
chore(github): issue & PR templates + CLAUDE.md link in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Report a defect in Black Box (ingestion, analysis, grounding gate, UI, eval, reporting)
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Summary
+One sentence describing the defect.
+
+## Environment
+- Black Box commit / branch:
+- Python version:
+- OS:
+- Mode (forensic / scenario mining / synthetic QA):
+- Platform adapter (nao6 / other):
+
+## Reproduce
+Steps to reproduce the behavior. Include the exact command(s) run.
+
+```bash
+# paste command(s) here
+```
+
+## Expected vs actual
+**Expected:**
+
+**Actual:**
+
+## Session / bag identifiers
+Give enough for a maintainer to re-run or triage.
+
+- Session folder or case key:
+- Bag file(s) (numeric prefix + name, for example `2_camera_front.bag`):
+- Recording timestamp / duration:
+- Public-data case id (if from `black-box-bench/`):
+
+## Cost log excerpt
+Paste the relevant lines from `data/costs.jsonl` (cached_input_tokens, uncached_input_tokens, output_tokens, USD). This is critical for reproducing token-budget regressions.
+
+```jsonl
+# paste cost-log lines here
+```
+
+## Evidence / artifacts
+Attach or link: screenshots of UI, PDF report, grounding-gate verdict, diff HTML, telemetry plot PNGs, tracebacks.
+
+## Additional context
+Anything else the maintainer should know (recent changes, related issues, suspected area of code).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/LucasErcolano/BlackBox/discussions
+    about: Ask questions, share ideas, or talk about the project with the community.
+  - name: Project rules (CLAUDE.md)
+    url: https://github.com/LucasErcolano/BlackBox/blob/master/CLAUDE.md
+    about: Read the hackathon hard rules and project shape before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature request
+about: Propose a new capability or enhancement for Black Box
+title: "[FEAT] "
+labels: enhancement
+assignees: ''
+---
+
+## Motivation
+What problem does this solve? Who is the user (operator, evaluator, judge, bench contributor)? Why now?
+
+## Proposal
+One paragraph of the happy-path behavior. Be concrete about inputs and outputs.
+
+## Scope
+- In scope:
+- Out of scope:
+- Affected modules (`ingestion/`, `analysis/`, `synthesis/`, `reporting/`, `ui/`, `eval/`, `memory/`, `platforms/`):
+
+## Hackathon hard rules (must not violate)
+Confirm this proposal respects the project's non-negotiable constraints from `CLAUDE.md`. Check each box.
+
+- [ ] No ROS 2 runtime. `rosbags` lib only.
+- [ ] No RAG, no vector DBs, no LangChain / AutoGen / LlamaIndex. Flat code.
+- [ ] No training. Inference-only over Opus 4.7 (`claude-opus-4-7`).
+- [ ] No ComfyUI / Wan 2.2 / Nano Banana runtime install. Synthesis emits text prompts only.
+- [ ] No architectural rewrites in patches. Scoped fixes only (clamp / timeout / null check / gain adjust).
+- [ ] Respects the closed 7-class bug taxonomy for benchmark scoring.
+
+If any box is unchecked, explain why the exception is justified.
+
+## Token / cost impact
+Does this add Claude calls, frames, or cached prompt segments? Estimate delta in `data/costs.jsonl` per case.
+
+## Alternatives considered
+Brief. Why this over the simpler option.
+
+## Acceptance criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Tests added or updated
+- [ ] Docs / README updated if user-visible
+
+## Additional context
+Links to related issues, prior art, or research.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for contributing to Black Box. Please read CLAUDE.md before opening.
+Keep the description terse. No preamble.
+-->
+
+## Summary
+One paragraph on what changed and why.
+
+Closes #
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Docs
+- [ ] CI / infra
+- [ ] Benchmark / eval
+
+## Checklist
+- [ ] Tests added or updated (unit / eval / smoke).
+- [ ] `data/costs.jsonl` impact noted below (token / USD delta, or "none").
+- [ ] Bug taxonomy unchanged (the closed 7-class set in `CLAUDE.md` is not modified).
+- [ ] No new heavy deps (no ROS 2 runtime, no LangChain / AutoGen / LlamaIndex, no vector DB, no ComfyUI / Wan / Nano Banana runtime, no training frameworks).
+- [ ] Grounding gate thresholds (`GroundingThresholds`) not silently relaxed.
+- [ ] Model still `claude-opus-4-7`. No silent downgrade.
+- [ ] Docs / README updated if user-visible behavior changed.
+
+## Cost impact
+Expected delta on `data/costs.jsonl` per case:
+
+- cached_input_tokens: 
+- uncached_input_tokens: 
+- output_tokens: 
+- USD per case: 
+
+If the change adds Claude calls or frames, justify the budget.
+
+## Testing
+How this was verified. Commands, smoke scripts, bench cases, UI paths touched.
+
+```bash
+# paste commands and key output here
+```
+
+## Screenshots / artifacts
+Attach PDF report snippet, diff HTML, UI screenshots, or grounding-gate verdicts if UI-facing or report-facing.
+
+## Reviewer notes
+Anything the reviewer should look at first. Known follow-ups.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Forensic copilot for robots. Feed it a robot recording, get back a root-cause hy
 Built with **Claude Opus 4.7** (vision + reasoning) + **Managed Agents** (long-horizon session replay).
 
 ## Docs
+- [Project rules (`CLAUDE.md`)](CLAUDE.md) — hackathon hard rules, project shape, token discipline. Read this first.
 - [Build journal & strategy](https://gist.github.com/LucasErcolano/851c5e976c6aa364f69c9e6875544061) — narrative, novelty positioning, findings.
 - [Team onboarding](docs/ONBOARDING.md) — scope, cadence, conventions.
 - [Pitch](docs/PITCH.md) — one-liner, elevator, positioning one-liners.


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/{bug_report.md,feature_request.md,config.yml}` and `.github/PULL_REQUEST_TEMPLATE.md` so the repo reads as maintained and external contributors have a funnel.
- Links `CLAUDE.md` from the top of the README Docs section so judges and contributors see the hackathon hard rules (no ROS 2, no RAG, no training) before they file anything.
- `CLAUDE.md` stays at repo root. The CI workflow from PR #45 is not touched.

Closes #64.

## What's in each file
- `bug_report.md` — repro steps, expected vs actual, session / bag id, cost-log excerpt from `data/costs.jsonl`.
- `feature_request.md` — motivation, scope, and a hard-rules checklist mirroring `CLAUDE.md` (no ROS 2 runtime, no RAG / LangChain / vector DB, no training, no ComfyUI / Wan / Nano Banana runtime, scoped-patch shapes only, closed 7-class taxonomy).
- `config.yml` — blank issues disabled, contact links to Discussions and to `CLAUDE.md`.
- `PULL_REQUEST_TEMPLATE.md` — checklist: tests updated, `costs.jsonl` impact, taxonomy unchanged, no new heavy deps, grounding-gate thresholds not silently relaxed, model stays `claude-opus-4-7`.

## Test plan
- [ ] New-issue UI at https://github.com/LucasErcolano/BlackBox/issues/new/choose renders Bug report and Feature request, no blank option.
- [ ] Opening a new PR auto-populates the checklist template.
- [ ] README Docs section links `CLAUDE.md` as the first bullet.
- [ ] `CLAUDE.md` remains at repo root.
- [ ] `.github/workflows/ci.yml` unchanged.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>