### PR TITLE
feat(eval): overnight_batch flat-rtk npz loader + --single-case (#120)

### DIFF
--- a/data/bench_runs/batch_2026-04-25_dryrun/manifest.json
+++ b/data/bench_runs/batch_2026-04-25_dryrun/manifest.json
@@ -1,0 +1,26 @@
+{
+  "batch_id": "batch_2026-04-25_dryrun",
+  "mode": "dry-run",
+  "model": "claude-opus-4-7",
+  "started_utc": "2026-04-25T12:22:20.696753+00:00",
+  "finished_utc": "2026-04-25T12:22:20.697189+00:00",
+  "budget_usd": 50.0,
+  "baseline_cost_usd": 37.67704425000002,
+  "spent_usd": 0.0,
+  "n_cases": 1,
+  "n_match": 1,
+  "rows": [
+    {
+      "case_key": "rtk_heading_break_01",
+      "ground_truth_bug": "sensor_timeout",
+      "predicted_bug": "sensor_timeout",
+      "bug_class_match": true,
+      "confidence": 0.77,
+      "cost_usd": 0.0,
+      "wall_time_s": 0.0,
+      "status": "ok",
+      "source": "stub",
+      "notes": "dry-run: stub predictor echoed ground truth"
+    }
+  ]
+}

--- a/data/bench_runs/batch_2026-04-25_dryrun/rtk_heading_break_01.json
+++ b/data/bench_runs/batch_2026-04-25_dryrun/rtk_heading_break_01.json
@@ -1,0 +1,12 @@
+{
+  "case_key": "rtk_heading_break_01",
+  "ground_truth_bug": "sensor_timeout",
+  "predicted_bug": "sensor_timeout",
+  "bug_class_match": true,
+  "confidence": 0.77,
+  "cost_usd": 0.0,
+  "wall_time_s": 0.0,
+  "status": "ok",
+  "source": "stub",
+  "notes": "dry-run: stub predictor echoed ground truth"
+}

--- a/data/bench_runs/batch_2026-04-25_dryrun/table.md
+++ b/data/bench_runs/batch_2026-04-25_dryrun/table.md
@@ -1,0 +1,14 @@
+# Overnight batch: batch_2026-04-25_dryrun
+
+- mode: `dry-run`
+- model: `claude-opus-4-7`
+- started: 2026-04-25T12:22:20.696753+00:00
+- finished: 2026-04-25T12:22:20.697189+00:00
+- budget: $50.00 (baseline cumulative $37.677, spent this run $0.000)
+- cases: 1, matches: 1
+
+## Table
+
+| case | wall-s | $ | bug_class_match | top-hyp confidence |
+|---|---:|---:|:---:|---:|
+| rtk_heading_break_01 | 0.0 | 0.000 | OK | 0.77 |

--- a/data/bench_runs/batch_2026-04-25_dryrun/table.txt
+++ b/data/bench_runs/batch_2026-04-25_dryrun/table.txt
@@ -1,0 +1,3 @@
+case                 | wall-s | $     | bug_class_match | top-hyp confidence
+---------------------+--------+-------+-----------------+-------------------
+rtk_heading_break_01 | 0.0    | 0.000 | OK              | 0.77              

--- a/scripts/overnight_batch.py
+++ b/scripts/overnight_batch.py
@@ -193,6 +193,60 @@ def stub_predict(case: Path, gt: dict[str, Any]) -> CaseRow:
     )
 
 
+def load_telemetry_npz(npz_path: Path, np, TimeSeries) -> dict[str, Any]:
+    """Load telemetry.npz under either the prefixed or flat schema.
+
+    Two npz schemas are accepted:
+
+    1. Prefixed (run_opus_bench): ``<base>__t_ns``, ``<base>__values``,
+       ``<base>__fields`` — values is (N,D), fields names the columns.
+    2. Flat (rtk_heading_break_01 family): ``<prefix>_t_ns`` plus sibling
+       1-D scalar arrays ``<prefix>_<field>``. Stacked into a (N,D)
+       matrix at load time so downstream prompt code is uniform.
+    """
+    telemetry: dict[str, Any] = {}
+    z = np.load(npz_path, allow_pickle=True)
+    keys = list(z.files)
+    for key in keys:
+        if key.endswith("__t_ns"):
+            base = key[: -len("__t_ns")]
+            topic = "/" + base.replace(".", "/")
+            try:
+                fields = [str(f) for f in z[f"{base}__fields"].tolist()]
+                telemetry[topic] = TimeSeries(
+                    t_ns=z[f"{base}__t_ns"],
+                    values=z[f"{base}__values"],
+                    fields=fields,
+                )
+            except KeyError:
+                continue
+        elif key.endswith("_t_ns"):
+            base = key[: -len("_t_ns")]
+            if not base:
+                continue
+            t_ns = z[key]
+            siblings = [
+                k for k in keys
+                if k != key and k.startswith(base + "_") and not k.endswith("_t_ns")
+            ]
+            if not siblings:
+                continue
+            fields_list: list[str] = []
+            cols: list[Any] = []
+            for sk in sorted(siblings):
+                arr = z[sk]
+                if arr.ndim != 1 or arr.shape[0] != t_ns.shape[0]:
+                    continue
+                fields_list.append(sk[len(base) + 1 :])
+                cols.append(arr)
+            if not cols:
+                continue
+            values = np.column_stack(cols) if len(cols) > 1 else cols[0]
+            topic = "/" + base.replace("_", "/")
+            telemetry[topic] = TimeSeries(t_ns=t_ns, values=values, fields=fields_list)
+    return telemetry
+
+
 def claude_predict(case: Path, gt: dict[str, Any]) -> CaseRow:
     """Real Opus 4.7 post_mortem pass.
 
@@ -241,26 +295,8 @@ def claude_predict(case: Path, gt: dict[str, Any]) -> CaseRow:
             notes=f"import_error:{e!r}",
         )
 
-    # Load telemetry with the same prefixed-npz convention used by
-    # scripts/run_opus_bench.py. Cases whose npz layout the loader can't
-    # parse (e.g. rtk_heading_break_01) are flagged but not fatal.
-    telemetry: dict[str, Any] = {}
     try:
-        z = np.load(case / "telemetry.npz", allow_pickle=True)
-        for key in z.files:
-            if not key.endswith("__t_ns"):
-                continue
-            base = key[: -len("__t_ns")]
-            topic = "/" + base.replace(".", "/")
-            try:
-                fields = [str(f) for f in z[f"{base}__fields"].tolist()]
-                telemetry[topic] = TimeSeries(
-                    t_ns=z[f"{base}__t_ns"],
-                    values=z[f"{base}__values"],
-                    fields=fields,
-                )
-            except KeyError:
-                continue
+        telemetry = load_telemetry_npz(case / "telemetry.npz", np, TimeSeries)
     except Exception as e:
         return CaseRow(
             case_key=case.name,
@@ -404,7 +440,8 @@ def main(argv: list[str] | None = None) -> int:
                     help="Case directory. Default: black-box-bench/cases/.")
     ap.add_argument("--out-dir", type=Path, default=None,
                     help="Override output directory. Default: data/bench_runs/batch_<date>[_dryrun]/")
-    ap.add_argument("--only", default=None, help="Run a single case by key.")
+    ap.add_argument("--only", "--single-case", dest="only", default=None,
+                    help="Run a single case by key.")
     ap.add_argument("--suffix", default=None,
                     help="Extra suffix on the batch directory (e.g. 'v2').")
     args = ap.parse_args(argv)

--- a/tests/test_bench_runners.py
+++ b/tests/test_bench_runners.py
@@ -65,6 +65,42 @@ def test_rtk_heading_break_01_is_green_in_offline_tier1():
     assert row["match"] or row.get("skeleton"), row
 
 
+def test_overnight_batch_loads_flat_rtk_npz_schema():
+    """#120 — overnight_batch.load_telemetry_npz must parse rtk_heading_break_01."""
+    import importlib.util
+    import numpy as np
+    from black_box.ingestion.rosbag_reader import TimeSeries
+
+    spec = importlib.util.spec_from_file_location(
+        "overnight_batch_test_mod", ROOT / "scripts" / "overnight_batch.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["overnight_batch_test_mod"] = mod
+    spec.loader.exec_module(mod)
+    npz = ROOT / "black-box-bench" / "cases" / "rtk_heading_break_01" / "telemetry.npz"
+    telemetry = mod.load_telemetry_npz(npz, np, TimeSeries)
+    assert telemetry, "rtk flat-schema npz produced no topics — loader regressed"
+    assert any("rover" in topic for topic in telemetry), list(telemetry)
+    rover_topic = next(t for t in telemetry if "rover" in t)
+    ts = telemetry[rover_topic]
+    assert ts.t_ns.shape[0] > 0
+    assert "carr" in ts.fields or "fixType" in ts.fields, ts.fields
+
+
+def test_overnight_batch_single_case_alias():
+    """#120 — --single-case must be accepted as alias for --only."""
+    res = subprocess.run(
+        [sys.executable, "scripts/overnight_batch.py", "--dry-run",
+         "--single-case", "rtk_heading_break_01"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert res.returncode == 0, res.stderr
+    assert "rtk_heading_break_01" in res.stdout
+
+
 def test_public_asset_fetch_idempotent_with_cache(tmp_path, monkeypatch):
     from black_box.eval.public_data import PublicAsset, fetch_asset
 


### PR DESCRIPTION
## Summary
- \`scripts/overnight_batch.py\` previously could not parse \`rtk_heading_break_01\` telemetry — that case uses a flat npz schema (\`<prefix>_t_ns\` + sibling 1-D fields), not the prefixed \`<base>__t_ns / __values / __fields\` layout produced by \`run_opus_bench.py\`.
- Extracted loader to module-level \`load_telemetry_npz\` accepting both schemas; flat siblings get stacked into a (N,D) values matrix so downstream prompt code stays uniform.
- \`--single-case\` added as an alias for \`--only\` (issue called for the new flag name).
- 2 new regression tests in \`tests/test_bench_runners.py\`.

## Test plan
- [x] \`rtk proxy pytest tests/test_bench_runners.py -x -q\` → 7/7.
- Live-mode burn (real Opus call against rtk_heading_break_01) **not run** to preserve hackathon API budget; loader correctness is now verified by unit test against the actual fixture.

Closes #120.