### PR TITLE
feat(ui): promote live pipeline to canonical worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,17 @@ Reproduce: `python scripts/capture_screenshots.py` (requires `playwright` + `pla
 
 ## UI status
 
-`src/black_box/ui/` ships the upload → streaming-reasoning → side-by-side-diff UX. Behind the UI, the pipeline worker is currently the streaming **stub** (`_run_pipeline_stub` in `ui/app.py`) that walks through realistic stage chunks and emits a canned patch artifact for the diff viewer (tag: `replay`). The demo video uses this path.
+`src/black_box/ui/` ships the upload → streaming-reasoning → side-by-side-diff UX. Behind the UI the canonical worker is **live** (ingestion → `ForensicAgent` session → PDF render). It runs by default whenever `ANTHROPIC_API_KEY` is set; no `BLACKBOX_REAL_PIPELINE` opt-in required (#75).
 
-The real worker (ingestion → `ForensicAgent` session → PDF render) runs today via `scripts/managed_agent_smoke.py` (tag: `live`, gated on `BLACKBOX_REAL_PIPELINE=1`); wiring that into the UI background task is deferred — see [`SCOPE_FREEZE.md`](SCOPE_FREEZE.md).
+Source-mode selection at upload time (form field `source`, default `auto`):
+
+| `source=` | Behavior |
+|---|---|
+| `auto` | Live when an API key is set; stub otherwise. |
+| `live` | Force the real worker. 503 if the key is missing. |
+| `stub` | Force the offline scripted walkthrough — used in the demo video for deterministic playback. |
+
+If the live pipeline fails mid-run, the failure is surfaced as a `failed` job with the error message — there is **no** silent stub fallback. `BLACKBOX_REAL_PIPELINE=0` remains as the kill-switch for offline-only environments.
 
 ## Demo asset catalog
 
@@ -415,7 +423,7 @@ Primary mapping: [`demo_assets/INDEX.md`](demo_assets/INDEX.md). Tags per beat:
 - `platforms/` — robot-specific adapters + taxonomies (see **Bonus** below).
 - `synthesis/` — injected-bug recordings + text video prompts.
 - `reporting/` — reportlab PDF (NTSB-style), unified diff + HTML side-by-side.
-- `ui/` — FastAPI + HTMX progress polling (stub worker today; real wiring deferred per `SCOPE_FREEZE.md`).
+- `ui/` — FastAPI + HTMX progress polling. Live worker is canonical (#75); `?source=stub` opt-in for the offline demo.
 - `eval/` — tier-3 runner + offline stub path; tier-1/tier-2 batch runners pending.
 
 ## Bonus — NAO6 humanoid adapter (not on the demo critical path)

--- a/SCOPE_FREEZE.md
+++ b/SCOPE_FREEZE.md
@@ -25,7 +25,7 @@ Demo proof: `demo_assets/grounding_gate/README.md`.
 - **Self-improving memory loop** (L2 priors priming the system prompt, L3 tie-breaking, L4 regression alarms). Substrate ships; loop does not. README calls this out explicitly.
 - **Tier-1 / Tier-2 batch runners.** Single-case paths work; batched CLI is skeleton only.
 - **Public-data downloader path** (`eval.public_data`). Stub only.
-- **Real rosbag upload path in the deployed UI** — the video demo uses the streaming stub (`_run_pipeline_stub`). Real pipeline is reachable via env flag and `scripts/managed_agent_smoke.py`; not the demo critical path.
+- ~~**Real rosbag upload path in the deployed UI**~~ — promoted to canonical via #75. Live is the default worker whenever `ANTHROPIC_API_KEY` is set; the streaming stub is now opt-in via `?source=stub` for the deterministic demo cut.
 - **Video synthesis execution** (Wan 2.2, Nano Banana Pro, ComfyUI). We emit text prompts only. Operator runs video tools on their own GPU.
 - **ROS 2 runtime.** Never installed. `rosbags` library only.
 - **LangChain / AutoGen / LlamaIndex / vector DBs / RAG.** None, ever.

--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -416,8 +416,17 @@ def _run_pipeline_replay(job_id: str, replay_name: str) -> None:
 
 # ---- real pipeline ----------------------------------------------------------
 def _real_pipeline_enabled() -> bool:
-    """Real pipeline only fires when explicitly enabled AND an API key is set."""
-    return os.getenv("BLACKBOX_REAL_PIPELINE") == "1" and bool(os.getenv("ANTHROPIC_API_KEY"))
+    """Live is the default canonical worker (#75).
+
+    Returns True whenever an ANTHROPIC_API_KEY is set. Operators can force
+    the stub for offline demo by setting BLACKBOX_REAL_PIPELINE=0 or by
+    passing ``?source=stub`` to /analyze. Pre-#75 behavior required an
+    explicit BLACKBOX_REAL_PIPELINE=1 opt-in; that's now the off-switch
+    rather than the on-switch.
+    """
+    if os.getenv("BLACKBOX_REAL_PIPELINE") == "0":
+        return False
+    return bool(os.getenv("ANTHROPIC_API_KEY"))
 
 
 def _fmt_stream_event(ev: dict) -> str | None:
@@ -570,10 +579,10 @@ def _run_pipeline_real(job_id: str, upload_path: Path, mode: Mode) -> None:
 
         _push("done", "Complete", 1.0, done=True)
     except Exception as e:  # pragma: no cover - live API failure path
+        # #75: surface the error. NO silent stub fallback — the canonical
+        # path is live. If the operator wants the stub they pass ?source=stub.
         buffer.append(f"ERROR: {e!r}")
-        buffer.append("[fallback] Falling back to stub pipeline so the UI stays responsive.")
-        _push("analyzing", "Live pipeline failed — replaying stub", 0.3)
-        _run_pipeline_stub(job_id, upload_path, mode)
+        _push("failed", f"Live pipeline failed: {e}", 0.0)
 
 
 def _run_pipeline_telemetry_only(
@@ -750,9 +759,12 @@ async def analyze(
     background: BackgroundTasks,
     file: UploadFile = File(...),
     mode: str = Form("post_mortem"),
+    source: str = Form("auto"),
 ) -> HTMLResponse:
     if mode not in ("post_mortem", "scenario_mining", "synthetic_qa"):
         raise HTTPException(400, f"unknown mode: {mode}")
+    if source not in ("auto", "live", "stub"):
+        raise HTTPException(400, f"unknown source: {source!r} (auto|live|stub)")
 
     job_id = uuid.uuid4().hex[:12]
     upload_path = UPLOADS_DIR / f"{job_id}_{file.filename}"
@@ -774,7 +786,16 @@ async def analyze(
             "has_diff": False,
         },
     )
-    live = _real_pipeline_enabled()
+    # #75: live is the canonical worker. ?source=stub forces the offline
+    # walkthrough; ?source=live demands live and 503s if no API key set.
+    if source == "stub":
+        live = False
+    elif source == "live":
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            raise HTTPException(503, "source=live requested but ANTHROPIC_API_KEY is unset")
+        live = True
+    else:
+        live = _real_pipeline_enabled()
     worker = _run_pipeline_real if live else _run_pipeline_stub
     # Re-stamp with correct source before the worker starts so the progress
     # card's first render already shows the right badge.

--- a/tests/test_canonical_live_default.py
+++ b/tests/test_canonical_live_default.py
@@ -1,0 +1,38 @@
+"""#75 — default UI worker is live; no silent stub fallback."""
+from __future__ import annotations
+
+import pytest
+
+
+def test_real_pipeline_default_on_when_key_present(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.delenv("BLACKBOX_REAL_PIPELINE", raising=False)
+    from black_box.ui.app import _real_pipeline_enabled
+    assert _real_pipeline_enabled() is True
+
+
+def test_real_pipeline_off_when_no_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("BLACKBOX_REAL_PIPELINE", raising=False)
+    from black_box.ui.app import _real_pipeline_enabled
+    assert _real_pipeline_enabled() is False
+
+
+def test_explicit_disable_with_real_pipeline_zero(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("BLACKBOX_REAL_PIPELINE", "0")
+    from black_box.ui.app import _real_pipeline_enabled
+    assert _real_pipeline_enabled() is False
+
+
+def test_real_pipeline_no_silent_stub_fallback_on_exception():
+    """Acceptance: live pipeline failure must surface, not silently route to stub."""
+    import inspect
+    from black_box.ui import app as app_mod
+    src = inspect.getsource(app_mod._run_pipeline_real)
+    # Pre-#75 the except branch called _run_pipeline_stub. That path is gone.
+    assert "_run_pipeline_stub(job_id" not in src, (
+        "live pipeline silently falls back to stub — #75 forbids this; "
+        "surface the error to the operator instead."
+    )
+    assert "_push(\"failed\"" in src or "stage='failed'" in src or '"failed"' in src


### PR DESCRIPTION
Closes #75.

## Behavior change
| | Before | After |
|---|---|---|
| Default worker | stub (`_run_pipeline_stub`) | **live** (`_run_pipeline_real`) |
| To enable live | `BLACKBOX_REAL_PIPELINE=1` | nothing — happens automatically when `ANTHROPIC_API_KEY` is set |
| To force stub | nothing — the default | `BLACKBOX_REAL_PIPELINE=0`, or `?source=stub` per-request |
| Live-pipeline error | silent fallback to stub | surfaced as a `failed` stage with the error message |
| Per-request override | none | `source ∈ {auto, live, stub}` form field |

## Tests
`tests/test_canonical_live_default.py` — 4 cases:
- live default ON when key present and `BLACKBOX_REAL_PIPELINE` unset
- live default OFF when key absent
- explicit `BLACKBOX_REAL_PIPELINE=0` disables live even with key
- `_run_pipeline_real` no longer contains a `_run_pipeline_stub(job_id` fallback call (string-level inspection guard)

```
$ pytest tests/test_canonical_live_default.py -q
4 passed in 0.57s
```

## Docs
- `README.md` — *UI status* rewritten; new source-mode table; old "stub worker today" sentence gone.
- `SCOPE_FREEZE.md` — "Real rosbag upload path in the deployed UI" line struck through and replaced with the #75 promotion note.

## Acceptance
- [x] Default UI run executes the real pipeline; no env var required.
- [x] Replay / sample / stub modes are explicitly selectable (form field `source`) and visibly tagged.
- [x] If the real pipeline fails, surface the error — no silent stub fallback.
- [x] README + SCOPE_FREEZE updated.
- [x] Smoke test asserts default code path hits the real worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)