### PR TITLE
docs(nao6): reposition as bonus adapter only

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -12,19 +12,13 @@ Judging weights: Opus 4.7 Use 25% + Depth 20% + Impact 30% + Creativity 25%.
 
 ## Your scope
 
-### 1. NAO6 recordings — critical path, start tonight
+### 1. ~~NAO6 recordings — critical path~~ (descoped)
 
-Target: **3–5 failure recordings** (falls, grip fails, balance loss). Three artifacts per incident:
+> **Status (2026-04-25):** real-hardware NAO6 captures did not land. NAO6 is now a **bonus adapter only** — synthetic fall fixture under `src/black_box/platforms/nao6/` proves the adapter shape generalizes, but the judged demo runs on rover (`sanfer_sanisidro`) and marine bags only. Do **not** invest more time on NAO6 hardware.
 
-- onboard camera footage
-- controller / state logs at failure time
-- controller source code snapshot
+### 2. NAO6 ingestion adapter — keep as bonus, do not extend
 
-Each fall needs setup + reset, so this is ~2 days. **Don't batch at the end.**
-
-### 2. NAO6 ingestion adapter
-
-Code in `src/black_box/platforms/nao6/`. Convert the three artifact types into the pipeline's canonical format (frames + time series + code blobs). Mirror the API of the car adapter Lucas is building at `src/black_box/platforms/car_av/`.
+Existing scaffold under `src/black_box/platforms/nao6/` (synthetic fall fixture, humanoid taxonomy → global closed set, controller snapshots) stays. It is referenced in the pitch with **one line only**: *"platform adapter shape already validated on NAO6"*. No NAO6 footage in the judged beat, no NAO6 hero asset in the landing UI.
 
 ### 3. Managed Agents — real implementation
 
@@ -93,14 +87,14 @@ FastAPI + HTMX already scaffolded. You own:
 
 | Day | Focus |
 |-----|-------|
-| 1–2 (now) | NAO6 recordings start. Read Opus 4.7 + Managed Agents docs. Fork repo, get local setup running. |
-| 3 | NAO6 ingestion adapter + first fall analysis with all three artifacts fused. First real test of the core novelty claim — prioritize. |
+| 1–2 | ~~NAO6 recordings~~ (descoped). Read Opus 4.7 + Managed Agents docs. Fork repo, get local setup running. |
+| 3 | ~~NAO6 ingestion adapter~~ — synthetic fixture only, scaffolded. Move to managed agent + memory stack port early. |
 | 4 | Managed Agents real implementation + memory stack port. Joint prompt iteration with Lucas. |
-| 5 | Grounding gate + UI polish + PDF templates final. Demo rehearsal. |
+| 5 | Grounding gate + UI polish + PDF templates final. Demo rehearsal on rover/marine bags. |
 | 6 | Buffer + submit. |
 
 ## Watch-outs
 
 - **Kairos was Gemini, this is Anthropic.** Not everything ports 1:1. Flag uncertain patterns on tomorrow's call — we'll review what's portable vs needs adaptation.
-- **No scope creep.** Two platforms (car + NAO6) with depth beats four shallow. Don't pull in other robots.
+- **No scope creep.** Single judged platform (rover/marine, real bags) with depth beats two shallow. NAO6 stays a bonus adapter, not a demo beat.
 - **Patches stay scoped.** Clamps, timeouts, null checks, gain adjustments — never rewrites. A dumb patch kills credibility of the whole tool.

--- a/docs/REHEARSAL.md
+++ b/docs/REHEARSAL.md
@@ -84,7 +84,7 @@ Pre-answered, 2 sentences each:
 > AURA is telemetry-only, live, no patch. ROSA is NASA-JPL's air-traffic-control layer. We're post-mortem, fuse camera + code + logs, and emit a scoped diff. Different axis.
 
 **"Real data or synthetic?"**
-> Both. Three synthetic cases with ground truth for eval; real AV bags (5-camera, multi-minute) for the hero findings. NAO6 humanoid recordings land on Day 4–5.
+> Both. Three synthetic cases with ground truth for eval; real bags (rover `sanfer_sanisidro` for the hero RTK-heading finding, marine USV for cross-platform proof). NAO6 ships only as a bonus platform adapter (synthetic fall fixture, taxonomy mapping) — not in the judged demo beat.
 
 **"What's the business?"**
 > AV labs and humanoid teams process petabytes of bags. Post-incident review is a staffing problem. If this saves one engineer-week per incident, it pays for itself on the first bag.

--- a/docs/TESTIMONIAL.md
+++ b/docs/TESTIMONIAL.md
@@ -24,7 +24,7 @@ Contact at least 3 in parallel. Don't serialize.
 
 ## Ask (message template — EN)
 
-> Hi [name], short ask. I'm in a hackathon this week (Cerebral Valley × Anthropic, "Built with Opus 4.7") shipping **Black Box** — a forensic copilot that reads a ROS bag and returns ranked root-cause hypotheses plus a scoped code patch. Two platforms: 5-camera autonomous car + NAO6 humanoid. Demo ships Apr 26.
+> Hi [name], short ask. I'm in a hackathon this week (Cerebral Valley × Anthropic, "Built with Opus 4.7") shipping **Black Box** — a forensic copilot that reads a ROS bag and returns ranked root-cause hypotheses plus a scoped code patch. Real bags from a 5-camera rover (hero finding: RTK-heading break) and a marine USV; NAO6 humanoid ships as a bonus platform-adapter shape proof. Demo ships Apr 26.
 >
 > Would you have 10 minutes to look at one analysis output? If you find it credible, I'd love a 1–2 sentence quote I can use in the submission video. If you think it's off, tell me and I'll take the note. No obligation either way.
 >
@@ -33,7 +33,7 @@ Contact at least 3 in parallel. Don't serialize.
 
 ## Ask (message template — ES)
 
-> Hola [nombre], una ask corta. Estoy en un hackathon esta semana (Cerebral Valley × Anthropic, "Built with Opus 4.7") shipeando **Black Box** — copilot forense que lee un ROS bag y devuelve hipótesis de causa raíz ranqueadas + un parche de código acotado. Dos plataformas: auto autónomo 5 cámaras + humanoid NAO6. Demo sale 26 abril.
+> Hola [nombre], una ask corta. Estoy en un hackathon esta semana (Cerebral Valley × Anthropic, "Built with Opus 4.7") shipeando **Black Box** — copilot forense que lee un ROS bag y devuelve hipótesis de causa raíz ranqueadas + un parche de código acotado. Bags reales de un rover 5 cámaras (hallazgo hero: rotura de heading RTK) y un USV marino; el humanoide NAO6 va como bonus, sólo para probar la forma del adaptador de plataforma. Demo sale 26 abril.
 >
 > ¿Tenés 10 min para ver un análisis? Si lo ves creíble, me gustaría una frase de 1–2 oraciones para el video de la submission. Si ves algo flojo, decímelo y lo anoto. Sin obligación.
 >

--- a/tests/test_nao6_positioning.py
+++ b/tests/test_nao6_positioning.py
@@ -1,0 +1,53 @@
+"""Doc-lint: NAO6 must remain a bonus adapter, not a judged-beat platform.
+
+Per #91, NAO6 should appear only as a one-line generalization proof. Catches
+regressions where pitch/demo/onboarding docs reintroduce NAO6 as a primary
+platform.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Paths that drive the judged demo. Stronger constraint here.
+HERO_DOCS = [
+    "docs/PITCH.md",
+    "docs/DEMO_SCRIPT.md",
+    "docs/SUBMISSION.md",
+]
+
+# Phrases that imply NAO6 is a primary / hero / live-demoed platform.
+FORBIDDEN_PATTERNS = [
+    r"two platforms[^.]*nao6",
+    r"nao6[^.]*hero",
+    r"nao6 (live|hero) demo",
+    r"nao6 footage",
+]
+
+
+NEGATION = re.compile(r"\b(don't|didn'?t|not|never|no longer|won't|deprec|descop|bonus|adapter)\b")
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8").lower()
+
+
+def test_hero_docs_do_not_promote_nao6_to_primary():
+    for doc in HERO_DOCS:
+        for line in _read(doc).splitlines():
+            if NEGATION.search(line):
+                continue
+            for pat in FORBIDDEN_PATTERNS:
+                if re.search(pat, line):
+                    raise AssertionError(
+                        f"{doc} line '{line.strip()}' positively asserts a NAO6 "
+                        f"primary/hero claim; per #91 NAO6 is bonus only."
+                    )
+
+
+def test_pitch_carries_bonus_framing_for_nao6():
+    text = _read("docs/SUBMISSION.md")
+    if "nao6" in text:
+        assert "bonus" in text or "adapter" in text, (
+            "SUBMISSION.md mentions NAO6 without 'bonus' / 'adapter' framing."
+        )


### PR DESCRIPTION
Closes #91.

## Audit results
| Surface | Before | After |
|---|---|---|
| `README.md` | NAO6 already in bonus section | unchanged ✅ |
| `SCOPE_FREEZE.md` | NAO6 already framed as "bonus, scaffolded only" | unchanged ✅ |
| `docs/PITCH.md` | Already says *"we don't say two platforms — NAO6 didn't land"* | unchanged ✅ |
| `docs/SUBMISSION.md` | Already framed as "bonus, primary pitch is rover/marine" | unchanged ✅ |
| `docs/DEMO_SCRIPT.md` | "NAO6 beat. Real humanoid recordings not captured." | unchanged ✅ |
| `docs/RISKS.md` | Already RESOLVED row | unchanged ✅ |
| `docs/REHEARSAL.md` | Said *"NAO6 humanoid recordings land Day 4–5"* | rewritten to rover/marine + NAO6 bonus only |
| `docs/ONBOARDING.md` | NAO6 = critical path (sections 1+2, day-by-day, watch-outs) | reframed as descoped bonus |
| `docs/TESTIMONIAL.md` | EN+ES *"Two platforms: car + NAO6 humanoid"* | rover/marine real bags + NAO6 bonus framing |
| `src/black_box/ui/`, `cli.py`, runner config | No NAO6 paths exist in default live runner | already gated ✅ |
| Landing UI screenshot | No NAO6 hero asset | confirmed ✅ |

## Tests
`tests/test_nao6_positioning.py` — doc-lint guard. Scans `PITCH.md`, `DEMO_SCRIPT.md`, `SUBMISSION.md` line-by-line; fails if a line positively asserts NAO6 as a primary/hero/live platform without a negation marker (don't / didn't / not / bonus / adapter / descoped / deprecated).

```
$ pytest tests/test_nao6_positioning.py -q
2 passed
```

## Acceptance criteria
- [x] Audit README, demo script, slides, video script. NAO6 appears only as a single-line generalization sentence or in `descoped`/`bonus` framing.
- [x] DEMO_SCRIPT.md shows zero NAO6 footage in judged beat (already true).
- [x] No NAO6 hero asset in landing UI screenshot (no NAO6 paths in UI code; confirmed grep clean).
- [x] No NAO6-specific code paths in live runner default config — none exist; nothing to gate.

## Out of scope (explicitly kept)
- `src/black_box/platforms/nao6/` adapter, synthetic fall fixture, taxonomy mapping, controller snapshots — kept exactly as the issue says: "the bonus it is."

🤖 Generated with [Claude Code](https://claude.com/claude-code)