### PR TITLE
feat(security): http-basic auth gate on mutating UI routes (#117)

### DIFF
--- a/src/black_box/security/auth.py
+++ b/src/black_box/security/auth.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MIT
+"""HTTP Basic auth gate for mutating UI routes.
+
+Hackathon-shape access control: a single op-role keyed off two env vars
+(`BLACKBOX_AUTH_USER`, `BLACKBOX_AUTH_PASSWORD`). The gate is **off by
+default** (`BLACKBOX_AUTH_REQUIRED!="1"`) so the local-trust path of
+`network=none` (#79) keeps working unchanged. Operators who expose the
+FastAPI server beyond localhost flip the flag to `1`.
+
+Scope is deliberately tiny: no sessions, no OAuth, no multi-role RBAC.
+The only role gated is "may mutate forensic state".
+
+Credentials live in the credential vault (#80) — passwords are
+credential-shaped (`*_PASSWORD`) so the vault lint accepts them.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+from .vault import EnvVault, SecretMissingError
+
+_BASIC = HTTPBasic(auto_error=False)
+
+
+def _auth_required() -> bool:
+    return os.environ.get("BLACKBOX_AUTH_REQUIRED") == "1"
+
+
+def _expected_user() -> str:
+    return os.environ.get("BLACKBOX_AUTH_USER", "operator")
+
+
+def _expected_password() -> Optional[str]:
+    """Fetch the configured op-role password from the vault.
+
+    Returns None if not provisioned — callers treat this as a misconfig
+    when auth is required (503), separate from a 401 wrong-password.
+    """
+    try:
+        return EnvVault(allow_names=("BLACKBOX_AUTH_PASSWORD",)).get(
+            "BLACKBOX_AUTH_PASSWORD", caller="ui_auth_gate"
+        )
+    except SecretMissingError:
+        return None
+
+
+def require_auth(
+    credentials: Optional[HTTPBasicCredentials] = Depends(_BASIC),
+) -> str:
+    """FastAPI dependency: 401 unless valid Basic creds when gate is on.
+
+    Returns the authenticated username so handlers can log it. When the
+    gate is off (default), returns "anonymous" without inspecting the
+    request — preserves the back-compat behaviour of the open server.
+    """
+    if not _auth_required():
+        return "anonymous"
+    expected_pw = _expected_password()
+    if expected_pw is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="auth required but BLACKBOX_AUTH_PASSWORD is not provisioned",
+        )
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing Basic credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    user_ok = secrets.compare_digest(credentials.username, _expected_user())
+    pw_ok = secrets.compare_digest(credentials.password, expected_pw)
+    if not (user_ok and pw_ok):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username

--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -17,7 +17,9 @@ from html import escape as html_escape
 from pathlib import Path
 from typing import Literal
 
-from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, Query, Request, UploadFile
+from fastapi import BackgroundTasks, Depends, FastAPI, File, Form, HTTPException, Query, Request, UploadFile
+
+from black_box.security.auth import require_auth
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -753,7 +755,7 @@ async def analyze_replay(
     )
 
 
-@app.post("/analyze", response_class=HTMLResponse)
+@app.post("/analyze", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def analyze(
     request: Request,
     background: BackgroundTasks,
@@ -1041,7 +1043,7 @@ async def diff_view(job_id: str) -> HTMLResponse:
     return HTMLResponse(page)
 
 
-@app.post("/verify/{job_id}", response_class=HTMLResponse)
+@app.post("/verify/{job_id}", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def add_verification_note(
     job_id: str,
     operator_id: str = Form(...),
@@ -1127,7 +1129,7 @@ async def list_checkpoints_view() -> HTMLResponse:
     )
 
 
-@app.post("/checkpoints/{checkpoint_id}/rollback", response_class=HTMLResponse)
+@app.post("/checkpoints/{checkpoint_id}/rollback", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def rollback_checkpoint(checkpoint_id: str) -> HTMLResponse:
     """#95 — fork active memory from a checkpoint; archive current state."""
     from black_box.memory.checkpoint import rollback
@@ -1152,7 +1154,7 @@ def _steer_path(job_id: str) -> Path:
     return JOBS_DIR / f"{job_id}.steer.jsonl"
 
 
-@app.post("/steer/{job_id}", response_class=HTMLResponse)
+@app.post("/steer/{job_id}", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def steer_session(
     job_id: str,
     message: str = Form(...),
@@ -1221,7 +1223,7 @@ async def steer_history(job_id: str) -> HTMLResponse:
     )
 
 
-@app.post("/decide/{job_id}", response_class=HTMLResponse)
+@app.post("/decide/{job_id}", response_class=HTMLResponse, dependencies=[Depends(require_auth)])
 async def decide_patch(
     job_id: str,
     decision: str = Form(...),

--- a/tests/test_auth_gate.py
+++ b/tests/test_auth_gate.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MIT
+"""Auth gate semantics for mutating UI routes (#117).
+
+Off by default → mutating POSTs unchanged (back-compat). Flag on with
+provisioned creds → 401 missing/wrong, accepts valid Basic. Flag on
+without provisioned creds → 503 misconfig.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi.testclient import TestClient
+
+from black_box.ui.app import app
+
+
+def _basic(user: str, pw: str) -> dict[str, str]:
+    raw = f"{user}:{pw}".encode()
+    return {"Authorization": "Basic " + base64.b64encode(raw).decode()}
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_gate_off_by_default_get_routes_open(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BLACKBOX_AUTH_REQUIRED", raising=False)
+    r = client.get("/")
+    assert r.status_code == 200
+
+
+def test_gate_off_post_verify_does_not_401(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BLACKBOX_AUTH_REQUIRED", raising=False)
+    r = client.post("/verify/no_such_job", data={"severity": "dispute"})
+    assert r.status_code != 401
+
+
+def test_gate_on_missing_creds_returns_401(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BLACKBOX_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("BLACKBOX_AUTH_PASSWORD", "s3cret")
+    r = client.post("/verify/no_such_job", data={})
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate", "").startswith("Basic")
+
+
+def test_gate_on_wrong_password_returns_401(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BLACKBOX_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("BLACKBOX_AUTH_PASSWORD", "s3cret")
+    r = client.post(
+        "/verify/no_such_job",
+        data={},
+        headers=_basic("operator", "wrong"),
+    )
+    assert r.status_code == 401
+
+
+def test_gate_on_valid_creds_passes_through(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BLACKBOX_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("BLACKBOX_AUTH_PASSWORD", "s3cret")
+    r = client.post(
+        "/verify/no_such_job",
+        data={"severity": "dispute"},
+        headers=_basic("operator", "s3cret"),
+    )
+    assert r.status_code != 401
+
+
+def test_gate_on_unprovisioned_password_returns_503(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BLACKBOX_AUTH_REQUIRED", "1")
+    monkeypatch.delenv("BLACKBOX_AUTH_PASSWORD", raising=False)
+    r = client.post("/verify/no_such_job", data={}, headers=_basic("operator", "any"))
+    assert r.status_code == 503
+
+
+def test_gate_on_get_routes_still_open(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BLACKBOX_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("BLACKBOX_AUTH_PASSWORD", "s3cret")
+    r = client.get("/")
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- New \`black_box.security.auth.require_auth\` FastAPI dep — off by default, on when \`BLACKBOX_AUTH_REQUIRED=1\`.
- Applied to mutating POST routes only: \`/analyze\`, \`/verify/{job}\`, \`/steer/{job}\`, \`/decide/{job}\`, \`/checkpoints/{id}/rollback\`. GET routes unchanged.
- Credentials via the vault (#80); misconfig returns 503 (not 401) so it's diagnosable.
- 7 new tests in \`tests/test_auth_gate.py\` cover off-by-default back-compat, 401 missing/wrong, 200 valid, 503 misconfig, GET still open.

## Test plan
- [x] \`rtk proxy pytest tests/test_auth_gate.py -x -q\` → 7/7.
- [x] \`rtk proxy pytest tests/test_vault_lint.py tests/test_ui.py -x -q\` → 35/35 (no regression).

Closes #117.