### PR TITLE
feat(ui): wire live worker to consume steer.jsonl + exercise script (#129)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ Per #90: classify each script as **eval / demo / ops / dev** so evaluators can t
 | `hero_analysis.py` | eval | hero analysis driver wrapper. |
 | `hero_bag0_indoor.py` | eval | hero-case indoor variant (legacy). |
 | `managed_agent_smoke.py` | eval | smoke for the ForensicAgent / Managed Agents wiring. |
+| `exercise_steering_live.py` | eval | live verification of `/steer/{job_id}` consumer on the sanfer hero (#129). |
 | `analyze_bag.py` | eval | single-bag analysis (legacy v1). |
 | `analyze_bag_v2.py` | eval | single-bag analysis (current; v2). |
 | `memory_loop_demo.py` | demo | two-run sequence proving memory L1–L4 priors are read and applied (#76). |

--- a/scripts/exercise_steering_live.py
+++ b/scripts/exercise_steering_live.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: MIT
+"""Live exercise of the steering consumer (#129).
+
+Boots the FastAPI app on a private port, kicks off a real /analyze
+against a chosen bag (default: the sanfer hero bag), waits for the
+analyzing stage, posts a steer message, then watches the reasoning
+buffer for the corresponding ``[steer] -> agent`` line.
+
+This is the operator-on-API-budget verification that the consumer side
+of #105 works end-to-end. Unit tests already prove the wire (see
+``tests/test_steer_consumer.py``); this script is for the demo capture.
+
+Usage
+-----
+    export ANTHROPIC_API_KEY=...
+    python scripts/exercise_steering_live.py \
+        --bag data/bags/1_cam-lidar.bag \
+        --message "focus on RTK degradation window before the tunnel"
+
+Cost ceiling: bounded by the live worker's task budget (default 7 min)
+times Opus 4.7 list. Empirically <$5 on the sanfer hero. Abort with
+Ctrl-C is honoured — the worker drops to the ``failed`` stage cleanly.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_up(base: str, timeout: float = 30.0) -> None:
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        try:
+            with urllib.request.urlopen(base + "/", timeout=1.0) as r:
+                if r.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.4)
+    raise TimeoutError(f"uvicorn did not come up at {base}")
+
+
+def _post_form(url: str, fields: dict[str, str]) -> tuple[int, str]:
+    data = urllib.parse.urlencode(fields).encode()
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as r:
+            return r.status, r.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--bag", type=Path, default=ROOT / "data" / "bags" / "1_cam-lidar.bag")
+    p.add_argument(
+        "--message",
+        default="focus on RTK degradation window before the tunnel",
+        help="The steer message to inject mid-stream.",
+    )
+    p.add_argument("--steer-after-s", type=float, default=20.0,
+                   help="Seconds to wait after analyze before posting the steer.")
+    p.add_argument("--watch-window-s", type=float, default=180.0,
+                   help="Seconds to watch the reasoning buffer for confirmation.")
+    args = p.parse_args()
+
+    if "ANTHROPIC_API_KEY" not in os.environ:
+        print("ERROR: ANTHROPIC_API_KEY not set; this script is the live exercise.", file=sys.stderr)
+        return 2
+    if not args.bag.exists():
+        print(f"ERROR: bag not found: {args.bag}", file=sys.stderr)
+        return 2
+
+    port = _free_port()
+    base = f"http://127.0.0.1:{port}"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    env["BLACKBOX_REAL_PIPELINE"] = "1"
+
+    cmd = [
+        sys.executable, "-m", "uvicorn",
+        "black_box.ui.app:app",
+        "--host", "127.0.0.1", "--port", str(port),
+        "--log-level", "warning",
+    ]
+    proc = subprocess.Popen(cmd, env=env, cwd=str(ROOT))
+    try:
+        _wait_up(base)
+        job_id = "exercise" + uuid.uuid4().hex[:6]
+
+        # Multipart upload via stdlib
+        boundary = "----steerexercise"
+        body = (
+            f"--{boundary}\r\n"
+            f"Content-Disposition: form-data; name=\"file\"; filename=\"{args.bag.name}\"\r\n"
+            f"Content-Type: application/octet-stream\r\n\r\n"
+        ).encode()
+        body += args.bag.read_bytes()
+        body += f"\r\n--{boundary}\r\n".encode()
+        body += b"Content-Disposition: form-data; name=\"mode\"\r\n\r\npost_mortem\r\n"
+        body += f"--{boundary}--\r\n".encode()
+        req = urllib.request.Request(f"{base}/analyze?job_id={job_id}", data=body, method="POST")
+        req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+        with urllib.request.urlopen(req, timeout=120.0) as r:
+            print(f"analyze posted: status={r.status} job_id={job_id}")
+
+        print(f"sleeping {args.steer_after_s:.0f}s before posting steer...")
+        time.sleep(args.steer_after_s)
+        code, _ = _post_form(f"{base}/steer/{job_id}", {"message": args.message})
+        print(f"steer posted: status={code} message={args.message!r}")
+
+        deadline = time.time() + args.watch_window_s
+        seen = False
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(f"{base}/status/{job_id}.json" if False else f"{base}/status/{job_id}",
+                                            timeout=5.0) as r:
+                    body = r.read().decode("utf-8", errors="replace")
+                if f"[steer] -> agent: {args.message}" in body:
+                    seen = True
+                    print(f"CONFIRMED: steer line surfaced in /status after "
+                          f"{int(time.time() - deadline + args.watch_window_s)}s")
+                    break
+            except Exception as e:
+                print(f"poll error: {e!r}")
+            time.sleep(3.0)
+
+        if not seen:
+            print("FAILED: steer line never surfaced — drop the steering claim from the video.")
+            return 1
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -532,6 +532,32 @@ def _run_pipeline_real(job_id: str, upload_path: Path, mode: Mode) -> None:
         buffer.append(f"[agent] session_id={session.session_id}")
         _push("analyzing", "Claude is reviewing evidence", 0.25)
 
+        steer_path = _steer_path(job_id)
+        seen_steers = 0
+
+        def _drain_steers() -> None:
+            nonlocal seen_steers
+            if not steer_path.exists():
+                return
+            try:
+                lines = [ln for ln in steer_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+            except OSError:
+                return
+            for raw in lines[seen_steers:]:
+                try:
+                    rec = json.loads(raw)
+                    msg = (rec.get("message") or "").strip()
+                except (json.JSONDecodeError, AttributeError):
+                    msg = raw.strip()
+                if not msg:
+                    continue
+                try:
+                    session.steer(msg)
+                    buffer.append(f"[steer] -> agent: {msg}")
+                except Exception as se:
+                    buffer.append(f"[steer] FAILED ({se!r}): {msg}")
+            seen_steers = len(lines)
+
         event_count = 0
         for ev in session.stream():
             event_count += 1
@@ -541,6 +567,7 @@ def _run_pipeline_real(job_id: str, upload_path: Path, mode: Mode) -> None:
             stage, label = _REAL_STAGE_MAP.get(ev.get("type", ""), ("analyzing", "Claude is reviewing evidence"))
             # Coarse progress: 0.25 -> 0.75 across the stream; never regress.
             progress = min(0.75, 0.25 + 0.005 * event_count)
+            _drain_steers()
             _push(stage, label, progress)
 
         buffer.append("[finalize] Parsing agent report payload...")

--- a/tests/test_steer_consumer.py
+++ b/tests/test_steer_consumer.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: MIT
+"""Live-worker steering consumer (#129).
+
+PR #105 shipped the producer side: POST /steer/{job_id} writes to a
+JSONL audit. This file proves the consumer side: between agent-stream
+events, the live worker drains new steer entries and forwards them to
+ForensicSession.steer().
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+class _FakeSession:
+    """Drop-in for ForensicSession in _run_pipeline_real."""
+
+    def __init__(self) -> None:
+        self.session_id = "fake_session"
+        self.steers: list[str] = []
+        self._events: list[dict] = [
+            {"type": "agent.thinking", "text": "checking carrier-phase timeline"},
+            {"type": "agent.tool_call", "name": "read_telemetry"},
+            {"type": "agent.thinking", "text": "examining REL_POS_VALID flag"},
+            {"type": "agent.message", "text": "done"},
+        ]
+
+    def stream(self):
+        for ev in self._events:
+            yield ev
+
+    def steer(self, message: str) -> None:
+        self.steers.append(message)
+
+    def finalize(self) -> dict:
+        return {
+            "hypotheses": [{"bug_class": "sensor_timeout"}],
+            "patch_proposal": "",
+        }
+
+
+class _FakeAgent:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.session = _FakeSession()
+
+    def open_session(self, *, bag_path: Path, case_key: str):
+        return self.session
+
+
+def test_live_worker_drains_steer_jsonl_into_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from black_box.ui import app as ui_app
+
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "PATCHES_DIR", tmp_path)
+
+    fake_agent = _FakeAgent()
+    monkeypatch.setattr(
+        "black_box.analysis.managed_agent.ForensicAgent",
+        lambda *a, **kw: fake_agent,
+    )
+    monkeypatch.setattr(
+        "black_box.analysis.managed_agent.ForensicAgentConfig",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "black_box.reporting.build_report",
+        lambda **kw: kw["out_pdf"].write_text("# stub report"),
+    )
+
+    from black_box.ingestion.manifest import Manifest, TopicInfo
+    monkeypatch.setattr(
+        "black_box.ingestion.manifest.build_manifest",
+        lambda *a, **kw: Manifest(
+            root=tmp_path,
+            session_key="fake",
+            bags=[tmp_path / "fake.bag"],
+            duration_s=1.0,
+            t_start_ns=0,
+            t_end_ns=10**9,
+            cameras=[TopicInfo(topic="/cam1", msgtype="sensor_msgs/Image", count=10, kind="camera")],
+        ),
+    )
+
+    job_id = "jobsteer"
+    upload = tmp_path / "fake.bag"
+    upload.write_bytes(b"")
+
+    steer_path = tmp_path / f"{job_id}.steer.jsonl"
+    steer_path.write_text(
+        json.dumps({"message": "focus on RTK degradation window before the tunnel", "ts": 0}) + "\n"
+    )
+
+    ui_app._run_pipeline_real(job_id, upload, "post_mortem")
+
+    assert fake_agent.session.steers == ["focus on RTK degradation window before the tunnel"], (
+        f"expected one steer forwarded; got {fake_agent.session.steers}"
+    )
+    status = json.loads((tmp_path / f"{job_id}.json").read_text())
+    buf = "\n".join(status["reasoning_buffer"])
+    assert "[steer] -> agent: focus on RTK degradation" in buf, buf
+
+
+def test_live_worker_no_steer_file_no_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from black_box.ui import app as ui_app
+
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "PATCHES_DIR", tmp_path)
+
+    fake_agent = _FakeAgent()
+    monkeypatch.setattr(
+        "black_box.analysis.managed_agent.ForensicAgent",
+        lambda *a, **kw: fake_agent,
+    )
+    monkeypatch.setattr(
+        "black_box.analysis.managed_agent.ForensicAgentConfig",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "black_box.reporting.build_report",
+        lambda **kw: kw["out_pdf"].write_text("# stub report"),
+    )
+
+    from black_box.ingestion.manifest import Manifest, TopicInfo
+    monkeypatch.setattr(
+        "black_box.ingestion.manifest.build_manifest",
+        lambda *a, **kw: Manifest(
+            root=tmp_path,
+            session_key="fake",
+            bags=[tmp_path / "fake.bag"],
+            duration_s=1.0,
+            t_start_ns=0,
+            t_end_ns=10**9,
+            cameras=[TopicInfo(topic="/cam1", msgtype="sensor_msgs/Image", count=10, kind="camera")],
+        ),
+    )
+
+    job_id = "jobnone"
+    upload = tmp_path / "fake.bag"
+    upload.write_bytes(b"")
+
+    ui_app._run_pipeline_real(job_id, upload, "post_mortem")
+
+    assert fake_agent.session.steers == []
+
+
+def test_live_worker_drains_steer_added_mid_stream(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Steer file written after stream starts is still picked up before stream ends."""
+    from black_box.ui import app as ui_app
+
+    monkeypatch.setattr(ui_app, "JOBS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(ui_app, "PATCHES_DIR", tmp_path)
+
+    job_id = "jobmid"
+    steer_path = tmp_path / f"{job_id}.steer.jsonl"
+
+    class _MidStreamSession(_FakeSession):
+        def __init__(self, steer_target: Path) -> None:
+            super().__init__()
+            self._target = steer_target
+
+        def stream(self):
+            for i, ev in enumerate(self._events):
+                if i == 1:
+                    self._target.write_text(
+                        json.dumps({"message": "look at the second window", "ts": 1}) + "\n"
+                    )
+                yield ev
+
+    fake_agent = _FakeAgent()
+    fake_agent.session = _MidStreamSession(steer_path)
+    monkeypatch.setattr(
+        "black_box.analysis.managed_agent.ForensicAgent",
+        lambda *a, **kw: fake_agent,
+    )
+    monkeypatch.setattr(
+        "black_box.analysis.managed_agent.ForensicAgentConfig",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "black_box.reporting.build_report",
+        lambda **kw: kw["out_pdf"].write_text("# stub report"),
+    )
+
+    from black_box.ingestion.manifest import Manifest, TopicInfo
+    monkeypatch.setattr(
+        "black_box.ingestion.manifest.build_manifest",
+        lambda *a, **kw: Manifest(
+            root=tmp_path,
+            session_key="fake",
+            bags=[tmp_path / "fake.bag"],
+            duration_s=1.0,
+            t_start_ns=0,
+            t_end_ns=10**9,
+            cameras=[TopicInfo(topic="/cam1", msgtype="sensor_msgs/Image", count=10, kind="camera")],
+        ),
+    )
+
+    upload = tmp_path / "fake.bag"
+    upload.write_bytes(b"")
+    ui_app._run_pipeline_real(job_id, upload, "post_mortem")
+
+    assert fake_agent.session.steers == ["look at the second window"], (
+        f"steer added mid-stream should be drained; got {fake_agent.session.steers}"
+    )


### PR DESCRIPTION
## Summary
PR #105 shipped only the producer side of steering: \`POST /steer/{job_id}\` wrote to \`<job_id>.steer.jsonl\`, but **no consumer ever drained the file**. Live sessions ignored steer messages — the demo's "look at the second window" beat would have produced no observable effect.

This PR wires the consumer in \`_run_pipeline_real\`:
- Between every event yielded by \`session.stream()\`, drain new lines from \`steer.jsonl\`. Track high-water mark so each entry fires exactly once.
- For each new entry, call \`ForensicSession.steer(message)\` (Managed Agents \`user.message\` event) and append a \`[steer] -> agent: <msg>\` line into the reasoning buffer so the UI shows the inflection point.

## Tests
\`tests/test_steer_consumer.py\` — 3 tests, all pass:
- pre-stream entries forwarded.
- empty/no file → no-op.
- entries written mid-stream drained before stream ends.

## Live exercise
\`scripts/exercise_steering_live.py\` — operator-on-API-budget verification: boot UI, kick real \`/analyze\`, post steer, poll \`/status\` until the \`[steer]\` line surfaces. Cost ceiling <\$5 on the sanfer hero. Run before recording the demo to verify the steering beat is real before claiming it.

## Test plan
- [x] \`rtk proxy pytest tests/test_steer_consumer.py -x -q\` → 3/3.
- [x] \`rtk proxy pytest tests/test_ui.py -x -q\` → no regression.
- [ ] Operator: \`python scripts/exercise_steering_live.py --bag data/bags/1_cam-lidar.bag\` (manual, before final video cut).

Closes #129.