### PR TITLE
feat(memory): native managed-agents memory_stores alongside L1-L4 stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ flowchart TB
 
 **Shipped:** stack wiring, pydantic records, four independent stores, `MemoryStack.open()`, accuracy roll-ups by case and bug class, taxonomy counts on every finalize.
 
+**Native Managed Agents memory stores** sit alongside the local stack. Every `ForensicAgent.open_session(...)` provisions two `client.beta.memory_stores.*` resources mounted under `/mnt/memory/`: a shared `bb-platform-priors` store (read-only, seeded from the bug taxonomy and verified anti-hypotheses like the `rtk_heading_break_01` prior that refutes "GPS fails in tunnel"), and a fresh per-case `bb-forensic-learnings-{case_key}` store (read-write, case-isolated). Promotion of unverified content into the platform store is blocked by `promote_verified_priors_to_managed_memory` until a human writes a `severity="confirmation"` entry to the verification ledger. Beta header `managed-agents-2026-04-01`, model `claude-opus-4-7`. Details: [docs/MEMORY_STACK.md](docs/MEMORY_STACK.md#native-managed-agents-memory-stores).
+
 **Not yet shipped (roadmap):** the policy loop that reads L2 priors to bias the system prompt, uses L3 frequency as a tie-breaker on low-confidence hypotheses, and raises a regression alarm when L4 accuracy on a previously-solved case class drops below a threshold. Calling that "self-improving" would be overclaim until the loop is visible between runs.
 
 ## Grounding gate

--- a/docs/MEMORY_STACK.md
+++ b/docs/MEMORY_STACK.md
@@ -152,6 +152,86 @@ the v2 cached payload is below the minimum block size Anthropic accepts
 for caching. Fix is a one-line padding change; numbers above show the
 payoff.
 
+## Native Managed Agents memory stores
+
+The local L1-L4 stack drives the policy advisor and the Tier-1 prompt
+priors. Native Anthropic Managed Agents memory stores are a *separate*
+substrate that gives the in-session agent direct filesystem-like access at
+`/mnt/memory/` while the session is running. Both layers coexist; one does
+not replace the other.
+
+Wired in
+[`src/black_box/analysis/managed_agent.py`](../src/black_box/analysis/managed_agent.py)
+on top of `client.beta.memory_stores.*` (anthropic SDK, beta header
+`managed-agents-2026-04-01`, model `claude-opus-4-7`).
+
+Two stores are mounted on every `ForensicAgent.open_session(...)`:
+
+| Store | Access | Lifecycle | Mount path | Source of truth |
+|-------|--------|-----------|------------|-----------------|
+| `bb-platform-priors` | read_only | shared across all cases (idempotent — created once, reused thereafter) | `/mnt/memory/bb-platform-priors` | human-curated taxonomy + verified anti-hypotheses (e.g. the `rtk_heading_break_01` anti-prior that refutes "GPS fails in tunnel") |
+| `bb-forensic-learnings-{case_key}` | read_write | fresh per session — never reused across cases | `/mnt/memory/bb-forensic-learnings-<case_key>` | in-session agent scratchpad for signal-to-bug-class learnings |
+
+```mermaid
+flowchart LR
+    subgraph LOCAL[Local L1-L4 JSONL stack]
+        L1[L1 case]
+        L2[L2 platform priors]
+        L3[L3 taxonomy]
+        L4[L4 eval]
+    end
+
+    subgraph NATIVE[Native managed-agents memory stores]
+        RO[bb-platform-priors<br/>read-only<br/>shared across cases]
+        RW[bb-forensic-learnings-<br/>case_key<br/>read-write<br/>fresh per session]
+    end
+
+    LOCAL -- "drives PolicyAdvisor + prime_prompt_block" --> AGENT[ForensicAgent]
+    AGENT -- "open_session" --> NATIVE
+    NATIVE -- "/mnt/memory/" --> CLAUDE[Opus 4.7 in-session]
+    CLAUDE -. "verified L2/L3 entries" .-> GATE{human verification gate}
+    GATE -- confirmation severity --> RO
+```
+
+### The promotion gate
+
+`promote_verified_priors_to_managed_memory` in
+[`src/black_box/memory/verification.py`](../src/black_box/memory/verification.py)
+is the only sanctioned write path into the read-only platform store. It
+refuses to forward an entry into the SDK unless one of the following is
+true:
+
+1. The entry carries an explicit `verified=True` flag (used for
+   human-curated bootstrap seeds).
+2. The entry references an `analysis_id` for which the global
+   verification ledger contains at least one
+   `severity == "confirmation"` note.
+
+Otherwise it raises `UnverifiedMemoryPromotionError` *before* any SDK call.
+The platform store is never partially mutated by an unverified batch. This
+closes the loop: untrusted recording content (operator narratives,
+freshly-extracted hypotheses from a fresh bag) cannot reach the read-only
+store without a human writing a confirmation note first.
+
+The agent itself never calls this function — it is invoked from operator
+tooling after a verification ledger entry is filed.
+
+### Why both layers
+
+* **Local L1-L4** is the source of truth for the offline policy advisor,
+  regression alarms, and prompt priming. It survives reboots, is
+  inspectable in the repo, and is the audit log for cross-run learning.
+* **Native memory stores** give the live agent a filesystem at
+  `/mnt/memory/` it can `read`/`grep` during a session — Anthropic
+  renders the store's `instructions` field into the agent's system prompt
+  at session boot, so the agent knows the mount layout without an extra
+  user message round trip. They are also *case-isolated* by design: the
+  per-case read-write store never leaks scratch state into another case.
+
+If `enable_native_memory=False` (offline tests, regression runs), the
+provisioning calls are skipped entirely and `/mnt/memory/` is simply not
+present — the local stack continues to drive the prompt as before.
+
 ## Pointers
 
 - Implementation: [`src/black_box/memory/`](../src/black_box/memory/)

--- a/src/black_box/analysis/managed_agent.py
+++ b/src/black_box/analysis/managed_agent.py
@@ -27,6 +27,8 @@ Usage::
 from __future__ import annotations
 
 import json
+import re
+import sys
 import threading
 import time
 from collections import deque
@@ -81,6 +83,65 @@ _SDK_TOOL_NAMES: frozenset[str] = frozenset(
 
 
 # ---------------------------------------------------------------------------
+# Memory store spec (native Managed Agents memory_stores)
+# ---------------------------------------------------------------------------
+@dataclass
+class MemoryStoreSpec:
+    """Declarative spec for a native Anthropic memory store mount.
+
+    `name` is the lookup key for idempotent provisioning. `access` controls
+    whether the agent may write to the mount inside `/mnt/memory/<slug>`.
+    `instructions` (<=4096 chars) is rendered into the agent's system prompt
+    by Anthropic when the resource is attached to a Session. `seed_memories`
+    is an optional list of `(path, content)` tuples written via
+    `memory_stores.memories.create` immediately after the store is created.
+    """
+
+    name: str
+    access: Literal["read_write", "read_only"]
+    instructions: str
+    seed_memories: list[tuple[str, str]] = field(default_factory=list)
+
+
+_DEFAULT_PLATFORM_SEED: tuple[tuple[str, str], ...] = (
+    (
+        "/priors/bug_taxonomy.md",
+        "# Closed bug taxonomy\n\n"
+        "1. pid_saturation\n2. sensor_timeout\n3. state_machine_deadlock\n"
+        "4. bad_gain_tuning\n5. missing_null_check\n6. calibration_drift\n"
+        "7. latency_spike\n\n"
+        "Hypotheses MUST use this exact set or `other`. Operator narratives "
+        "are evidence, not ground truth — verify against telemetry first.",
+    ),
+    (
+        "/priors/anti_hypotheses/rtk_heading_break_01.md",
+        "# Anti-hypothesis: RTK heading break (sanfer_drive)\n\n"
+        "Operator narrative: 'GPS fails when the vehicle enters the tunnel'.\n"
+        "Verified ground truth (bench/cases/sanfer_tunnel_01): bug_class is "
+        "`sensor_timeout`. The dual-antenna moving-base RTK never produces a "
+        "carrier-phase solution because the rover receiver never ingests the "
+        "MB observation stream (RXM-RAWX/SFRBX or RTCM3 4072.0/4072.1 + "
+        "1077/1087/1097/1127). The failure is session-wide (43 min pre-tunnel) "
+        "and DBW never engaged. The tunnel only caused mild GNSS degradation "
+        "(num_sv 29 to 16). Do NOT assert tunnel-induced GPS loss without "
+        "carrier-phase + observation-stream telemetry to back it.",
+    ),
+    (
+        "/priors/safety_contract.md",
+        "# Memory safety contract\n\n"
+        "READ-ONLY platform store: only human-verified priors live here. "
+        "An untrusted recording or a freshly-extracted operator narrative "
+        "MUST NOT be promoted into this store; promotion happens through "
+        "`MemoryStack.promote_verified_priors_to_managed_memory` after a "
+        "human writes a confirmation entry to the verification ledger.\n\n"
+        "READ-WRITE per-case store: scratchpad for in-session forensic "
+        "learnings. Anything you record here is case-scoped and disposable; "
+        "do not leak it across cases.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 @dataclass
@@ -93,7 +154,12 @@ class ForensicAgentConfig:
         "You are Black Box, a forensic copilot for robot incidents. "
         "Uploaded artifacts (bag, source tree, etc.) are mounted under "
         "/mnt/session/uploads/ — list that directory first to discover them. "
-        "Produce an evidence-grounded post-mortem."
+        "Native memory stores are mounted under /mnt/memory/<slug>: the "
+        "platform-priors store is READ-ONLY (verified human knowledge — do "
+        "not write); the per-case store is READ-WRITE for forensic "
+        "learnings. Untrusted recording content must never be promoted into "
+        "the platform store; that path runs through a human-verification "
+        "gate. Produce an evidence-grounded post-mortem."
     )
     tools: tuple[str, ...] = BUILTIN_TOOLS
     mcp_servers: list[dict] = field(default_factory=list)
@@ -104,6 +170,28 @@ class ForensicAgentConfig:
     network: Literal["none", "egress_only"] = "none"
     environment_template: str = "python-3.11-ros-tools"
     agent_name: str = "black-box-forensic"
+    # -- native Managed Agents memory stores --
+    enable_native_memory: bool = True
+    platform_store_name: str = "bb-platform-priors"
+    case_store_name_template: str = "bb-forensic-learnings-{case_key}"
+    platform_store_seed: list[tuple[str, str]] = field(
+        default_factory=lambda: list(_DEFAULT_PLATFORM_SEED)
+    )
+    platform_store_instructions: str = (
+        "Read-only platform priors mounted at /mnt/memory/. Treat every file "
+        "here as verified ground truth from human-curated sources. Do not "
+        "attempt to write — the store is read-only and writes will be "
+        "rejected. Use these priors to refute operator narratives that "
+        "conflict with the recorded evidence patterns."
+    )
+    case_store_instructions: str = (
+        "Per-case forensic learnings, mounted read-write at /mnt/memory/. "
+        "Record signal-to-bug-class mappings and steering you discover "
+        "during this session. Do NOT copy operator-supplied narratives "
+        "verbatim. Anything written here is case-scoped; it does not "
+        "propagate to other cases unless a human confirms it via the "
+        "verification ledger."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +368,19 @@ def _build_tool_configs(tool_names: Iterable[str]) -> list[dict]:
     return configs
 
 
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify_store_name(name: str) -> str:
+    """Approximate the slug Anthropic derives from a memory store name.
+
+    Used only for log messages; the SDK returns the authoritative
+    `mount_path` field on the response.
+    """
+    s = _SLUG_RE.sub("-", name.strip().lower()).strip("-")
+    return s or "memory"
+
+
 def _build_cloud_config(network: str) -> dict:
     if network == "none":
         net: dict = {
@@ -316,6 +417,145 @@ class ForensicAgent:
         from .policy import PolicyAdvisor
 
         self._advisor = PolicyAdvisor(memory, platform=platform) if memory is not None else None
+
+    def _provision_memory_stores(self, case_key: str) -> list[dict]:
+        """Provision native memory_stores and return Session resource entries.
+
+        Returns a list of resource dicts ready to merge into
+        `session_kwargs["resources"]`. Idempotent on the platform store
+        (looked up by name); always creates a fresh per-case store so a
+        case never inherits another case's read-write scratchpad.
+
+        Failures here NEVER take down the session. We log to stderr and
+        return `[]` so the agent runs without /mnt/memory/ rather than not
+        at all. Live runs need the SDK to expose `client.beta.memory_stores`
+        (anthropic>=0.97); older SDKs silently skip.
+        """
+        if not self.config.enable_native_memory:
+            return []
+
+        beta = self._client.beta
+        stores_api = getattr(beta, "memory_stores", None)
+        if stores_api is None:
+            print(
+                "[managed_agent] beta.memory_stores not available on this "
+                "Anthropic SDK; running without native /mnt/memory/.",
+                file=sys.stderr,
+            )
+            return []
+
+        resources: list[dict] = []
+
+        try:
+            platform_store = self._find_or_create_platform_store(stores_api)
+            if platform_store is not None:
+                resources.append(
+                    {
+                        "type": "memory_store",
+                        "memory_store_id": platform_store.id,
+                        "access": "read_only",
+                        "instructions": self.config.platform_store_instructions[:4096],
+                    }
+                )
+        except Exception as exc:
+            print(
+                f"[managed_agent] platform memory_store provisioning failed: "
+                f"{exc}; continuing without it.",
+                file=sys.stderr,
+            )
+
+        try:
+            case_store = self._create_case_store(stores_api, case_key)
+            if case_store is not None:
+                resources.append(
+                    {
+                        "type": "memory_store",
+                        "memory_store_id": case_store.id,
+                        "access": "read_write",
+                        "instructions": self.config.case_store_instructions[:4096],
+                    }
+                )
+        except Exception as exc:
+            print(
+                f"[managed_agent] per-case memory_store provisioning failed: "
+                f"{exc}; continuing without it.",
+                file=sys.stderr,
+            )
+
+        return resources
+
+    def _find_or_create_platform_store(self, stores_api):
+        existing = self._lookup_store_by_name(stores_api, self.config.platform_store_name)
+        if existing is not None:
+            return existing
+
+        _CREATE_LIMITER.acquire()
+        store = _wrap_call(
+            "memory_stores.create",
+            stores_api.create,
+            name=self.config.platform_store_name,
+            description=(
+                "Read-only platform priors. Verified human-curated knowledge only."
+            ),
+            metadata={"role": "platform_priors", "owner": "black_box"},
+        )
+
+        memories_api = getattr(stores_api, "memories", None)
+        if memories_api is not None:
+            for path, content in self.config.platform_store_seed:
+                try:
+                    _CREATE_LIMITER.acquire()
+                    _wrap_call(
+                        "memory_stores.memories.create",
+                        memories_api.create,
+                        memory_store_id=store.id,
+                        path=path,
+                        content=content,
+                    )
+                except Exception as exc:
+                    print(
+                        f"[managed_agent] failed to seed platform memory "
+                        f"{path!r}: {exc}",
+                        file=sys.stderr,
+                    )
+
+        return store
+
+    def _create_case_store(self, stores_api, case_key: str):
+        case_name = self.config.case_store_name_template.format(case_key=case_key)
+        _CREATE_LIMITER.acquire()
+        return _wrap_call(
+            "memory_stores.create",
+            stores_api.create,
+            name=case_name,
+            description=(
+                f"Per-case forensic learnings for {case_key}. Read-write "
+                "scratchpad scoped to this incident."
+            ),
+            metadata={
+                "role": "case_learnings",
+                "case_key": case_key,
+                "owner": "black_box",
+            },
+        )
+
+    @staticmethod
+    def _lookup_store_by_name(stores_api, name: str):
+        _READ_LIMITER.acquire()
+        try:
+            page = stores_api.list()
+        except Exception as exc:
+            raise RuntimeError(f"memory_stores.list failed: {exc}") from exc
+        items = getattr(page, "data", None)
+        if items is None:
+            try:
+                items = list(page)
+            except TypeError:
+                items = []
+        for item in items:
+            if getattr(item, "name", None) == name:
+                return item
+        return None
 
     def open_session(self, bag_path: Path, case_key: str) -> "ForensicSession":
         beta = self._client.beta
@@ -378,14 +618,17 @@ class ForensicAgent:
         _CREATE_LIMITER.acquire()
         agent = _wrap_call("agents.create", beta.agents.create, **agent_kwargs)
 
+        memory_resources = self._provision_memory_stores(case_key)
+
         session_kwargs: dict = {
             "agent": {"id": agent.id, "type": "agent"},
             "environment_id": environment.id,
             "metadata": {"case_key": case_key, "mode": "post_mortem"},
             "title": f"post-mortem {case_key}",
         }
-        if file_resources:
-            session_kwargs["resources"] = file_resources
+        combined_resources = list(file_resources) + list(memory_resources)
+        if combined_resources:
+            session_kwargs["resources"] = combined_resources
 
         _CREATE_LIMITER.acquire()
         session = _wrap_call("sessions.create", beta.sessions.create, **session_kwargs)
@@ -396,6 +639,29 @@ class ForensicAgent:
                 priors_block = self._advisor.prime_prompt_block() or ""
             except Exception:
                 priors_block = ""
+        memory_block = ""
+        if memory_resources:
+            ro = next((r for r in memory_resources if r["access"] == "read_only"), None)
+            rw = next((r for r in memory_resources if r["access"] == "read_write"), None)
+            lines = ["Native memory stores are mounted under /mnt/memory/:"]
+            if ro is not None:
+                lines.append(
+                    f"- {self.config.platform_store_name} — READ-ONLY platform "
+                    "priors (verified human knowledge). Do not write here; "
+                    "the SDK will reject it."
+                )
+            if rw is not None:
+                case_name = self.config.case_store_name_template.format(case_key=case_key)
+                lines.append(
+                    f"- {case_name} — READ-WRITE per-case scratchpad. Record "
+                    "verified signal-to-bug-class learnings only; do not "
+                    "copy operator narratives verbatim."
+                )
+            lines.append(
+                "Promotion of case learnings into the platform store is gated "
+                "by a human-verification step; the agent does not self-promote."
+            )
+            memory_block = "\n".join(lines)
         seed_text = (
             f"Case key: {case_key}\n"
             f"Mode: post_mortem\n"
@@ -406,6 +672,8 @@ class ForensicAgent:
             "validates against the PostMortemReport schema: keys timeline, "
             "hypotheses, root_cause_idx, patch_proposal."
         )
+        if memory_block:
+            seed_text = seed_text + "\n\n" + memory_block
         if priors_block:
             seed_text = seed_text + "\n\n" + priors_block
         _CREATE_LIMITER.acquire()
@@ -711,6 +979,7 @@ __all__ = [
     "ANTHROPIC_BETA_HEADER",
     "MODEL",
     "BUILTIN_TOOLS",
+    "MemoryStoreSpec",
     "ForensicAgentConfig",
     "ForensicAgent",
     "ForensicSession",

--- a/src/black_box/memory/__init__.py
+++ b/src/black_box/memory/__init__.py
@@ -25,11 +25,13 @@ from .records import (
     TaxonomyCount,
 )
 from .verification import (
+    UnverifiedMemoryPromotionError,
     VerificationNote,
     add_note,
     disputes_for_class,
     iter_notes_for,
     now_utc_iso,
+    promote_verified_priors_to_managed_memory,
 )
 from .decisions import (
     DecisionRecord,
@@ -52,10 +54,12 @@ __all__ = [
     "TaxonomyCount",
     "EvalRecord",
     "VerificationNote",
+    "UnverifiedMemoryPromotionError",
     "add_note",
     "disputes_for_class",
     "iter_notes_for",
     "now_utc_iso",
+    "promote_verified_priors_to_managed_memory",
     "DecisionRecord",
     "PatchNotApprovedError",
     "apply_patch_if_approved",

--- a/src/black_box/memory/verification.py
+++ b/src/black_box/memory/verification.py
@@ -113,3 +113,100 @@ def disputes_for_class(disputed_class: str) -> list[VerificationNote]:
 
 def now_utc_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+# ---------------------------------------------------------------------------
+# Promotion gate for native managed-agents memory stores
+# ---------------------------------------------------------------------------
+class UnverifiedMemoryPromotionError(RuntimeError):
+    """Raised when promotion to the read-only platform store is attempted
+    with an entry that is not flagged as human-verified.
+
+    The native platform store represents verified human-curated knowledge.
+    Promoting unverified L1 case records or freshly-extracted operator
+    narratives into it would defeat the safety contract. This error is
+    deliberately loud — callers must opt in by either passing
+    `verified=True` per-entry or by sourcing entries from the global
+    verification ledger with `severity == "confirmation"`.
+    """
+
+
+def promote_verified_priors_to_managed_memory(
+    client,
+    store_id: str,
+    verified_priors: list[dict],
+    *,
+    require_verified: bool = True,
+) -> list[str]:
+    """Write human-verified priors into the read-only platform memory store.
+
+    `verified_priors` is a list of dicts shaped like:
+        {"path": "/priors/foo.md", "content": "...", "verified": True}
+
+    Each entry is rejected unless ``verified is True`` OR the entry
+    references an analysis_id whose verification ledger contains a
+    `severity == "confirmation"` note. Failures raise
+    `UnverifiedMemoryPromotionError` BEFORE any SDK call; the platform
+    store is never partially mutated by an unverified batch.
+
+    This is the load-bearing safety contract: untrusted recording content
+    cannot reach the platform store without passing through the human
+    ledger.
+    """
+    stores_api = getattr(getattr(client, "beta", None), "memory_stores", None)
+    if stores_api is None:
+        raise RuntimeError(
+            "client.beta.memory_stores is not available; cannot promote priors."
+        )
+    memories_api = getattr(stores_api, "memories", None)
+    if memories_api is None:
+        raise RuntimeError(
+            "client.beta.memory_stores.memories is not available; cannot promote priors."
+        )
+
+    # Validate the whole batch before mutating.
+    for prior in verified_priors:
+        path = prior.get("path")
+        content = prior.get("content")
+        if not path or content is None:
+            raise ValueError(
+                f"prior must include 'path' and 'content' keys; got {prior!r}"
+            )
+        if require_verified and not _is_verified(prior):
+            raise UnverifiedMemoryPromotionError(
+                f"refusing to promote {path!r}: entry is not flagged "
+                "verified=True and has no confirmation note in the "
+                "verification ledger. Untrusted recording content cannot "
+                "reach the platform store."
+            )
+
+    written: list[str] = []
+    for prior in verified_priors:
+        result = memories_api.create(
+            memory_store_id=store_id,
+            path=prior["path"],
+            content=prior["content"],
+        )
+        rid = getattr(result, "id", None)
+        if rid is not None:
+            written.append(rid)
+    return written
+
+
+def _is_verified(prior: dict) -> bool:
+    """An entry passes the gate if either:
+
+    1. It carries an explicit ``verified=True`` flag (caller takes
+       responsibility — used for human-curated bootstrap seeds), OR
+    2. Its `analysis_id` has at least one `severity == "confirmation"`
+       note in the global verification ledger.
+    """
+    if prior.get("verified") is True:
+        return True
+    analysis_id = prior.get("analysis_id")
+    if not analysis_id:
+        return False
+    for note in iter_notes_for(analysis_id):
+        if getattr(note, "severity", None) == "confirmation":
+            return True
+    return False

--- a/tests/test_memory_stores.py
+++ b/tests/test_memory_stores.py
@@ -1,0 +1,443 @@
+"""Tests for native Anthropic Managed Agents memory_stores wiring.
+
+Covers:
+  * idempotent platform-store provisioning (lookup before create)
+  * fresh per-case store on every session (case isolation)
+  * session resources include both read_only + read_write entries
+  * `enable_native_memory=False` short-circuits the API
+  * safety gate refuses unverified promotion to platform store
+  * a freshly-extracted "operator says X" hypothesis cannot auto-promote
+
+All Anthropic SDK calls are stubbed; nothing hits the network.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from black_box.analysis import managed_agent as ma
+from black_box.analysis.managed_agent import (
+    ForensicAgent,
+    ForensicAgentConfig,
+    MemoryStoreSpec,
+)
+from black_box.memory import (
+    UnverifiedMemoryPromotionError,
+    promote_verified_priors_to_managed_memory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+class _FakeMemoriesAPI:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+
+    def create(self, *, memory_store_id, path, content, **_):
+        rec = {"memory_store_id": memory_store_id, "path": path, "content": content}
+        self.created.append(rec)
+        return SimpleNamespace(
+            id=f"mem_{len(self.created):04d}",
+            memory_store_id=memory_store_id,
+            path=path,
+        )
+
+
+class _FakeMemoryStoresAPI:
+    def __init__(self, preexisting: list[SimpleNamespace] | None = None) -> None:
+        self._stores: list[SimpleNamespace] = list(preexisting or [])
+        self.created: list[dict] = []
+        self.list_calls = 0
+        self.memories = _FakeMemoriesAPI()
+
+    def list(self):
+        self.list_calls += 1
+        return SimpleNamespace(data=list(self._stores))
+
+    def create(self, *, name, description=None, metadata=None, **_):
+        store = SimpleNamespace(
+            id=f"memstore_{len(self._stores) + 1:04d}",
+            name=name,
+            description=description,
+            metadata=metadata or {},
+            mount_path=f"/mnt/memory/{name}",
+        )
+        self._stores.append(store)
+        self.created.append(
+            {"name": name, "description": description, "metadata": metadata}
+        )
+        return store
+
+
+class _FakeFiles:
+    def upload(self, *, file, **_):
+        name = file[0] if isinstance(file, tuple) else "blob"
+        return SimpleNamespace(id=f"file_{name}", filename=name)
+
+
+class _FakeEnvironments:
+    def create(self, **kwargs):
+        return SimpleNamespace(id="env_abc", name=kwargs.get("name"))
+
+
+class _FakeAgents:
+    def create(self, **kwargs):
+        return SimpleNamespace(id="agent_xyz", **{k: v for k, v in kwargs.items() if k != "betas"})
+
+
+class _FakeEvents:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    def send(self, *, session_id, events, **_):
+        self.sent.append({"session_id": session_id, "events": list(events)})
+        return SimpleNamespace(ok=True)
+
+    def stream(self, *, session_id, **_):
+        return iter([])
+
+    def list(self, *, session_id, order="asc", limit=100, **_):
+        return SimpleNamespace(data=[])
+
+
+class _FakeSessions:
+    def __init__(self, events) -> None:
+        self.events = events
+        self.created: list[dict] = []
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(id="session_123")
+
+    def retrieve(self, session_id, **_):
+        return SimpleNamespace(id=session_id, status="idle", usage=None)
+
+
+class _FakeBeta:
+    def __init__(self, *, memory_stores: _FakeMemoryStoresAPI | None) -> None:
+        self.files = _FakeFiles()
+        self.environments = _FakeEnvironments()
+        self.agents = _FakeAgents()
+        events = _FakeEvents()
+        self.sessions = _FakeSessions(events)
+        self.sessions.events = events
+        if memory_stores is not None:
+            self.memory_stores = memory_stores
+
+
+class _FakeClient:
+    def __init__(self, *, memory_stores: _FakeMemoryStoresAPI | None) -> None:
+        self.beta = _FakeBeta(memory_stores=memory_stores)
+
+
+# ---------------------------------------------------------------------------
+# Provisioning tests
+# ---------------------------------------------------------------------------
+def test_platform_store_is_reused_when_it_already_exists(tmp_path: Path):
+    existing = SimpleNamespace(
+        id="memstore_existing",
+        name="bb-platform-priors",
+        mount_path="/mnt/memory/bb-platform-priors",
+    )
+    stores = _FakeMemoryStoresAPI(preexisting=[existing])
+    client = _FakeClient(memory_stores=stores)
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"x")
+
+    agent = ForensicAgent(
+        config=ForensicAgentConfig(task_budget_minutes=1),
+        client=client,
+    )
+    agent.open_session(bag_path=bag, case_key="crash_001")
+
+    # Platform store reused — only the per-case store should have been created.
+    case_creates = [c for c in stores.created if c["name"] != "bb-platform-priors"]
+    platform_creates = [c for c in stores.created if c["name"] == "bb-platform-priors"]
+    assert platform_creates == []  # idempotent
+    assert len(case_creates) == 1  # fresh per-case store
+    assert case_creates[0]["name"].startswith("bb-forensic-learnings-crash_001")
+    # No seed memories were written to a reused platform store.
+    assert stores.memories.created == []
+
+
+def test_platform_store_is_created_and_seeded_when_absent(tmp_path: Path):
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"x")
+
+    agent = ForensicAgent(
+        config=ForensicAgentConfig(task_budget_minutes=1),
+        client=client,
+    )
+    agent.open_session(bag_path=bag, case_key="crash_002")
+
+    names_created = [c["name"] for c in stores.created]
+    assert "bb-platform-priors" in names_created
+    # Seed memories were written on first creation.
+    seed_paths = [m["path"] for m in stores.memories.created]
+    assert any("anti_hypotheses/rtk_heading_break" in p for p in seed_paths)
+    assert any("bug_taxonomy" in p for p in seed_paths)
+
+
+def test_per_case_store_is_fresh_each_session(tmp_path: Path):
+    """Two sessions with the same case_key still create distinct case stores.
+
+    Case isolation is the safety contract: a case store is a read-write
+    scratchpad, so reuse across sessions would leak state across runs.
+    """
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"x")
+
+    cfg = ForensicAgentConfig(task_budget_minutes=1)
+    ForensicAgent(config=cfg, client=client).open_session(bag_path=bag, case_key="case_a")
+    ForensicAgent(config=cfg, client=client).open_session(bag_path=bag, case_key="case_a")
+
+    case_creates = [c for c in stores.created if "forensic-learnings" in c["name"]]
+    # Two separate creations even though the case_key is identical.
+    assert len(case_creates) == 2
+
+
+def test_session_resources_include_read_only_and_read_write(tmp_path: Path):
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"x")
+
+    agent = ForensicAgent(
+        config=ForensicAgentConfig(task_budget_minutes=1),
+        client=client,
+    )
+    agent.open_session(bag_path=bag, case_key="crash_003")
+
+    session_kwargs = client.beta.sessions.created[0]
+    resources = session_kwargs["resources"]
+    types_seen = {r["type"] for r in resources}
+    assert "memory_store" in types_seen
+    accesses = {r["access"] for r in resources if r["type"] == "memory_store"}
+    assert accesses == {"read_only", "read_write"}
+    # Both have non-empty instructions and they fit the 4096-char ceiling.
+    for r in resources:
+        if r["type"] == "memory_store":
+            assert r["instructions"]
+            assert len(r["instructions"]) <= 4096
+
+
+def test_seed_text_mentions_mount_path_and_human_gate(tmp_path: Path):
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"x")
+
+    agent = ForensicAgent(
+        config=ForensicAgentConfig(task_budget_minutes=1),
+        client=client,
+    )
+    agent.open_session(bag_path=bag, case_key="crash_004")
+
+    seed_text = client.beta.sessions.events.sent[0]["events"][0]["content"][0]["text"]
+    assert "/mnt/memory/" in seed_text
+    assert "READ-ONLY" in seed_text
+    assert "READ-WRITE" in seed_text
+    assert "human-verification" in seed_text
+
+
+def test_enable_native_memory_false_skips_api_calls(tmp_path: Path):
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"x")
+
+    agent = ForensicAgent(
+        config=ForensicAgentConfig(task_budget_minutes=1, enable_native_memory=False),
+        client=client,
+    )
+    agent.open_session(bag_path=bag, case_key="crash_off")
+
+    assert stores.created == []
+    assert stores.list_calls == 0
+    # Session should still have file resources but no memory_store entries.
+    session_kwargs = client.beta.sessions.created[0]
+    resources = session_kwargs.get("resources", [])
+    assert all(r["type"] != "memory_store" for r in resources)
+
+
+def test_provisioning_failure_falls_back_gracefully(tmp_path: Path):
+    """If memory_stores.list raises, the session still launches.
+
+    The senior reviewer's call: native memory is a strict bonus; an outage
+    should not take the whole forensic session down.
+    """
+    class _BoomStores(_FakeMemoryStoresAPI):
+        def list(self):
+            raise RuntimeError("simulated outage")
+
+    stores = _BoomStores(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+    bag = tmp_path / "crash.bag"
+    bag.write_bytes(b"x")
+
+    agent = ForensicAgent(
+        config=ForensicAgentConfig(task_budget_minutes=1),
+        client=client,
+    )
+    # Should not raise; session is still created without memory_store resources.
+    agent.open_session(bag_path=bag, case_key="crash_boom")
+    session_kwargs = client.beta.sessions.created[0]
+    resources = session_kwargs.get("resources", [])
+    # Platform path raised; per-case path will still attempt and may succeed,
+    # but we explicitly assert at least no platform read_only resource leaked.
+    accesses = {r["access"] for r in resources if r.get("type") == "memory_store"}
+    assert "read_only" not in accesses
+
+
+# ---------------------------------------------------------------------------
+# Safety gate tests
+# ---------------------------------------------------------------------------
+def test_safety_gate_rejects_unverified_promotion(tmp_path: Path):
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+
+    operator_says = {
+        "path": "/priors/operator_narrative_2026.md",
+        "content": "Operator says: GPS fails inside the tunnel.",
+        # No `verified=True` and no analysis_id with a confirmation note.
+    }
+
+    with pytest.raises(UnverifiedMemoryPromotionError):
+        promote_verified_priors_to_managed_memory(
+            client=client,
+            store_id="memstore_platform",
+            verified_priors=[operator_says],
+        )
+
+    # Nothing was written even partially.
+    assert stores.memories.created == []
+
+
+def test_safety_gate_accepts_explicit_verified_flag(tmp_path: Path):
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+
+    prior = {
+        "path": "/priors/sanfer_rtk.md",
+        "content": "RTK heading break — sensor_timeout, refutes operator narrative.",
+        "verified": True,
+    }
+    written = promote_verified_priors_to_managed_memory(
+        client=client,
+        store_id="memstore_platform",
+        verified_priors=[prior],
+    )
+    assert len(written) == 1
+    assert stores.memories.created[0]["path"] == "/priors/sanfer_rtk.md"
+
+
+def test_safety_gate_accepts_confirmation_note_in_ledger(tmp_path: Path, monkeypatch):
+    """A prior referencing an analysis_id with a `severity='confirmation'`
+    note in the verification ledger passes the gate without `verified=True`.
+    """
+    from black_box.memory import VerificationNote, add_note
+
+    fake_ledger = tmp_path / "verification.jsonl"
+
+    monkeypatch.setattr(
+        "black_box.memory.verification._global_ledger_path",
+        lambda: fake_ledger,
+    )
+
+    note = VerificationNote(
+        analysis_id="case_sanfer_42",
+        operator_id="aayush@morgan.edu",
+        written_at="2026-04-23T12:00:00+00:00",
+        agent_conclusion="bug_class=sensor_timeout",
+        real_cause="confirmed: rover never ingested MB observation stream",
+        disputed_class=None,
+        severity="confirmation",
+    )
+    add_note(tmp_path / "case_sanfer_42", note)
+
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+
+    prior = {
+        "path": "/priors/case_sanfer_42.md",
+        "content": "Verified: sensor_timeout root cause confirmed by operator.",
+        "analysis_id": "case_sanfer_42",
+    }
+    written = promote_verified_priors_to_managed_memory(
+        client=client,
+        store_id="memstore_platform",
+        verified_priors=[prior],
+    )
+    assert len(written) == 1
+
+
+def test_freshly_extracted_operator_hypothesis_cannot_auto_promote(tmp_path: Path):
+    """Negative test: the most dangerous failure mode.
+
+    The agent extracted an operator narrative ("GPS fails in tunnel") from a
+    new bag and tried to write it into the platform store as if it were a
+    verified prior. This MUST be rejected by the safety gate, not just
+    discouraged in prose.
+    """
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+
+    fresh_extraction = {
+        "path": "/priors/auto_extracted_2026_04_23.md",
+        "content": (
+            "Operator narrative auto-extracted from sanfer_drive bag: "
+            "'GPS fails when entering the tunnel'. Bug class: sensor_timeout."
+        ),
+        "analysis_id": "case_unverified_999",
+        # No verified=True. No confirmation note in the ledger.
+    }
+
+    with pytest.raises(UnverifiedMemoryPromotionError):
+        promote_verified_priors_to_managed_memory(
+            client=client,
+            store_id="memstore_platform",
+            verified_priors=[fresh_extraction],
+        )
+    assert stores.memories.created == []
+
+
+def test_safety_gate_rejects_whole_batch_atomically(tmp_path: Path):
+    """One unverified entry sinks the whole batch; the platform store is
+    never partially mutated.
+    """
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(memory_stores=stores)
+
+    batch = [
+        {"path": "/priors/ok.md", "content": "ok", "verified": True},
+        {"path": "/priors/bad.md", "content": "bad"},  # no verified flag
+    ]
+    with pytest.raises(UnverifiedMemoryPromotionError):
+        promote_verified_priors_to_managed_memory(
+            client=client,
+            store_id="memstore_platform",
+            verified_priors=batch,
+        )
+    assert stores.memories.created == []
+
+
+# ---------------------------------------------------------------------------
+# Spec dataclass smoke
+# ---------------------------------------------------------------------------
+def test_memory_store_spec_round_trip():
+    spec = MemoryStoreSpec(
+        name="bb-test",
+        access="read_only",
+        instructions="x" * 100,
+        seed_memories=[("/p.md", "c")],
+    )
+    assert spec.access == "read_only"
+    assert spec.seed_memories == [("/p.md", "c")]


### PR DESCRIPTION
## Summary

Wires Anthropic's native `client.beta.memory_stores.*` into the forensic agent so the in-session model gets `/mnt/memory/` filesystem access while the local L1-L4 JSONL stack continues to drive the offline policy advisor and prompt priming. Two stores per session, case-isolated read-write, idempotent shared read-only.

## Architecture — local stack + native stores side-by-side

```
+------------------------ Local L1-L4 (offline) ------------------------+
|  L1 case      L2 platform priors      L3 taxonomy      L4 eval        |
|     |               |                    |                |           |
|     +---------------+--------------------+----------------+           |
|                     |                                                 |
|                     v                                                 |
|             PolicyAdvisor (prime_prompt_block, tie-break, alarms)     |
+----------------------------------+------------------------------------+
                                   |
                                   v
                          ForensicAgent.open_session
                                   |
                  provisions native memory_stores
                                   |
        +--------------------------+--------------------------+
        v                                                     v
+----------------------------+              +-----------------------------------+
| bb-platform-priors         |              | bb-forensic-learnings-{case_key}  |
| read_only, shared          |              | read_write, fresh per session     |
| seeded once via memories.* |              | case-isolated scratchpad          |
| /mnt/memory/...            |              | /mnt/memory/...                   |
+----------------------------+              +-----------------------------------+
                |                                                     |
                +----------------------- Opus 4.7 in-session ---------+
                                          |
        Promotion (case -> platform) gated by verification ledger:
        only severity="confirmation" notes (or explicit verified=True
        bootstrap seeds) pass through promote_verified_priors_to_managed_memory.
```

## Senior reviewer's six asks

1. **`client.beta.memory_stores.create(...)` is actually called.** `ForensicAgent._provision_memory_stores` -> `_find_or_create_platform_store` / `_create_case_store`. (`src/black_box/analysis/managed_agent.py`)
2. **Optional seeding via `memory_stores.memories.create(...)`.** Seeding loop in `_find_or_create_platform_store` runs `_DEFAULT_PLATFORM_SEED` (taxonomy + rtk_heading_break_01 anti-hypothesis + safety contract) when the platform store is freshly created. (`src/black_box/analysis/managed_agent.py`)
3. **Session `resources[]` entry of type `memory_store` mounted at `/mnt/memory/<slug>`.** Returned dicts have `{"type": "memory_store", "memory_store_id": ..., "access": ..., "instructions": ...}` and are merged into `session_kwargs["resources"]` before `sessions.create`. The slug comes back authoritatively on the SDK response; `_slugify_store_name` mirrors it for log lines. (`src/black_box/analysis/managed_agent.py`)
4. **Read-only store for stable robot/platform knowledge.** `bb-platform-priors`, idempotent (looked up by `name` via `memory_stores.list`), `access="read_only"`. (`src/black_box/analysis/managed_agent.py`)
5. **Read-write store for per-project forensic learnings.** `bb-forensic-learnings-{case_key}`, fresh per session, `access="read_write"`. (`src/black_box/analysis/managed_agent.py`)
6. **Untrusted recording content must NOT poison persistent memory without human verification.** `promote_verified_priors_to_managed_memory` in `src/black_box/memory/verification.py` rejects any batch entry that lacks `verified=True` or a `severity="confirmation"` ledger note; rejection is atomic (no partial writes). The agent itself never calls this; it is operator tooling.

## Safety contract — who can write to the platform store

| Path | Can write to `bb-platform-priors`? | Notes |
|------|-----------------------------------|-------|
| Agent inside a Session | NO | mount is `read_only`; SDK rejects writes |
| `_DEFAULT_PLATFORM_SEED` at first creation | YES | static, code-reviewed bootstrap content |
| `promote_verified_priors_to_managed_memory(verified=True)` | YES | caller (human-curated tooling) takes responsibility |
| `promote_verified_priors_to_managed_memory` with `analysis_id` referencing a `severity="confirmation"` note | YES | gated through the human verification ledger |
| Anything else (operator narrative, freshly-extracted hypothesis, untrusted bag) | NO | raises `UnverifiedMemoryPromotionError` before any SDK call |

The per-case `bb-forensic-learnings-{case_key}` store is read-write and is wiped between cases by being recreated fresh on every `open_session` — there is no cross-case bleed of scratch state.

## Test plan

`tests/test_memory_stores.py` (13 cases, all passing locally via `PYTHONPATH=src pytest -q`):

- [x] `test_platform_store_is_reused_when_it_already_exists` — idempotent provisioning (existing platform store is reused, not duplicated).
- [x] `test_platform_store_is_created_and_seeded_when_absent` — first run creates the store and writes the seed memories (taxonomy + rtk anti-hypothesis).
- [x] `test_per_case_store_is_fresh_each_session` — two `open_session` calls with the same `case_key` create two distinct read-write stores.
- [x] `test_session_resources_include_read_only_and_read_write` — session `resources[]` contains both `{type: memory_store, access: read_only}` and `{type: memory_store, access: read_write}` entries; `instructions` <=4096 chars.
- [x] `test_seed_text_mentions_mount_path_and_human_gate` — `/mnt/memory/`, READ-ONLY, READ-WRITE, and the human-verification gate all surface in the seed message.
- [x] `test_enable_native_memory_false_skips_api_calls` — kill switch short-circuits the API entirely; no `memory_stores.list` / `.create` invocations.
- [x] `test_provisioning_failure_falls_back_gracefully` — simulated `memory_stores.list` outage logs to stderr and the session still launches without a `read_only` resource.
- [x] `test_safety_gate_rejects_unverified_promotion` — operator narrative (no `verified=True`, no confirmation note) is refused before any SDK call.
- [x] `test_safety_gate_accepts_explicit_verified_flag` — `verified=True` bootstrap seed is accepted and returns the SDK response id.
- [x] `test_safety_gate_accepts_confirmation_note_in_ledger` — `analysis_id` with a `severity="confirmation"` note in the global verification ledger passes the gate even without `verified=True`.
- [x] `test_freshly_extracted_operator_hypothesis_cannot_auto_promote` — load-bearing negative test: a freshly-extracted "operator says GPS fails in tunnel" hypothesis is rejected; the platform store is not mutated.
- [x] `test_safety_gate_rejects_whole_batch_atomically` — one unverified entry sinks the whole batch; the platform store is never partially mutated.
- [x] `test_memory_store_spec_round_trip` — `MemoryStoreSpec` dataclass shape sanity.

Full suite (`PYTHONPATH=src pytest -q`): 477 passed, 1 skipped, 0 failures.

Smoke evidence against the live edge is pending a manual run; brief explicitly authorized skipping the billable round-trip and noting it here.

Beta header: `managed-agents-2026-04-01`. Model: `claude-opus-4-7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)