### PR TITLE
feat(schemas): freeze bug taxonomy at exactly 7 Literal entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,14 +157,29 @@ classDiagram
     synthesis ..> ingestion : replays as recording
 ```
 
-## Bug taxonomy — closed-set benchmark, open-world product
+## Bug taxonomy — closed set of 7 (frozen)
 
-The benchmark scorer requires an **exact-match label** from a closed set of seven common failure modes. That closed set exists for *measurement*, not for *expression* — the product surface accepts any label the model produces and routes unknown labels to a neutral `other` bucket that still carries evidence and a scoped patch.
+The taxonomy is **frozen at exactly 7 labels**. Schema enforcement lives in
+`src/black_box/analysis/schemas.py` as a Pydantic `Literal`; anything outside
+the set raises `ValidationError` at parse time — no silent coercion, no
+catch-all bucket. This block is the source of truth; CLAUDE.md, the cached
+prompt block in `src/black_box/analysis/prompts.py`, and the benchmark scorer
+all mirror these exact strings verbatim.
+
+```
+pid_saturation
+sensor_timeout
+state_machine_deadlock
+bad_gain_tuning
+missing_null_check
+calibration_drift
+latency_spike
+```
 
 ```mermaid
 classDiagram
     class BugClass {
-        <<closed benchmark set>>
+        <<closed set, exactly 7>>
         pid_saturation
         sensor_timeout
         state_machine_deadlock
@@ -172,7 +187,6 @@ classDiagram
         missing_null_check
         calibration_drift
         latency_spike
-        other
     }
     class Patch {
         <<scoped fix shape>>
@@ -182,7 +196,7 @@ classDiagram
         gain_adjust
     }
     class Hypothesis {
-        +bug_class: BugClass or str
+        +bug_class: BugClass
         +summary: str
         +evidence_refs: list
         +confidence: 0..1
@@ -191,8 +205,9 @@ classDiagram
     BugClass ..> Patch : shapes the patch kind
 ```
 
-- **For the benchmark:** closed 7-class set. A hypothesis scores iff `predicted == ground_truth`.
-- **For production traffic:** open-world labels allowed. `other` is a first-class bucket — the model still has to justify the claim with telemetry + frames, and the patch shape still has to be one of the scoped primitives (clamp / timeout / null check / gain adjust). New failure modes that recur get promoted into the taxonomy via the memory stack, not by changing the prompt.
+- A hypothesis scores iff `predicted == ground_truth` against one of the 7 labels.
+- Patch shape stays one of the scoped primitives (clamp / timeout / null check / gain adjust).
+- New failure modes get promoted into the taxonomy via a deliberate schema bump (updating this block, the `Literal`, the cached prompt, and the scorer in the same PR), not by the model inventing a label at runtime.
 
 ## Memory stack — substrate today, self-improving loop on the roadmap
 

--- a/demo_assets/grounding_gate/clean_recording/README.md
+++ b/demo_assets/grounding_gate/clean_recording/README.md
@@ -18,7 +18,7 @@ nothing than ship a fabrication.
 |--:|-----------|-----:|---------:|--------|
 | 0 | `pid_saturation` | 0.72 | 1 | dropped — only 1 evidence row(s) (need >= 2) |
 | 1 | `calibration_drift` | 0.60 | 2 | dropped — only 1 source (camera) — need >= 2 |
-| 2 | `other` | 0.55 | 2 | dropped — bug_class=other with 2 evidence rows (need >= 3) |
+| 2 | `bad_gain_tuning` | 0.55 | 2 | dropped — only 1 source (telemetry) — need >= 2 |
 | 3 | `latency_spike` | 0.22 | 2 | dropped — confidence 0.22 < 0.4 |
 
 **Gated output** — `patch_proposal`: _No anomaly detected with sufficient evidence to support a scoped fix._
@@ -28,7 +28,6 @@ nothing than ship a fabrication.
 
 - min confidence: `0.4`
 - min evidence rows / hypothesis: `2`
-- min evidence rows for `other`: `3`
 - min distinct evidence sources: `min(2, available_sources)`
 - info-severity moments dropped by default
 

--- a/demo_assets/grounding_gate/clean_recording/drop_reasons.json
+++ b/demo_assets/grounding_gate/clean_recording/drop_reasons.json
@@ -10,9 +10,9 @@
     "reason_dropped": "only 1 source (camera) \u2014 need >= 2"
   },
   {
-    "bug_class": "other",
+    "bug_class": "bad_gain_tuning",
     "confidence": 0.55,
-    "reason_dropped": "bug_class=other with 2 evidence rows (need >= 3)"
+    "reason_dropped": "only 1 source (telemetry) \u2014 need >= 2"
   },
   {
     "bug_class": "latency_spike",

--- a/demo_assets/grounding_gate/clean_recording/raw_hypotheses.json
+++ b/demo_assets/grounding_gate/clean_recording/raw_hypotheses.json
@@ -47,7 +47,7 @@
       "patch_hint": "recalibrate cam2 extrinsics"
     },
     {
-      "bug_class": "other",
+      "bug_class": "bad_gain_tuning",
       "confidence": 0.55,
       "summary": "Ambient vibration signature looks a little noisy",
       "evidence": [
@@ -58,13 +58,13 @@
           "snippet": "accel RMS 0.4 m/s^2"
         },
         {
-          "source": "timeline",
-          "topic_or_file": "derived",
-          "t_ns": 45000000000,
-          "snippet": "no correlated control event"
+          "source": "telemetry",
+          "topic_or_file": "/imu",
+          "t_ns": 46000000000,
+          "snippet": "accel RMS 0.41 m/s^2"
         }
       ],
-      "patch_hint": "add vibration damper"
+      "patch_hint": "retune control gains for vibration band"
     },
     {
       "bug_class": "latency_spike",

--- a/scripts/build_grounding_gate_demo.py
+++ b/scripts/build_grounding_gate_demo.py
@@ -40,7 +40,7 @@ def _raw_report() -> PostMortemReport:
     Each hypothesis is crafted to fail one specific gate rule:
       #0 high-conf but ONLY ONE evidence row            (< 2 evidence)
       #1 two evidence rows but both from same source    (< 2 distinct sources)
-      #2 'other' with low evidence count                (< 3 for 'other')
+      #2 two telemetry-only rows — fails cross-source   (< 2 distinct sources)
       #3 two evidence rows but confidence below floor   (< 0.4 confidence)
 
     No hypothesis passes — gate returns the no-anomaly payload.
@@ -86,7 +86,7 @@ def _raw_report() -> PostMortemReport:
                 patch_hint="recalibrate cam2 extrinsics",
             ),
             Hypothesis(
-                bug_class="other",
+                bug_class="bad_gain_tuning",
                 confidence=0.55,
                 summary="Ambient vibration signature looks a little noisy",
                 evidence=[
@@ -97,13 +97,13 @@ def _raw_report() -> PostMortemReport:
                         snippet="accel RMS 0.4 m/s^2",
                     ),
                     Evidence(
-                        source="timeline",
-                        topic_or_file="derived",
-                        t_ns=45_000_000_000,
-                        snippet="no correlated control event",
+                        source="telemetry",
+                        topic_or_file="/imu",
+                        t_ns=46_000_000_000,
+                        snippet="accel RMS 0.41 m/s^2",
                     ),
                 ],
-                patch_hint="add vibration damper",
+                patch_hint="retune control gains for vibration band",
             ),
             Hypothesis(
                 bug_class="latency_spike",
@@ -136,8 +136,6 @@ def _reason_dropped(h: Hypothesis, t: GroundingThresholds, available_sources: in
         return f"confidence {h.confidence:.2f} < {t.min_confidence}"
     if len(h.evidence) < t.min_evidence_per_hypothesis:
         return f"only {len(h.evidence)} evidence row(s) (need >= {t.min_evidence_per_hypothesis})"
-    if h.bug_class == "other" and len(h.evidence) < t.min_evidence_for_other:
-        return f"bug_class=other with {len(h.evidence)} evidence rows (need >= {t.min_evidence_for_other})"
     required = min(t.min_cross_source_evidence, available_sources)
     distinct = {e.source for e in h.evidence}
     if len(distinct) < required:
@@ -220,7 +218,6 @@ def _render_readme(
         "",
         f"- min confidence: `{t.min_confidence}`",
         f"- min evidence rows / hypothesis: `{t.min_evidence_per_hypothesis}`",
-        f"- min evidence rows for `other`: `{t.min_evidence_for_other}`",
         f"- min distinct evidence sources: "
         f"`min({t.min_cross_source_evidence}, available_sources)`",
         "- info-severity moments dropped by default",

--- a/src/black_box/analysis/prompts.py
+++ b/src/black_box/analysis/prompts.py
@@ -11,7 +11,7 @@ SYSTEM_PROMPT = """You are a forensic analyst for robotic systems. Your role is 
 
 Always respond with JSON only. No preamble, no markdown fencing.
 
-Bug taxonomy (see detailed documentation below):
+Bug taxonomy (closed set of exactly 7 — no other labels are permitted):
 - pid_saturation: PID controller integral term grows unbounded
 - sensor_timeout: Expected sensor reading never arrives
 - state_machine_deadlock: FSM enters unrecoverable state
@@ -19,7 +19,10 @@ Bug taxonomy (see detailed documentation below):
 - missing_null_check: Null/invalid sensor value crashes or corrupts state
 - calibration_drift: Sensor readings drift over time
 - latency_spike: Unexpected delay in loop execution
-- other: Anomaly not matching above taxonomy
+
+If nothing in the evidence matches one of the 7 labels, emit an empty
+hypothesis list. Never invent a label; never coerce to a catch-all. The
+Pydantic validator downstream will reject any label outside this set.
 
 Reasoning rules:
 1. Cross-reference evidence across camera, telemetry, code, and timeline sources
@@ -68,8 +71,13 @@ BUG_TAXONOMY_DOC = """
 **Video**: Brief stall or delayed response.
 **Code signature**: Unprotected I/O, memory allocation, or GC pause in real-time loop.
 
-### other
-Anomaly that does not fit above categories. Describe it clearly.
+### Closed-set rule
+The taxonomy is frozen at exactly these 7 labels:
+`pid_saturation`, `sensor_timeout`, `state_machine_deadlock`, `bad_gain_tuning`,
+`missing_null_check`, `calibration_drift`, `latency_spike`.
+Any other label is a schema violation — the response will be rejected by
+the Pydantic validator downstream. Return an empty hypothesis list rather
+than a label outside the set.
 """
 
 
@@ -214,7 +222,7 @@ def synthetic_qa_prompt():
             "{{\n"
             '  "hypotheses": [\n'
             "    {{\n"
-            '      "bug_class": "<one of: pid_saturation|sensor_timeout|state_machine_deadlock|bad_gain_tuning|missing_null_check|calibration_drift|latency_spike|other>",\n'
+            '      "bug_class": "<exactly one of: pid_saturation|sensor_timeout|state_machine_deadlock|bad_gain_tuning|missing_null_check|calibration_drift|latency_spike>",\n'
             '      "confidence": <float 0..1>,\n'
             '      "summary": "<short>",\n'
             '      "evidence": [ {{"source": "telemetry|camera|code|timeline", "topic_or_file": "<str>", "t_ns": <int or null>, "snippet": "<str>"}} ],\n'

--- a/src/black_box/analysis/schemas.py
+++ b/src/black_box/analysis/schemas.py
@@ -12,22 +12,28 @@ class Evidence(BaseModel):
     snippet: str  # short human-readable
 
 
+# Frozen closed-set bug taxonomy. Source of truth: CLAUDE.md + root README.
+# Exactly 7 entries. Do NOT add, remove, or rename without updating
+# CLAUDE.md, README.md, and src/black_box/analysis/prompts.py in the same PR.
+BugClass = Literal[
+    "pid_saturation",
+    "sensor_timeout",
+    "state_machine_deadlock",
+    "bad_gain_tuning",
+    "missing_null_check",
+    "calibration_drift",
+    "latency_spike",
+]
+
+
 class Hypothesis(BaseModel):
-    """Single bug hypothesis with confidence and supporting evidence."""
-    bug_class: Literal[
-        "pid_saturation",
-        "sensor_timeout",
-        "state_machine_deadlock",
-        "bad_gain_tuning",
-        "missing_null_check",
-        "calibration_drift",
-        "latency_spike",
-        "sensor_dropout",
-        "config_error",
-        "degraded_state_estimation",
-        "communication_failure",
-        "other",
-    ]
+    """Single bug hypothesis with confidence and supporting evidence.
+
+    ``bug_class`` is a closed Literal of exactly 7 entries. Any value outside
+    the set raises ``pydantic.ValidationError`` at parse time — no silent
+    coercion, no fallback bucket. See ``BugClass`` above.
+    """
+    bug_class: BugClass
     confidence: float  # 0..1
     summary: str
     evidence: list[Evidence]

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -80,20 +80,6 @@ def test_single_evidence_rejected():
     assert out.patch_proposal == NO_ANOMALY_PATCH
 
 
-def test_other_bug_class_requires_three_evidence():
-    h_two = _hyp(bug_class="other", evidence=[_ev("telemetry"), _ev("code")])
-    out = ground_post_mortem(_report([h_two]))
-    assert out.hypotheses == []
-    assert out.patch_proposal == NO_ANOMALY_PATCH
-
-    h_three = _hyp(
-        bug_class="other",
-        evidence=[_ev("telemetry"), _ev("code"), _ev("camera")],
-    )
-    out_ok = ground_post_mortem(_report([h_three]))
-    assert len(out_ok.hypotheses) == 1
-
-
 def test_same_source_rejected_when_multi_source_available_in_report():
     """If the report surfaces >1 distinct evidence source, a hypothesis that cites only one is rejected."""
     single_src = _hyp(
@@ -121,7 +107,7 @@ def test_all_rejected_yields_no_anomaly_shell():
     hs = [
         _hyp(confidence=0.2),
         _hyp(evidence=[_ev("telemetry")]),
-        _hyp(bug_class="other", evidence=[_ev("telemetry"), _ev("code")]),
+        _hyp(confidence=0.1, evidence=[_ev("telemetry"), _ev("code")]),
     ]
     out = ground_post_mortem(_report(hs, root_cause_idx=2))
     assert out.hypotheses == []

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,117 @@
+"""Closed-set bug taxonomy enforcement tests.
+
+The taxonomy is frozen at exactly 7 entries (see CLAUDE.md, README.md,
+`src/black_box/analysis/schemas.py`, and the cached block in
+`src/black_box/analysis/prompts.py`). These tests guard against silent drift
+between the narrative contract and the Pydantic schema.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+from pydantic import ValidationError
+
+from black_box.analysis.prompts import BUG_TAXONOMY_DOC, post_mortem_prompt
+from black_box.analysis.schemas import BugClass, Evidence, Hypothesis
+
+
+CANONICAL_TAXONOMY: tuple[str, ...] = (
+    "pid_saturation",
+    "sensor_timeout",
+    "state_machine_deadlock",
+    "bad_gain_tuning",
+    "missing_null_check",
+    "calibration_drift",
+    "latency_spike",
+)
+
+
+def _valid_evidence() -> list[Evidence]:
+    return [
+        Evidence(source="telemetry", topic_or_file="/imu", t_ns=1, snippet="e1"),
+        Evidence(source="code", topic_or_file="pid.py:42", t_ns=None, snippet="e2"),
+    ]
+
+
+def test_bug_class_literal_has_exactly_seven_entries():
+    """The `BugClass` alias is a `Literal` of precisely 7 strings — no more, no less."""
+    args = typing.get_args(BugClass)
+    assert len(args) == 7, f"BugClass must have 7 entries, got {len(args)}: {args}"
+    assert set(args) == set(CANONICAL_TAXONOMY)
+
+
+def test_bug_class_literal_order_matches_canonical():
+    """Order is part of the contract so diffs against CLAUDE.md and README stay obvious."""
+    args = typing.get_args(BugClass)
+    assert tuple(args) == CANONICAL_TAXONOMY
+
+
+@pytest.mark.parametrize("canonical", CANONICAL_TAXONOMY)
+def test_each_canonical_label_accepted(canonical: str):
+    h = Hypothesis(
+        bug_class=canonical,  # type: ignore[arg-type]
+        confidence=0.9,
+        summary="s",
+        evidence=_valid_evidence(),
+        patch_hint="clamp",
+    )
+    assert h.bug_class == canonical
+
+
+@pytest.mark.parametrize(
+    "bad_label",
+    [
+        "other",                      # previously-accepted escape hatch — now rejected
+        "sensor_dropout",             # previously-accepted synonym — now rejected
+        "config_error",               # previously-accepted broad bucket — now rejected
+        "degraded_state_estimation",  # previously-accepted alias — now rejected
+        "communication_failure",      # previously-accepted alias — now rejected
+        "PID_SATURATION",             # wrong case
+        "pid saturation",             # wrong separator
+        "",                           # empty
+        "made_up_bug",                # hallucinated class
+        None,                         # wrong type
+        42,                           # wrong type
+    ],
+)
+def test_non_canonical_label_raises_validation_error(bad_label):
+    """Any value outside the closed 7-set must raise ValidationError — no silent coercion."""
+    with pytest.raises(ValidationError) as exc:
+        Hypothesis(
+            bug_class=bad_label,  # type: ignore[arg-type]
+            confidence=0.9,
+            summary="s",
+            evidence=_valid_evidence(),
+            patch_hint="clamp",
+        )
+    # Pydantic's literal_error message should name the field so operators
+    # can diagnose drift without reading the traceback.
+    assert "bug_class" in str(exc.value)
+
+
+def test_prompt_taxonomy_block_mentions_all_seven_labels_verbatim():
+    """Prompt cache block must spell the 7 labels verbatim (contract alignment)."""
+    for label in CANONICAL_TAXONOMY:
+        assert label in BUG_TAXONOMY_DOC, f"prompt cache missing label: {label}"
+
+
+def test_prompt_taxonomy_block_does_not_list_removed_catchall():
+    """`other` is gone from the prompt — the model must not be told it is a valid label."""
+    # The word "other" is a common English word, so we match the shape we
+    # actually cared about: `### other` header or `- other:` bullet.
+    assert "### other" not in BUG_TAXONOMY_DOC
+    assert "- other:" not in BUG_TAXONOMY_DOC
+
+
+def test_prompt_taxonomy_block_is_cached():
+    """Closed-set taxonomy must travel as a `cache_control` block in every mode."""
+    spec = post_mortem_prompt()
+    cached_texts = [b["text"] for b in spec["cached_blocks"] if "cache_control" in b]
+    # At least one cached block contains the taxonomy doc verbatim.
+    assert any(BUG_TAXONOMY_DOC == t or BUG_TAXONOMY_DOC in t for t in cached_texts)
+    # And the cache_control is ephemeral, matching the rest of the prompt layer.
+    taxonomy_blocks = [b for b in spec["cached_blocks"] if b["text"] == BUG_TAXONOMY_DOC]
+    assert taxonomy_blocks, "BUG_TAXONOMY_DOC is not referenced by post_mortem_prompt"
+    assert taxonomy_blocks[0]["cache_control"]["type"] == "ephemeral"


### PR DESCRIPTION
closes #62

## Summary

Freezes the bug taxonomy to the canonical 7-entry closed set so the
narrative contract (CLAUDE.md, README) can no longer drift from the
technical contract (Pydantic schema + cached prompt).

- `Hypothesis.bug_class` is now a `Literal` of exactly 7 entries, aliased as `BugClass`.
- Previously-accepted labels (`other`, `sensor_dropout`, `config_error`, `degraded_state_estimation`, `communication_failure`) are rejected with `ValidationError`.
- Prompt cache block spells the 7 labels verbatim under `cache_control: ephemeral` and instructs the model to emit an empty hypothesis list rather than invent a label.
- README has a new "Bug taxonomy — closed set of 7 (frozen)" section with a fenced code block matching the `Literal` byte-for-byte.

## Acceptance (from issue body)

- [x] Taxonomy is a `Literal` in `schemas.py` (7 entries, no more, no less).
- [x] README list matches `Literal` verbatim (fenced code block).
- [x] Prompt template references the same strings, cached under `cache_control`.
- [x] Negative test green (`tests/test_taxonomy.py`).

## Collateral

- `scripts/build_grounding_gate_demo.py` — hypothesis previously keyed to the `other` grounding rule now fails cross-source instead; regenerated `demo_assets/grounding_gate/clean_recording/` artifacts.
- `tests/test_grounding.py` — removed the now-unreachable `other`-branch test and swapped the same-named fixture in `test_all_rejected_yields_no_anomaly_shell` to a low-confidence hypothesis of a valid class.

## Test plan

- [x] `pytest -q` — all 191 tests pass locally.
- [x] `python scripts/build_grounding_gate_demo.py` — regenerates cleanly.
- [ ] CI: GitHub Actions runs full suite on push.

Dead `"other"` branches remain in `src/black_box/analysis/grounding.py` and `src/black_box/analysis/managed_agent.py` (no-op fallbacks) — left intentionally to minimize the blast radius of this PR per the scope note on the issue. Can be removed in a follow-up hygiene PR.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>