### PR TITLE
feat(memory): visible self-improving loop demo

### DIFF
--- a/scripts/memory_loop_demo.py
+++ b/scripts/memory_loop_demo.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Visible self-improving memory loop demo (#76).
+
+Deterministic two-run sequence proving memory is read-and-applied:
+
+    run 1 — clean case ``rtk_alpha`` lands hypothesis 'sensor_timeout' as
+            the top class. Priors written to L2 and L3.
+
+    run 2 — paired case ``rtk_beta`` lands a near-tie between
+            'sensor_timeout' and 'calibration_drift' (Δ confidence < tie_delta).
+            PolicyAdvisor.apply_tie_break uses run-1's L3 frequency to
+            promote 'sensor_timeout'. The delta is captured in a
+            "memory used" panel JSON the reporting layer consumes.
+
+Runs offline (no Anthropic call). Idempotent — purges its own scratch
+memory dir on each invocation. Output JSON at:
+    data/memory_loop_demo/run1_summary.json
+    data/memory_loop_demo/run2_summary.json
+    data/memory_loop_demo/memory_used_panel.json
+
+Use as a pre-recorded beat in the demo script.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from black_box.analysis.policy import PolicyAdvisor
+from black_box.memory import (
+    CaseRecord,
+    MemoryStack,
+    PlatformPrior,
+    TaxonomyCount,
+)
+
+
+def _seed_run1(memory: MemoryStack, platform: str = "rover_av") -> dict:
+    case_key = "rtk_alpha"
+    memory.case.log(CaseRecord(case_key=case_key, kind="hypothesis", payload={"bug_class": "sensor_timeout", "confidence": 0.91}))
+    memory.platform.log(PlatformPrior(
+        platform=platform,
+        signature="rtk_carr_soln_none_persistent",
+        bug_class="sensor_timeout",
+        confidence=0.91,
+        hits=4,
+        source_case=case_key,
+    ))
+    memory.taxonomy.log(TaxonomyCount(
+        bug_class="sensor_timeout",
+        signature="rtk_carr_soln_none_persistent",
+        count=4,
+    ))
+    return {
+        "case_key": case_key,
+        "top_hypothesis": "sensor_timeout",
+        "confidence": 0.91,
+        "wrote_priors": ["L1.case", "L2.platform", "L3.taxonomy"],
+    }
+
+
+def _run2_with_advisor(memory: MemoryStack, platform: str = "rover_av") -> dict:
+    advisor = PolicyAdvisor(memory=memory, platform=platform, tie_delta=0.1)
+
+    pre_tie_break = [
+        {"bug_class": "calibration_drift", "confidence": 0.71},
+        {"bug_class": "sensor_timeout", "confidence": 0.69},
+    ]
+    post = advisor.apply_tie_break(list(pre_tie_break))
+
+    primed = advisor.prime_prompt_block(top_k=3)
+    return {
+        "case_key": "rtk_beta",
+        "pre_tie_break": pre_tie_break,
+        "post_tie_break": post,
+        "tie_break_applied": pre_tie_break != post,
+        "promoted": post[0]["bug_class"] if post else None,
+        "primed_prompt_block": primed,
+    }
+
+
+def _memory_used_panel(run1: dict, run2: dict) -> dict:
+    return {
+        "title": "Memory used",
+        "subtitle": "How priors from a prior session shaped this run.",
+        "evidence_chain": [
+            {
+                "from_case": run1["case_key"],
+                "prior_kind": "L3 taxonomy frequency + L2 platform prior",
+                "signature": "rtk_carr_soln_none_persistent → sensor_timeout",
+                "effect": (
+                    f"Tie-break promoted sensor_timeout over calibration_drift "
+                    f"(Δ confidence {run2['pre_tie_break'][0]['confidence']-run2['pre_tie_break'][1]['confidence']:+.2f}, "
+                    f"under tie_delta=0.10)."
+                ),
+            }
+        ],
+        "delta_summary": {
+            "without_memory_top": run2["pre_tie_break"][0]["bug_class"],
+            "with_memory_top": run2["post_tie_break"][0]["bug_class"],
+            "changed": run2["tie_break_applied"],
+        },
+        "primed_prompt_block_preview": run2["primed_prompt_block"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=Path("data/memory_loop_demo"))
+    args = parser.parse_args(argv)
+
+    out = args.out
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    mem_root = out / "_memory"
+    memory = MemoryStack.open(mem_root)
+
+    run1 = _seed_run1(memory)
+    (out / "run1_summary.json").write_text(json.dumps(run1, indent=2), encoding="utf-8")
+
+    run2 = _run2_with_advisor(memory)
+    (out / "run2_summary.json").write_text(json.dumps(run2, indent=2), encoding="utf-8")
+
+    panel = _memory_used_panel(run1, run2)
+    (out / "memory_used_panel.json").write_text(json.dumps(panel, indent=2), encoding="utf-8")
+
+    print(json.dumps({"run1": run1, "run2": run2, "panel": panel}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/black_box/reporting/memory_panel.py
+++ b/src/black_box/reporting/memory_panel.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+"""Renderer for the 'Memory used' panel (#76).
+
+Reads the deterministic JSON output of ``scripts/memory_loop_demo.py``
+(or any equivalent two-run capture) and renders a sober HTML fragment
+suitable for embedding in a report. The structure is intentionally
+compact: one chain of evidence + a delta summary the operator can
+verify at a glance.
+"""
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+
+def render_memory_used_panel(panel: dict[str, Any]) -> str:
+    title = escape(panel.get("title", "Memory used"))
+    subtitle = escape(panel.get("subtitle", ""))
+
+    chain_html = "".join(
+        f"<li><strong>From {escape(c.get('from_case',''))}</strong> "
+        f"<em>{escape(c.get('prior_kind',''))}</em>: "
+        f"<code>{escape(c.get('signature',''))}</code><br/>"
+        f"<span>{escape(c.get('effect',''))}</span></li>"
+        for c in panel.get("evidence_chain", [])
+    )
+
+    delta = panel.get("delta_summary", {})
+    delta_html = (
+        f"<table class='memory-delta'>"
+        f"<thead><tr><th>without memory</th><th>with memory</th><th>changed?</th></tr></thead>"
+        f"<tbody><tr>"
+        f"<td><code>{escape(str(delta.get('without_memory_top','')))}</code></td>"
+        f"<td><code>{escape(str(delta.get('with_memory_top','')))}</code></td>"
+        f"<td>{'✓' if delta.get('changed') else '—'}</td>"
+        f"</tr></tbody></table>"
+    )
+
+    primed = panel.get("primed_prompt_block_preview") or ""
+    primed_html = (
+        f"<details><summary>Primed prompt block</summary>"
+        f"<pre><code>{escape(str(primed))}</code></pre></details>"
+        if primed
+        else ""
+    )
+
+    return (
+        "<article class='memory-used-panel'>"
+        f"<header><h3>{title}</h3>"
+        f"{f'<p>{subtitle}</p>' if subtitle else ''}</header>"
+        f"<ol class='memory-chain'>{chain_html}</ol>"
+        f"{delta_html}"
+        f"{primed_html}"
+        "</article>"
+    )

--- a/tests/test_memory_loop_demo.py
+++ b/tests/test_memory_loop_demo.py
@@ -1,0 +1,67 @@
+"""#76 — visible memory loop end-to-end smoke."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_memory_loop_demo_run_executes(tmp_path):
+    out = tmp_path / "demo_out"
+    res = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "memory_loop_demo.py"), "--out", str(out)],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert (out / "run1_summary.json").exists()
+    assert (out / "run2_summary.json").exists()
+    assert (out / "memory_used_panel.json").exists()
+
+
+def test_run2_promotes_via_tie_break_with_memory(tmp_path):
+    out = tmp_path / "demo_out"
+    subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "memory_loop_demo.py"), "--out", str(out)],
+        cwd=str(ROOT),
+        check=True,
+        timeout=30,
+    )
+    panel = json.loads((out / "memory_used_panel.json").read_text(encoding="utf-8"))
+    delta = panel["delta_summary"]
+    assert delta["with_memory_top"] == "sensor_timeout"
+    assert delta["without_memory_top"] == "calibration_drift"
+    assert delta["changed"] is True
+
+
+def test_memory_panel_renders_html():
+    from black_box.reporting.memory_panel import render_memory_used_panel
+    panel = {
+        "title": "Memory used",
+        "subtitle": "From a prior session.",
+        "evidence_chain": [
+            {
+                "from_case": "rtk_alpha",
+                "prior_kind": "L3 taxonomy frequency",
+                "signature": "rtk_carr_soln_none_persistent → sensor_timeout",
+                "effect": "Tie-break promoted sensor_timeout over calibration_drift.",
+            }
+        ],
+        "delta_summary": {
+            "without_memory_top": "calibration_drift",
+            "with_memory_top": "sensor_timeout",
+            "changed": True,
+        },
+        "primed_prompt_block_preview": "Historical priors for platform `rover_av` ...",
+    }
+    html = render_memory_used_panel(panel)
+    for needle in ["Memory used", "rtk_alpha", "calibration_drift", "sensor_timeout", "✓"]:
+        assert needle in html


### PR DESCRIPTION
Closes #76. Deterministic, runs offline, ships under \$0.

## What ships
- `scripts/memory_loop_demo.py` — two-run sequence proving memory is read-and-applied:
  - **run 1** ('rtk_alpha'): top hypothesis `sensor_timeout` written into L1 case, L2 platform prior, L3 taxonomy count.
  - **run 2** ('rtk_beta'): hypotheses near-tied at 0.71 / 0.69 (Δ=0.02 < tie_delta=0.10). `PolicyAdvisor.apply_tie_break` uses run-1's L3 frequency to promote `sensor_timeout` → `calibration_drift`.
  - Outputs three JSON artifacts under `data/memory_loop_demo/`.
- `src/black_box/reporting/memory_panel.py` — renders the panel JSON as a sober HTML fragment (chain of evidence + without/with delta table + primed prompt block preview).
- `tests/test_memory_loop_demo.py` — 3 cases asserting the demo runs end-to-end and the with-memory result differs from without-memory.

```
$ python scripts/memory_loop_demo.py --out /tmp/demo
$ jq .delta_summary /tmp/demo/memory_used_panel.json
{
  "without_memory_top": "calibration_drift",
  "with_memory_top": "sensor_timeout",
  "changed": true
}
```

## Acceptance
- [x] Paired scenario shipped (rtk_alpha / rtk_beta).
- [x] Run 1 writes priors; Run 2 reads them.
- [x] Observable difference: tie-break resolved by historical frequency; surfaced in `memory_used_panel.json` and `render_memory_used_panel(...)` HTML.
- [x] Report panel: chain of evidence, prior_kind, signature, effect, delta table.
- [ ] Demo script update — left as a follow-up doc tweak so this PR stays small; the demo asset (`memory_used_panel.json`) is the artifact the demo script will reference.

## Why offline-only
The acceptance criterion is a *visible loop*, not a real Claude call. The offline path produces the exact same panel JSON shape the live `_run_pipeline_real` worker will emit; swapping the seeding step for a live two-bag run is a pure substitution. Keeps token spend at \$0 and gives CI a deterministic regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)