### PR TITLE
chore(scripts): classify all 56 scripts (eval/demo/ops/dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Primary mapping: [`demo_assets/INDEX.md`](demo_assets/INDEX.md). Tags per beat:
 - `reporting/` — reportlab PDF (NTSB-style), unified diff + HTML side-by-side.
 - `ui/` — FastAPI + HTMX progress polling (stub worker today; real wiring deferred per `SCOPE_FREEZE.md`).
 - `eval/` — tier-3 runner + offline stub path; tier-1/tier-2 batch runners pending.
+- `scripts/` — runners, demo asset builders, ops, dev utilities. Classified per category in [`scripts/README.md`](scripts/README.md) (eval / demo / ops / dev).
 
 ## Bonus — NAO6 humanoid adapter (not on the demo critical path)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,79 @@
+# `scripts/` — taxonomy
+
+Per #90: classify each script as **eval / demo / ops / dev** so evaluators can tell which scripts are core product vs submission artifacts vs one-off utilities. Layout stays flat (Option B); rename/move would break cross-repo references and CI for low gain pre-deadline. A future PR may move into subdirectories — the classification below is the contract that move would honor.
+
+## Categories
+
+- **eval** — benchmark and tier runners. Anything that produces a number that goes into the README or `data/bench_runs/`.
+- **demo** — assets for the submission video, screenshots, recording, and asset assembly. Re-runnable but not part of the live forensic loop.
+- **ops** — release packaging, batch ops, scheduled runs, cost reporting, anything an operator runs in production-shape.
+- **dev** — one-off utilities: ingestion experiments, format probes, salvage tools, ad-hoc data extraction. Useful but not on the critical path.
+
+## Inventory
+
+| Script | Class | One-line purpose |
+|---|---|---|
+| `run_opus_bench.py` | eval | budgeted benchmark runner producing `data/bench_runs/opus47_<UTC>.json`. README ground truth. |
+| `run_rtk_heading_case.py` | eval | hero-case telemetry-only one-shot for the sanfer RTK finding. |
+| `run_session.py` | eval | end-to-end forensic session over a folder of bags (real pipeline entry point). |
+| `bench_context_mode.py` | eval | context-mode A/B benchmark — measures live vs replay vs sample cost shape. |
+| `end_to_end_smoke.py` | eval | smoke harness that walks ingest → analyze → report on the synthetic fixture. |
+| `grounding_gate_live.py` | eval | grounding-gate regression on a known-clean window; CI fixture. |
+| `hero_analysis.py` | eval | hero analysis driver wrapper. |
+| `hero_bag0_indoor.py` | eval | hero-case indoor variant (legacy). |
+| `managed_agent_smoke.py` | eval | smoke for the ForensicAgent / Managed Agents wiring. |
+| `analyze_bag.py` | eval | single-bag analysis (legacy v1). |
+| `analyze_bag_v2.py` | eval | single-bag analysis (current; v2). |
+| `cost_report.py` | ops | summarize / chart `data/costs.jsonl` — cumulative spend, per-prompt CSV. |
+| `overnight_batch.py` | ops | unattended bench runner with budget gates; pairs with `OVERNIGHT_BATCH.md`. |
+| `record_replay.py` | ops | record a deterministic replay of a session (compressed). |
+| `record_replay_raw.py` | ops | record a raw replay (uncompressed) for forensic re-walk. |
+| `regen_reports_md.py` | ops | regenerate `*.md` reports from session artifacts. |
+| `legal_review.py` | ops | scan repo for license/legal risk markers (release gating). |
+| `snapshot_controllers.py` | ops | freeze the controller source tree for an analysis. |
+| `download_sample_bag.py` | ops | fetch the public sample bag (idempotent). |
+| `final_pipeline.py` | demo | submission-cut full pipeline driver (long; produces final video assets). |
+| `build_grounding_gate_demo.py` | demo | builds the grounding-gate replay demo asset. |
+| `build_sanfer_timelapse.py` | demo | timelapse of the sanfer hero session for the demo video. |
+| `build_bag_timelapse.py` | demo | generic bag timelapse for promo/demo cuts. |
+| `build_multicam_composite.py` | demo | 5-camera composite for the cross-view beat. |
+| `build_boat_traffic_plot.py` | demo | marine USV traffic plot for the cross-platform demo beat. |
+| `capture_screenshots.py` | demo | capture UI screenshots for README / submission. |
+| `capture_nao6.py` | demo | NAO6 fixture capture (bonus only — see `NAO6_CAPTURE_GUIDE.md`). |
+| `compose_demo.sh` | demo | top-level demo composition driver. |
+| `compose_demo_v1_nopad.sh` | demo | demo composition variant: no padding. |
+| `compose_demo_v2_xfade.sh` | demo | demo composition variant: crossfade. |
+| `compose_demo_v3_nopad_xfade.sh` | demo | demo composition variant: no-pad + crossfade. |
+| `compose_demo_v4_xfade_exp.sh` | demo | demo composition variant: experimental xfade. |
+| `render_block_01_hook.py` | demo | submission video block 01 — hook. |
+| `render_block_02_problem.py` | demo | submission video block 02 — problem. |
+| `render_block_03_setup.py` | demo | submission video block 03 — setup. |
+| `render_block_04_analysis_live.py` | demo | submission video block 04 — analysis live (v1). |
+| `render_block_04_analysis_live_v2.py` | demo | submission video block 04 — analysis live (current). |
+| `render_block_05_first_moment.py` | demo | submission video block 05 — first moment. |
+| `render_block_06_second_moment.py` | demo | submission video block 06 — second moment. |
+| `render_block_07_grounding.py` | demo | submission video block 07 — grounding gate. |
+| `render_block_08_money_shot.py` | demo | submission video block 08 — money shot. |
+| `render_block_09_punchline.py` | demo | submission video block 09 — punchline. |
+| `render_block_10_outro.py` | demo | submission video block 10 — outro. |
+| `render_diff.py` | demo | render a unified diff into the demo's HTML aesthetic. |
+| `render_rtk_diff.py` | demo | render the RTK diff for the hero-case money shot. |
+| `render_rtk_plots.py` | demo | render the RTK telemetry plots for the demo. |
+| `salvage_analysis.py` | dev | salvage partial analysis output when a session crashes mid-run. |
+| `bag_duration.py` | dev | print bag duration; used during ingestion debugging. |
+| `inspect_bag.py` | dev | print bag topic schema / counts; used to bootstrap a new platform adapter. |
+| `extract_hires.py` | dev | extract hi-res frames for visual inspection. |
+| `extract_window.py` | dev | extract a single timestamped window from a bag (legacy). |
+| `extract_windows_v2.py` | dev | windowed extraction (current). |
+| `extract_session_frames.py` | dev | dump session frames into a directory. |
+| `extract_sanfer_cam.py` | dev | extract sanfer cam frames (legacy). |
+| `extract_sanfer_cam_smart.py` | dev | extract sanfer cam frames with smart sub-sampling. |
+| `rtk.py` | dev | RTK debugging toolkit — interactive helpers used to author the hero finding. |
+
+## Companion files
+
+- `NAO6_CAPTURE_GUIDE.md` — bonus-platform capture playbook. Tied to the demoted NAO6 scope (#91).
+
+## How to add a new script
+
+Pick the smallest category that fits, then add a row above with a one-line purpose. If a script promotes from `dev` → `eval` (e.g. produces a number you cite in README), update the row and the README's *Status* table.

--- a/tests/test_scripts_taxonomy.py
+++ b/tests/test_scripts_taxonomy.py
@@ -1,0 +1,23 @@
+"""#90 — every executable in scripts/ must be classified in scripts/README.md.
+
+Catches the case where a new script lands without a one-line purpose row.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+README = SCRIPTS / "README.md"
+
+# Files in scripts/ that are not runnable scripts and don't need rows.
+NON_SCRIPT_FILES = {"README.md", "NAO6_CAPTURE_GUIDE.md"}
+
+
+def test_every_script_is_classified():
+    actual = {p.name for p in SCRIPTS.iterdir() if p.is_file()}
+    actual -= NON_SCRIPT_FILES
+    text = README.read_text(encoding="utf-8")
+    missing = sorted(name for name in actual if f"`{name}`" not in text)
+    assert not missing, (
+        f"scripts/README.md is missing rows for {len(missing)} scripts: {missing}. "
+        f"Add a one-line purpose row under the appropriate category (eval / demo / ops / dev)."
+    )


### PR DESCRIPTION
Closes #90. Option B per acceptance — flat layout, classified.

## Why Option B
The acceptance criteria allow either restructuring under sub-dirs (Option A) or a flat README classification (Option B). Option B was chosen because:
- 56 scripts referenced from CI, Makefile-equivalents, multiple docs (`OVERNIGHT_BATCH.md`, `README.md`, `docs/SMOKE_TEST.md`, `docs/DEMO_SCRIPT.md`), and the cross-repo benchmark.
- Renames would invalidate paths during the freeze window before submission.
- Classification + lint guard delivers the same reviewer signal at zero migration risk.

A future PR (post-deadline) can move into sub-dirs honoring this classification as the contract.

## What ships
- `scripts/README.md` — one-line purpose row per script, grouped by **eval / demo / ops / dev** (definitions in the doc).
- `tests/test_scripts_taxonomy.py` — fails if a new script lands in `scripts/` without a classification row. Runs in <50ms.
- `README.md` *Architecture (modules)* now points at `scripts/README.md`.

## Acceptance
- [x] Picked Option B.
- [x] No script silently broken — no files moved or renamed.
- [x] Referenced from main README "where things live" section (Architecture (modules)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)