### PR TITLE
docs(p5): clean-clone smoke test + restore missing client factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .venv/
+.smoke-venv/
 venv/
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ python scripts/run_rtk_heading_case.py   # tag: live, requires ANTHROPIC_API_KEY
 - [Demo script](docs/DEMO_SCRIPT.md) — 3-min video beat sheet.
 - [Risks](docs/RISKS.md) — risk register + stop-loss triggers.
 - [Submission](docs/SUBMISSION.md) — deliverables checklist.
+- [Smoke test](docs/SMOKE_TEST.md) — clean-clone reproducibility steps for judges.
 - [Testimonial](docs/TESTIMONIAL.md) — quote capture plan.
 - [Flag-plant](docs/FLAG_PLANT.md) — X/LinkedIn thread copy.
 - [Rehearsal](docs/REHEARSAL.md) — pitch timing, breath points, Q&A prep.
@@ -69,11 +70,14 @@ Every Claude call is logged to `data/costs.jsonl` (cached/uncached/creation toke
 - **Synthetic QA** — injected-bug recording in, hypothesis + self-eval vs ground truth out.
 
 ## Quickstart
+
+Offline smoke (no API key required, runs the 7-case public benchmark through
+the stub predictor so plumbing is exercised with zero spend):
+
 ```bash
-python -m venv .venv && source .venv/bin/activate
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
-export ANTHROPIC_API_KEY=...    # or put in .env
-python -m black_box.eval.runner --case-dir black-box-bench/cases
+python -m black_box.eval.runner --tier 3 --case-dir black-box-bench/cases
 ```
 
 Verified on this commit (2026-04-23, Python 3.13.9):
@@ -81,6 +85,16 @@ Verified on this commit (2026-04-23, Python 3.13.9):
 - `pytest -q` -> **169 passed** in 20.65s (2 deprecation warnings, no failures).
 - `python scripts/cost_report.py` -> **TOTAL $30.56** across 90 entries (29 real Opus 4.7 calls: $26.97; 61 test fixtures: $3.59).
 - `lychee README.md` -> **11/11 links OK, 0 errors** (enforced in CI via `.github/workflows/link-check.yml`).
+
+Live-run (real Opus 4.7):
+
+```bash
+export ANTHROPIC_API_KEY=...    # or put in .env
+python -m black_box.eval.runner --tier 3 --case-dir black-box-bench/cases --use-claude
+```
+
+Full clean-clone reproducibility steps a judge would follow live in
+[`docs/SMOKE_TEST.md`](docs/SMOKE_TEST.md).
 
 ## System overview
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -1,0 +1,125 @@
+# Clean-Clone Smoke Test
+
+End-to-end walkthrough a judge (or any fresh machine) runs after `git clone`.
+Exercises the package install, analysis imports, and one public-dataset
+benchmark case without spending a single API token.
+
+## Prereqs
+
+- Python **>= 3.10** (verified on 3.13).
+- `pip` and `venv` from the standard library (no extras).
+- ~600 MB disk for the transitive dependency set (numpy, opencv, matplotlib,
+  rosbags, reportlab, fastapi, anthropic, pydantic, etc.).
+- No ROS runtime required. No GPU required. No CUDA required.
+- No `ANTHROPIC_API_KEY` required for the smoke path (the offline stub runner
+  does not call the API). A key is only needed for `--use-claude` live runs.
+
+## Expected runtime
+
+| Step | Time (cold pip cache) | Time (warm pip cache) |
+|---|---|---|
+| `python -m venv` | ~3 s | ~3 s |
+| `pip install -e .` | ~90 s | ~10 s |
+| Offline benchmark run (7 cases) | < 1 s | < 1 s |
+
+Total: roughly 2 min on a fresh machine, 15 s on a warm one.
+
+## Expected output artifacts
+
+- Editable install of the `black-box` wheel plus its dependency closure into
+  the new venv.
+- Stdout table with one row per benchmark case and a summary tail:
+  `tier=3 cases=7 match=4 acc=57.14% cost=$0.0000 claude=False`.
+- No files written outside the venv directory. The offline stub path does
+  not touch `data/`.
+
+## Exact commands
+
+From the repo root after `git clone`:
+
+```bash
+python3 -m venv .smoke-venv
+source .smoke-venv/bin/activate
+pip install -e .
+python -m black_box.eval.runner --tier 3 --case-dir black-box-bench/cases
+```
+
+Expected stdout (verified 2026-04-23, Python 3.13.9, macOS arm64):
+
+```
+predicted_bug    predicted_window  cost_usd  wall_time_s  source  case_key                ground_truth_bug  skeleton  match
+---------------  ----------------  --------  -----------  ------  ----------------------  ----------------  --------  -----
+bad_gain_tuning  [5.0, 20.0]       0.0       0.0          stub    bad_gain_01             bad_gain_tuning   False     True
+unknown          None              0.0       0.0          stub    boat_lidar_01           unknown           True      False
+pid_saturation   [12.0, 18.0]      0.0       0.0          stub    pid_saturation_01       pid_saturation    False     True
+unknown          None              0.0       0.0          stub    reflect_public_01       unknown           True      False
+sensor_timeout   [0.0, 3626.8]     0.0       0.0          stub    rtk_heading_break_01    sensor_timeout    False     True
+unknown          None              0.0       0.0          stub    sensor_drop_cameras_01  sensor_timeout    True      False
+sensor_timeout   [10.0, 14.0]      0.0       0.0          stub    sensor_timeout_01       sensor_timeout    False     True
+
+tier=3 cases=7 match=4 acc=57.14% cost=$0.0000 claude=False
+```
+
+Four matches, three skeleton (no-bag) cases intentionally fail rather than
+silently score `unknown == unknown`. Total session cost: $0.00. Seven
+public-dataset cases exercised end-to-end.
+
+## Tier 1 smoke (offline, also free)
+
+The tier-1 runner adds a patch-target prediction on top of the tier-3 row:
+
+```bash
+python -m black_box.eval.runner --tier 1 --case-dir black-box-bench/cases
+```
+
+Tail row: `tier=1 cases=7 match=4 acc=57.14% cost=$0.0000 claude=False total_score=7.50/14.00`.
+
+## Sanity: run_session help
+
+Verifies the full pipeline entrypoint imports cleanly (no missing modules):
+
+```bash
+python scripts/run_session.py --help
+```
+
+Prints the argparse help text. If this fails with `ModuleNotFoundError`,
+open an issue; every module in `src/black_box/analysis/` is required.
+
+## Implicit directories
+
+The code creates these under the repo root on first real call. The offline
+smoke path does not touch them, so they only materialize when you move to
+live runs.
+
+| Path | Created by | When |
+|---|---|---|
+| `data/` | `ClaudeClient._ensure_costs_file` | on the first API call (auto-created) |
+| `data/costs.jsonl` | same | on the first API call (auto-created) |
+| `data/jobs/`, `data/reports/`, `data/uploads/`, `data/patches/` | `black_box.ui.app` module import | when the FastAPI app boots (auto-created) |
+| `data/runs/<session_name>/` | `scripts/run_session.py :: run()` | when `run_session.py` processes a folder (auto-created) |
+
+All are created with `Path.mkdir(parents=True, exist_ok=True)`; none need to
+be pre-staged. Judges running only the offline eval stub will not create any
+of them.
+
+## Live-run cost (skip for submission smoke)
+
+If you want to confirm the real Claude path works, flip the switch:
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+python -m black_box.eval.runner --tier 3 --case-dir black-box-bench/cases --use-claude
+```
+
+Rough cost ceiling: 7 cases x ~$0.50 upper bound per case = < $4 at current
+Opus 4.7 pricing. The offline smoke above is the canonical judge path;
+live-run is optional and only validates the Anthropic transport.
+
+## Cleanup
+
+```bash
+deactivate
+rm -rf .smoke-venv
+```
+
+`.smoke-venv/` is in `.gitignore`.


### PR DESCRIPTION
closes #63

## Summary

- Ran an end-to-end smoke test from a throwaway venv (`.smoke-venv/`) in this worktree; captured every failure a judge would hit.
- Restored `src/black_box/analysis/client.py` (the `build_client` factory). It was referenced by `claude_client.py` and `managed_agent.py` but never committed, so `scripts/run_session.py --help` (and every other entrypoint that touches the Anthropic SDK) crashed on a fresh install with `ModuleNotFoundError: No module named 'black_box.analysis.client'`. Hard-blocker for submission.
- Added `docs/SMOKE_TEST.md` with prereqs, exact commands, expected runtime, expected output.
- Rewrote README Quickstart to lead with the offline stub smoke path (`--use-claude` omitted) so judges verify the plumbing for $0. Live-run block is kept as an opt-in.
- Added `.smoke-venv/` to `.gitignore`.

## Fresh-clone run output (captured live)

Install:

```
python3 -m venv .smoke-venv
source .smoke-venv/bin/activate
pip install -e .
# ... Successfully installed ... black-box-0.1.0 ... anthropic-0.97.0 ...
```

Offline smoke (canonical judge path):

```
$ python -m black_box.eval.runner --tier 3 --case-dir black-box-bench/cases
predicted_bug    predicted_window  cost_usd  wall_time_s  source  case_key                ground_truth_bug  skeleton  match
---------------  ----------------  --------  -----------  ------  ----------------------  ----------------  --------  -----
bad_gain_tuning  [5.0, 20.0]       0.0       0.0          stub    bad_gain_01             bad_gain_tuning   False     True
unknown          None              0.0       0.0          stub    boat_lidar_01           unknown           True      False
pid_saturation   [12.0, 18.0]      0.0       0.0          stub    pid_saturation_01       pid_saturation    False     True
unknown          None              0.0       0.0          stub    reflect_public_01       unknown           True      False
sensor_timeout   [0.0, 3626.8]     0.0       0.0          stub    rtk_heading_break_01    sensor_timeout    False     True
unknown          None              0.0       0.0          stub    sensor_drop_cameras_01  sensor_timeout    True      False
sensor_timeout   [10.0, 14.0]      0.0       0.0          stub    sensor_timeout_01       sensor_timeout    False     True

tier=3 cases=7 match=4 acc=57.14% cost=$0.0000 claude=False
```

Sanity (proves `client.py` fix):

```
$ python scripts/run_session.py --help
usage: run_session.py [-h] [--prompt PROMPT] [--out OUT] [--force-deep]
                      [--reuse-frames] [--reuse-from REUSE_FROM]
                      path
...
```

Before the fix, the same command died with `ModuleNotFoundError: No module named 'black_box.analysis.client'`.

## Acceptance (issue #63)

- [x] Fresh-clone run succeeds on at least one public benchmark case (7/7 executed; 4/7 matched, 3 skeleton rows intentionally fail rather than silently scoring `unknown == unknown`).
- [x] `docs/SMOKE_TEST.md` committed with reproducible steps.
- [x] No manual "just copy this file from my other machine" steps remain.
- [x] Newly discovered implicit dep `src/black_box/analysis/client.py` checked in. No new pyproject deps needed; the `anthropic>=0.96` pin already covers `build_client`.

## Test plan

- [ ] `python3 -m venv .smoke-venv && source .smoke-venv/bin/activate && pip install -e .` succeeds.
- [ ] `python -m black_box.eval.runner --tier 3 --case-dir black-box-bench/cases` prints the 7-row table and tail summary above.
- [ ] `python scripts/run_session.py --help` prints argparse help (no `ModuleNotFoundError`).
- [ ] `docs/SMOKE_TEST.md` renders on GitHub.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>