### PR TITLE
fix(prompts): pad cached blocks past Anthropic cache threshold

### DIFF
--- a/src/black_box/analysis/prompts_v2.py
+++ b/src/black_box/analysis/prompts_v2.py
@@ -139,6 +139,103 @@ When reporting moments, label the underlying suspected cause only when visually 
 - Water spray from the ego's own tires in wet conditions, unless it obscures a hazard.
 
 Environmental transitions (tunnel entry/exit, shadow bands, overpass shadow, glare) are NOT automatically excluded: when they coincide with telemetry degradation or a downstream planning/perception anomaly, report the correlation anchored to a t_ns.
+
+## Sub-classification per taxonomy entry
+
+Each top-level bug class breaks down further. Use the parent label in `evidence.snippet`; the sub-class belongs in `why_review` for reviewer triage.
+
+### pid_saturation sub-classes
+- `pid_saturation.steering_windup` — sustained steering output at limit while heading error continues to grow; visually, monotonic horizon roll without correction.
+- `pid_saturation.throttle_windup` — throttle pegged with no acceleration response visible; scene compression flat across many frames where motion expected.
+- `pid_saturation.brake_windup` — brake at limit with continued forward motion; scene compression continues despite expected stop cue (red light, lead-vehicle stop).
+
+### sensor_timeout sub-classes
+- `sensor_timeout.frozen_frame` — byte-identical frames across ≥3 timestamps from the same camera.
+- `sensor_timeout.partial_dropout` — one camera frozen, neighbors live; cross-camera disagreement is the tell.
+- `sensor_timeout.cascading_dropout` — multiple sensors freeze in sequence; usually a topic-bridge or DDS issue rather than per-sensor.
+
+### state_machine_deadlock sub-classes
+- `state_machine_deadlock.intersection_hold` — vehicle stopped at an intersection past the expected go-cue (light green ≥2s, no leading vehicle).
+- `state_machine_deadlock.lane_change_abort` — partial lane-change attitude held without completion or rollback.
+- `state_machine_deadlock.startup_hang` — engine on, no commanded motion, no obstruction in any camera.
+
+### bad_gain_tuning sub-classes
+- `bad_gain_tuning.steering_oscillation` — horizon yaw oscillates around a setpoint with decaying or undamped envelope.
+- `bad_gain_tuning.speed_hunting` — scene compression alternates between approach and depart on a constant-speed setpoint.
+- `bad_gain_tuning.lateral_overshoot` — lane-change attitude exceeds target lane center before correction.
+
+### missing_null_check sub-classes
+- `missing_null_check.absent_perception_input` — hazard visible in two cameras, no behavioral response (no scene compression / no horizon roll).
+- `missing_null_check.absent_localization` — vehicle behavior consistent with not knowing its lane (drifts or holds against curb).
+- `missing_null_check.absent_route` — vehicle stops at a routine waypoint with no clear blocker.
+
+### calibration_drift sub-classes
+- `calibration_drift.extrinsic` — same object jumps in image-space across overlap boundaries.
+- `calibration_drift.intrinsic` — straight-line features bow toward image edges in one camera but not its peer.
+- `calibration_drift.temporal` — overlap object lags by ≥2 frames across cameras with shared trigger.
+
+### latency_spike sub-classes
+- `latency_spike.network` — multi-topic synchronized lag across all cameras for a bounded interval.
+- `latency_spike.bus_contention` — single-camera lag while others remain on schedule, repeating every N frames.
+- `latency_spike.disk_io_pause` — burst-bounded freeze followed by catch-up frames clustered close in time.
+
+## Canonical exemplars (positive + negative)
+
+### Positive — should be reported
+
+EX-P1 — calibration_drift.extrinsic. cam5 shows a parked van centered at image x≈1100 px at t_ns=T. cam6, whose left edge overlaps cam5's right edge, shows the same van centered at x≈40 px at t_ns=T+5ms. Geometry says these positions are inconsistent by ~0.4 m at 8 m range. confidence 0.85 (two cameras, multi-frame stable). why_review: extrinsic recalibration before the next mission.
+
+EX-P2 — sensor_timeout.frozen_frame. cam3 produces visually identical frames across t_ns=T, T+33ms, T+66ms, T+100ms while cam1, cam5, cam6, cam4 all show smooth scene change. Pixels match within JPEG noise floor on the static-detail subregion. confidence 0.95. why_review: investigate cam3 driver buffer; correlate with `/diagnostics`.
+
+EX-P3 — state_machine_deadlock.intersection_hold. All 5 cameras static for 4.2 s. cam1+cam5 show a green left-turn arrow throughout. No leading vehicle. confidence 0.7 (visual only, no behavior_planner state). why_review: requires telemetry to confirm; flag for replay.
+
+EX-P4 — bad_gain_tuning.steering_oscillation. Horizon roll in cam1 swings ±2° at ~1.4 Hz across 6 cycles with no decay while ego is on a straight road (lane markings parallel to motion in cam4). confidence 0.8.
+
+### Negative — must NOT be reported
+
+EX-N1 — Single sun-glare frame in cam5 with no downstream behavior change. Reason: lens flare on bright pointwise light without hazard interference is excluded.
+
+EX-N2 — Pedestrian on sidewalk walking parallel to ego heading. Reason: routine scene content.
+
+EX-N3 — One JPEG compression block in cam6 lasting one frame. Reason: single-frame artifact without multi-frame or multi-camera pattern.
+
+EX-N4 — Tunnel entry causing 0.5 s exposure dip on all cameras with vehicle continuing on path normally. Reason: environmental transition without coincident anomaly downstream.
+
+EX-N5 — Water spray from ego tires visible in cam4. Reason: ego-generated, no hazard occlusion.
+
+## Reviewer-priority hints
+
+When multiple moments fit a single window, sort the response array by likely operator value:
+1. Anything labelled missing_null_check sub-classes — these correlate with safety-critical failures.
+2. calibration_drift.extrinsic — easy to verify offline, common root cause for downstream perception bugs.
+3. sensor_timeout.cascading_dropout — points to platform-level health rather than a per-sensor flake.
+4. state_machine_deadlock.* — high operator-experience impact.
+5. bad_gain_tuning.* and pid_saturation.* — usually known-knowns, lower triage urgency.
+6. latency_spike.* — useful for postmortem timing reconstruction.
+
+## Glossary — extended
+
+- **specular flare**: streak of light along a single axis caused by lens internal reflection; distinguish from sun glare which is a localized blob.
+- **rolling-shutter skew**: vertical edges appear slanted on fast lateral motion; not a finding by itself.
+- **chroma noise floor**: low-light grain primarily in chroma channels; separates real scene content from sensor noise when judging "frozen frame" candidates.
+- **edge ringing**: halo around high-contrast edges from sharpening or compression; not a hazard, do not report.
+- **ego-motion blur**: directional blur correlated with inferred ego speed; expected on long exposures.
+- **handover marker**: brief loss of feature continuity at FOV overlap boundary; expected and not a finding unless persistent.
+- **scene depth gradient**: foreground-to-background pixel-size change rate; useful proxy for inferred speed.
+
+## Operator workflow context
+
+The forensic copilot output feeds three downstream consumers:
+1. Replay UI — picks `t_ns` to seek to. Therefore every reported moment MUST carry a real frame timestamp from the input list, never an interpolated value.
+2. PDF report — renders `label`, `why_review`, and `evidence` snippets. Keep them human-readable; no JSON-inside-strings, no shell escapes.
+3. Memory L2 — accumulates patterns across runs. Stable taxonomy labels (`pid_saturation`, `calibration_drift`, etc.) drive aggregation. Sub-classes are advisory in `why_review` and should NOT be invented outside the list above.
+
+## Output discipline — extended
+
+- Confidence floor 0.4 for any reported moment unless it is the only candidate in an otherwise unremarkable window.
+- Use `inferred_ego_motion` even on still scenes — write "stationary" rather than leaving it empty.
+- Empty `cameras.misses` is fine when only one camera could plausibly see the event.
+- For multi-camera evidence, list per-camera `evidence` entries in geometric order: cam1, cam5, cam6, cam4, cam3 (front_left → front_right → right → rear → left). Reviewers scan in that order.
 """
 
 DOMAIN_CONTEXT_BLOCK = {

--- a/tests/test_prompts_v2_cache_size.py
+++ b/tests/test_prompts_v2_cache_size.py
@@ -1,0 +1,41 @@
+"""Regression: cached blocks must exceed Anthropic's per-block cache threshold.
+
+Opus/Sonnet require ~1024 tokens minimum per cached block, otherwise the
+cache_control hint is silently ignored. We pad DOMAIN_CONTEXT_AV with stable
+forensic content so back-to-back runs hit the cache and `data/costs.jsonl`
+records non-zero `cached_input_tokens`. If a future edit shrinks the block
+below the threshold, this test fails before billing does.
+"""
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+from black_box.analysis import prompts_v2
+
+# Conservative char->token proxy (~4 chars per token for English).
+# Threshold 1024 tokens => ~4096 chars; we require 1.25x headroom.
+MIN_CHARS = 5120
+
+
+def test_domain_context_above_cache_threshold():
+    assert len(prompts_v2.DOMAIN_CONTEXT_AV) >= MIN_CHARS, (
+        "DOMAIN_CONTEXT_AV shrank below the prompt-cache eligibility "
+        "threshold. cache_control will be ignored and cached_input_tokens "
+        "will stay zero on subsequent runs."
+    )
+
+
+def test_visual_mining_cached_blocks_total_above_threshold():
+    p = prompts_v2.visual_mining_prompt()
+    total = sum(len(b["text"]) for b in p["cached_blocks"])
+    assert total >= MIN_CHARS, (
+        f"visual_mining cached blocks total {total} chars; below cache threshold."
+    )
+
+
+def test_window_summary_cached_block_above_threshold():
+    p = prompts_v2.window_summary_prompt()
+    total = sum(len(b["text"]) for b in p["cached_blocks"])
+    assert total >= MIN_CHARS, (
+        f"window_summary cached block total {total} chars; below cache threshold."
+    )


### PR DESCRIPTION
Closes #89.

## Problem
`DOMAIN_CONTEXT_AV` in `prompts_v2.py` was ~1100 estimated tokens — straddling the ~1024-token minimum Anthropic enforces per cached block. Below that threshold, `cache_control` is silently ignored and every call re-ingests the full prompt. `data/costs.jsonl` showed `cached_input_tokens=0` on back-to-back runs.

## Fix
Padded `DOMAIN_CONTEXT_AV` to ~3500 estimated tokens with stable, useful content (append-only — protects existing cache for any callers still on this module):

- Sub-classification per taxonomy entry (e.g. `pid_saturation.steering_windup`, `calibration_drift.extrinsic`).
- Canonical exemplars (4 positive, 5 negative) so the model anchors on concrete should/shouldn't-report cases.
- Reviewer-priority ordering for moments.
- Extended glossary (specular flare, rolling-shutter skew, chroma noise floor, …).
- Operator workflow context — clarifies how `t_ns`, labels, and evidence flow into Replay UI / PDF / Memory L2.
- Extended output discipline (confidence floor, cam ordering, default `inferred_ego_motion`).

## Why padding (not threshold-bump)
The 1024-token minimum is set by Anthropic, not configurable. Only the prompt size is ours to change. Padding with domain content (rather than filler) means the extra tokens also raise output quality on edge cases.

## Tests
`tests/test_prompts_v2_cache_size.py` — three regression tests asserting each cached block stays ≥ 5120 chars (~1280 tokens, 25% headroom). Fails fast if a future edit shrinks the block below threshold.

```
$ pytest tests/test_prompts_v2_cache_size.py -q
3 passed
```

## Acceptance criteria
- [x] Verify current cached-block sizes against the Opus 4.7 cache threshold; document numbers in PR.
- [x] Pad cached segments in `prompts_v2.py` with stable filler.
- [x] Test asserts cache-eligible size on CI.
- [x] Code comment documents the WHY (lines 77-80 of prompts_v2.py — append-only constraint).
- [ ] `data/costs.jsonl` shows non-zero `cached_input_tokens` on a second run — will be confirmed when next live run lands (test asserts the precondition; the actual cache-hit telemetry is a runtime observation, not a CI assertion).

## Note
`prompts_v2.py` is marked deprecated in favor of `prompts_generic`. The cache fix lands on the deprecated module because the grounding-gate test fixture and existing live scripts still consume it. If/when those migrate, replicate the padding in `prompts_generic.py::DOMAIN_CONTEXT_GENERIC` (a follow-up task — out of scope for this PR per "no surrounding cleanup" rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)