### PR TITLE
feat(memory): PII/secret sanitizer + concurrency hardening for promotion

### DIFF
--- a/config/sanitizer_allowlist.yaml
+++ b/config/sanitizer_allowlist.yaml
@@ -1,0 +1,22 @@
+# Allow-list for the platform-promotion sanitizer.
+#
+# Schema:
+#   operator_names: list[str] — exact strings (case-insensitive) of human
+#       operators whose names are SAFE to land in `bb-platform-priors`. Anything
+#       not in this list, when matched by an operator-name regex, is BLOCKED.
+#   customer_names: list[str] — same semantics for customer / company names.
+#   site_names:     list[str] — same semantics for site / facility identifiers.
+#
+# The sanitizer is closed-by-default: an entry is required for each name that
+# may legitimately appear in promoted priors. The empty defaults below mean
+# "platform priors must be name-free" until the team explicitly opts a name in.
+#
+# How to add a name (paranoid checklist):
+#   1. Confirm with Lucas / the operator that the name may be persisted in the
+#      shared platform memory_store (it is read-only across cases / customers).
+#   2. Add the exact spelling to the relevant list. Aliases need their own line.
+#   3. Re-run `pytest -q tests/test_memory_sanitizer.py`.
+
+operator_names: []
+customer_names: []
+site_names: []

--- a/docs/MEMORY_PROMOTION_PIPELINE.md
+++ b/docs/MEMORY_PROMOTION_PIPELINE.md
@@ -1,0 +1,149 @@
+# Memory promotion pipeline
+
+This is the contract for moving a prior from the local 4-layer stack
+(`L1 case → L2 platform → L3 taxonomy → L4 eval`) into the **native Anthropic
+Managed Agents memory store** (`bb-platform-priors`). The native store is
+shared across cases / customers, read-only at session time, and survives the
+session, so the bar for landing content there is much higher than for the
+local JSONL.
+
+Audit context: this document covers Lucas's audit asks **#6** (PII / secret
+sanitization on the way in) and **#7** (concurrency / atomicity guarantees
+for the create-only platform seed).
+
+## Pipeline
+
+```
+verify  →  sanitize  →  diff (review)  →  promote
+```
+
+Each stage is a hard gate. A failure at any stage refuses the whole batch;
+nothing partial reaches the platform store.
+
+### 1. verify  (`black_box.memory.verification`)
+
+The human-verification ledger is append-only at two levels (per-analysis MD
+and global JSONL). A prior is allowed past this stage iff:
+
+- it carries an explicit `verified=True` flag (caller takes responsibility,
+  e.g. human-curated bootstrap seeds), **or**
+- it references an `analysis_id` that has at least one ledger note with
+  `severity == "confirmation"`.
+
+Failures raise `UnverifiedMemoryPromotionError`.
+
+### 2. sanitize  (`black_box.memory.sanitizer`)
+
+Pure-Python regex pass over `content`. No ML, no model calls. Two
+severities:
+
+| severity   | action            | typical kinds                                           |
+|------------|-------------------|---------------------------------------------------------|
+| `block`    | refuse whole batch | `api_key`, `private_url`, `operator_name`, `customer_name`, `site_name` |
+| `redact`   | rewrite content   | `local_path`, `license_plate`                           |
+
+Operator / customer / site names are **closed-by-default**: the empty
+allow-list at `config/sanitizer_allowlist.yaml` means no names land in the
+platform store until a human edits the YAML and adds them. Adding a name
+to the allow-list is itself a deliberate, reviewable change.
+
+Public API:
+
+```python
+from black_box.memory import scan, assert_safe_for_platform_promotion, AllowList
+
+result = scan(content)                        # never raises; returns SanitizerResult
+clean = assert_safe_for_platform_promotion(   # raises UnsafePromotionContentError on block
+    content,
+    allow_list=AllowList.load(),
+)
+```
+
+The promotion function calls `assert_safe_for_platform_promotion` per
+prior **before any** `memories.create` call (see atomicity below).
+
+### 3. diff (review)
+
+Today: the sanitized `cleaned_content` differs from the original whenever
+a `local_path` or `license_plate` was redacted. Operators inspect this
+diff via the per-analysis verification MD before flipping the
+`severity == "confirmation"` bit. We do not auto-promote.
+
+This is the slot where a UI-driven approval flow would land if the team
+later wants a one-click promote button. The current implementation keeps
+the gate code-driven and reviewable.
+
+### 4. promote  (`promote_verified_priors_to_managed_memory`)
+
+Only after every prior in the batch has cleared stages 1–2 do we issue
+the SDK calls. Each call is `client.beta.memory_stores.memories.create`
+via the `build_client()` factory in `src/black_box/analysis/client.py`.
+
+## Why platform memories are append-only today
+
+The platform seed (`bb-platform-priors`) is **create-only** in our
+codebase. We never call `memories.update`. Reasons:
+
+- **Concurrency.** Two forensic sessions running in parallel could both
+  read the same prior, both decide to refine it, and race on the write.
+  The native API exposes per-version preconditions
+  (`If-Match` / `content_sha256`) so updates would have to be coded with
+  optimistic concurrency control. Append-only sidesteps this entirely:
+  a refinement is a new path (`/priors/v2/...`), not a mutation.
+- **Auditability.** With no in-place mutation, every prior the agent
+  reads at session time corresponds to a single git-reviewable
+  `memories.create` call. Diff `git log -- src/black_box/memory/seed/`
+  to see exactly what entered the store and when.
+- **Rollback.** Removing a bad prior is `memories.delete` plus a new
+  create on a fresh path; we never have to reconstruct a prior version
+  from a write-ahead log.
+
+When the team eventually needs in-place updates, the path is documented
+in the Anthropic memory_versions docs:
+
+> Updates require a `content_sha256` precondition matching the current
+> version. The server rejects with `412 Precondition Failed` if another
+> writer landed first.
+> — [Anthropic Managed Agents memory_versions](https://docs.anthropic.com/en/docs/agents/managed-agents/memory#versions)
+
+Until that day, **only `create`** is sanctioned in
+`src/black_box/memory/verification.py::promote_verified_priors_to_managed_memory`.
+
+## Atomicity guarantee
+
+`promote_verified_priors_to_managed_memory` is atomic at the batch level:
+
+1. The function validates **every** prior in `verified_priors` for
+   structural shape, verification status, and sanitizer safety.
+2. Only after the whole batch passes does it issue the first
+   `memories.create` call.
+3. If the sanitizer raises mid-validation, the SDK is **never touched** —
+   `client.beta.memory_stores.memories.create` is not called even once.
+
+The test
+[`test_memory_sanitizer.py::test_promote_atomic_no_partial_writes_when_sanitizer_blocks_second_entry`](../tests/test_memory_sanitizer.py)
+pins this behaviour: a 3-prior batch with a leaked API key in the middle
+entry refuses the batch and the fake `memories` API records zero
+`create` calls.
+
+What atomicity does **not** cover:
+
+- Network failure between two `create` calls within the same accepted
+  batch. We currently let the partial write stand (this is the same
+  semantics as L1-L4 JSONL appends — every line is independent). The
+  paths are deterministic, so a retry of the same batch is idempotent
+  at the *path* level only if the operator uses fresh paths; reusing a
+  path raises a server-side conflict.
+- Cross-process concurrent promotions targeting the same path. See the
+  "append-only today" section — we avoid this by never reusing paths.
+
+## File map
+
+```
+config/sanitizer_allowlist.yaml             — operator/customer/site allow-list
+src/black_box/memory/sanitizer.py           — detectors, AllowList, scan()
+src/black_box/memory/verification.py        — promote_…() pipeline glue
+src/black_box/analysis/client.py            — build_client() (managed-agents beta)
+tests/test_memory_sanitizer.py              — 21 tests, atomicity included
+docs/MEMORY_PROMOTION_PIPELINE.md           — this file
+```

--- a/src/black_box/memory/__init__.py
+++ b/src/black_box/memory/__init__.py
@@ -24,6 +24,14 @@ from .records import (
     PlatformPrior,
     TaxonomyCount,
 )
+from .sanitizer import (
+    AllowList,
+    Finding,
+    SanitizerResult,
+    UnsafePromotionContentError,
+    assert_safe_for_platform_promotion,
+    scan,
+)
 from .verification import (
     UnverifiedMemoryPromotionError,
     VerificationNote,
@@ -60,6 +68,12 @@ __all__ = [
     "iter_notes_for",
     "now_utc_iso",
     "promote_verified_priors_to_managed_memory",
+    "AllowList",
+    "Finding",
+    "SanitizerResult",
+    "UnsafePromotionContentError",
+    "assert_safe_for_platform_promotion",
+    "scan",
     "DecisionRecord",
     "PatchNotApprovedError",
     "apply_patch_if_approved",

--- a/src/black_box/memory/sanitizer.py
+++ b/src/black_box/memory/sanitizer.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: MIT
+"""PII / secret sanitizer for the platform-priors promotion gate.
+
+Pure-Python regex + YAML allow-list. No ML, no external services, no model
+calls. Runs INSIDE :func:`promote_verified_priors_to_managed_memory` BEFORE
+any ``memories.create`` is issued so that a single offending entry refuses
+the whole batch.
+
+Two severities:
+
+* ``redact`` — content is rewritten in place with a deterministic placeholder
+  (e.g. ``[REDACTED:license_plate]``). Promotion proceeds with the cleaned
+  content.
+* ``block`` — promotion is refused. The caller must fix the source upstream
+  (operator-supplied names should be allow-listed; secrets should never have
+  been written down at all).
+
+Detector classes (closed set):
+
+  ``api_key``           — ``sk-...``, ``ghp_...``, ``AKIA...``, JWT, long hex.
+                          Always BLOCK.
+  ``private_url``       — ``localhost``, RFC1918, ``*.internal``, ``*.local``,
+                          ``*.corp.*``. Always BLOCK.
+  ``local_path``        — absolute paths on the operator's machine. REDACT.
+  ``license_plate``     — US / EU / AR-style plates. REDACT.
+  ``operator_name``     — ``operator <Name>``, ``driver <First> <Last>`` etc.
+                          BLOCK unless name is in the allow-list.
+  ``customer_name``     — same shape as ``operator_name`` but for customer /
+                          company tokens. BLOCK unless allow-listed.
+  ``site_name``         — facility / site identifiers. BLOCK unless
+                          allow-listed.
+
+The closed-by-default posture is deliberate: an empty allow-list means "no
+names land in `bb-platform-priors` at all", which is the desired starting
+state until the team explicitly opts each name in.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+class UnsafePromotionContentError(RuntimeError):
+    """Promotion refused: at least one ``block``-severity finding."""
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    severity: str
+    matched: str
+    span: tuple[int, int]
+    reason: str
+
+
+@dataclass
+class SanitizerResult:
+    blocked: List[Finding] = field(default_factory=list)
+    redacted: List[Finding] = field(default_factory=list)
+    cleaned_content: str = ""
+
+
+@dataclass(frozen=True)
+class AllowList:
+    operator_names: tuple[str, ...] = ()
+    customer_names: tuple[str, ...] = ()
+    site_names: tuple[str, ...] = ()
+
+    @staticmethod
+    def empty() -> "AllowList":
+        return AllowList()
+
+    @staticmethod
+    def load(path: Path | str | None = None) -> "AllowList":
+        """Load allow-list from YAML.
+
+        ``path=None`` resolves to ``<repo>/config/sanitizer_allowlist.yaml``.
+        Missing file is treated as an empty allow-list (closed-by-default).
+        """
+        try:
+            import yaml  # type: ignore
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "PyYAML is required for AllowList.load; install pyyaml."
+            ) from exc
+
+        if path is None:
+            path = _default_allowlist_path()
+        p = Path(path)
+        if not p.exists():
+            return AllowList.empty()
+        raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"sanitizer allow-list must be a YAML mapping; got {type(raw).__name__}"
+            )
+        return AllowList(
+            operator_names=tuple(_str_list(raw.get("operator_names", []))),
+            customer_names=tuple(_str_list(raw.get("customer_names", []))),
+            site_names=tuple(_str_list(raw.get("site_names", []))),
+        )
+
+    def is_allowed(self, kind: str, name: str) -> bool:
+        canon = name.strip().lower()
+        if not canon:
+            return True
+        bucket: tuple[str, ...]
+        if kind == "operator_name":
+            bucket = self.operator_names
+        elif kind == "customer_name":
+            bucket = self.customer_names
+        elif kind == "site_name":
+            bucket = self.site_names
+        else:
+            return False
+        return any(canon == n.strip().lower() for n in bucket)
+
+
+def _str_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"expected list, got {type(value).__name__}")
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"expected string entry, got {type(item).__name__}")
+        out.append(item)
+    return out
+
+
+def _default_allowlist_path() -> Path:
+    here = Path(__file__).resolve()
+    # src/black_box/memory/sanitizer.py -> repo_root/config/...
+    repo_root = here.parents[3]
+    return repo_root / "config" / "sanitizer_allowlist.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+# ---------------------------------------------------------------------------
+_RE_API_KEY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("anthropic", re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}")),
+    ("openai", re.compile(r"sk-[A-Za-z0-9]{20,}")),
+    ("github_pat", re.compile(r"ghp_[A-Za-z0-9]{20,}")),
+    ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("jwt", re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+")),
+    ("hex_token", re.compile(r"\b[a-fA-F0-9]{32,}\b")),
+)
+
+_RE_PRIVATE_URL = re.compile(
+    r"https?://"
+    r"(?:"
+    r"localhost"
+    r"|127\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+    r"|10\.\d{1,3}\.\d{1,3}\.\d{1,3}"
+    r"|192\.168\.\d{1,3}\.\d{1,3}"
+    r"|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}"
+    r"|[A-Za-z0-9._\-]+\.internal"
+    r"|[A-Za-z0-9._\-]+\.local"
+    r"|[A-Za-z0-9._\-]+\.corp\.[A-Za-z0-9._\-]+"
+    r")"
+    r"(?:[:/][^\s]*)?",
+    re.IGNORECASE,
+)
+
+_RE_LOCAL_PATH_POSIX = re.compile(r"(?<![A-Za-z0-9_])(?:/Users/|/home/)[A-Za-z0-9._\-/]+")
+_RE_LOCAL_PATH_WIN = re.compile(r"\b[A-Za-z]:\\[A-Za-z0-9._\-\\]+")
+
+# Plates: keep the regex generous per Lucas being from Argentina.
+#
+# US 5-8 alphanumeric, often with dashes/spaces, optionally state-prefixed.
+# AR civilian: ``AB 123 CD`` (post-2016) or ``ABC 123`` (legacy).
+# EU: ``AB-123-CD`` / ``AB 12 CDE`` etc. The shared shape is two-or-more
+# letter clusters separated from a digit cluster by space or dash.
+_RE_PLATE_AR_NEW = re.compile(r"\b[A-Z]{2}\s?\d{3}\s?[A-Z]{2}\b")
+_RE_PLATE_AR_LEGACY = re.compile(r"\b[A-Z]{3}\s?\d{3}\b")
+_RE_PLATE_US = re.compile(r"\b[A-Z]{1,3}[\s\-]?\d{2,4}[\s\-]?[A-Z]{0,3}\b")
+_RE_PLATE_EU = re.compile(r"\b[A-Z]{1,3}\-\d{1,4}\-[A-Z]{1,3}\b")
+
+# Operator / driver / pilot / customer / site triggers. We capture two
+# capitalised words after the keyword as the candidate name, then consult the
+# allow-list before deciding block vs allow.
+_RE_OPERATOR_NAME = re.compile(
+    r"\b(?:operator|driver|pilot|technician)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})\b"
+)
+_RE_CUSTOMER_NAME = re.compile(
+    r"\b(?:customer|client|account)\s+([A-Z][A-Za-z0-9&.\-]+(?:\s+[A-Z][A-Za-z0-9&.\-]+){0,3})\b"
+)
+_RE_SITE_NAME = re.compile(
+    r"\b(?:site|facility|warehouse|plant|depot)\s+([A-Z][A-Za-z0-9.\-]+(?:\s+[A-Z0-9][A-Za-z0-9.\-]+){0,2})\b"
+)
+
+
+def _redact(content: str, span: tuple[int, int], placeholder: str) -> str:
+    a, b = span
+    return content[:a] + placeholder + content[b:]
+
+
+def _scan_api_keys(content: str) -> list[Finding]:
+    out: list[Finding] = []
+    for label, pat in _RE_API_KEY_PATTERNS:
+        for m in pat.finditer(content):
+            out.append(
+                Finding(
+                    kind="api_key",
+                    severity="block",
+                    matched=m.group(0),
+                    span=m.span(),
+                    reason=f"detected {label} secret token",
+                )
+            )
+    return out
+
+
+def _scan_private_urls(content: str) -> list[Finding]:
+    return [
+        Finding(
+            kind="private_url",
+            severity="block",
+            matched=m.group(0),
+            span=m.span(),
+            reason="detected internal/private URL host",
+        )
+        for m in _RE_PRIVATE_URL.finditer(content)
+    ]
+
+
+def _scan_local_paths(content: str) -> list[Finding]:
+    out: list[Finding] = []
+    for pat in (_RE_LOCAL_PATH_POSIX, _RE_LOCAL_PATH_WIN):
+        for m in pat.finditer(content):
+            out.append(
+                Finding(
+                    kind="local_path",
+                    severity="redact",
+                    matched=m.group(0),
+                    span=m.span(),
+                    reason="absolute filesystem path leaks operator workstation layout",
+                )
+            )
+    return out
+
+
+def _scan_plates(content: str) -> list[Finding]:
+    out: list[Finding] = []
+    seen_spans: set[tuple[int, int]] = set()
+    for pat in (_RE_PLATE_AR_NEW, _RE_PLATE_AR_LEGACY, _RE_PLATE_EU, _RE_PLATE_US):
+        for m in pat.finditer(content):
+            if m.span() in seen_spans:
+                continue
+            seen_spans.add(m.span())
+            out.append(
+                Finding(
+                    kind="license_plate",
+                    severity="redact",
+                    matched=m.group(0),
+                    span=m.span(),
+                    reason="vehicle plate shape detected",
+                )
+            )
+    return out
+
+
+def _scan_named_entities(
+    content: str,
+    pattern: re.Pattern[str],
+    kind: str,
+    allow_list: AllowList,
+) -> list[Finding]:
+    out: list[Finding] = []
+    for m in pattern.finditer(content):
+        candidate = m.group(1)
+        if allow_list.is_allowed(kind, candidate):
+            continue
+        out.append(
+            Finding(
+                kind=kind,
+                severity="block",
+                matched=m.group(0),
+                span=m.span(),
+                reason=(
+                    f"{kind.replace('_', ' ')} {candidate!r} is not in the "
+                    f"sanitizer allow-list (config/sanitizer_allowlist.yaml)"
+                ),
+            )
+        )
+    return out
+
+
+def scan(
+    content: str,
+    *,
+    allow_list: AllowList | None = None,
+) -> SanitizerResult:
+    """Run every detector over ``content`` and return findings + cleaned text.
+
+    The function never raises on unsafe content; it accumulates ``blocked``
+    findings instead. Callers needing the strict raise-on-unsafe semantics
+    use :func:`assert_safe_for_platform_promotion`.
+    """
+    if not isinstance(content, str):
+        raise TypeError("sanitizer.scan expects str content")
+    al = allow_list or AllowList.empty()
+
+    findings: list[Finding] = []
+    findings.extend(_scan_api_keys(content))
+    findings.extend(_scan_private_urls(content))
+    findings.extend(_scan_local_paths(content))
+    findings.extend(_scan_plates(content))
+    findings.extend(_scan_named_entities(content, _RE_OPERATOR_NAME, "operator_name", al))
+    findings.extend(_scan_named_entities(content, _RE_CUSTOMER_NAME, "customer_name", al))
+    findings.extend(_scan_named_entities(content, _RE_SITE_NAME, "site_name", al))
+
+    blocked = [f for f in findings if f.severity == "block"]
+    redacted = [f for f in findings if f.severity == "redact"]
+
+    cleaned = _apply_redactions(content, redacted)
+
+    return SanitizerResult(
+        blocked=blocked,
+        redacted=redacted,
+        cleaned_content=cleaned,
+    )
+
+
+def _apply_redactions(content: str, redacted: Iterable[Finding]) -> str:
+    # Apply right-to-left so spans stay valid as we splice.
+    ordered = sorted(redacted, key=lambda f: f.span[0], reverse=True)
+    out = content
+    for f in ordered:
+        placeholder = f"[REDACTED:{f.kind}]"
+        out = _redact(out, f.span, placeholder)
+    return out
+
+
+def assert_safe_for_platform_promotion(
+    content: str,
+    *,
+    allow_list: AllowList | None = None,
+) -> str:
+    """Return cleaned content or raise :class:`UnsafePromotionContentError`.
+
+    ``redact`` findings are auto-applied; ``block`` findings refuse the
+    promotion. The error message lists every blocked finding so the operator
+    can fix the source.
+    """
+    result = scan(content, allow_list=allow_list)
+    if result.blocked:
+        bullet_lines = "\n".join(
+            f"  - [{f.kind}] {f.reason}: {_excerpt(f.matched)}"
+            for f in result.blocked
+        )
+        raise UnsafePromotionContentError(
+            "refusing to promote prior — sanitizer found blocking content:\n"
+            + bullet_lines
+        )
+    return result.cleaned_content
+
+
+def _excerpt(s: str, *, limit: int = 60) -> str:
+    s = s.replace("\n", " ")
+    return s if len(s) <= limit else s[: limit - 1] + "\u2026"
+
+
+__all__ = [
+    "AllowList",
+    "Finding",
+    "SanitizerResult",
+    "UnsafePromotionContentError",
+    "assert_safe_for_platform_promotion",
+    "scan",
+]

--- a/src/black_box/memory/verification.py
+++ b/src/black_box/memory/verification.py
@@ -137,22 +137,36 @@ def promote_verified_priors_to_managed_memory(
     verified_priors: list[dict],
     *,
     require_verified: bool = True,
+    allow_list: "AllowList | None" = None,
 ) -> list[str]:
     """Write human-verified priors into the read-only platform memory store.
 
     `verified_priors` is a list of dicts shaped like:
         {"path": "/priors/foo.md", "content": "...", "verified": True}
 
+    Pipeline (atomic — every check runs over the whole batch before any
+    SDK mutation):
+
+      1. structural validation (`path` + `content` present)
+      2. human-verification gate (this module)
+      3. PII / secret sanitizer (``black_box.memory.sanitizer``)
+
     Each entry is rejected unless ``verified is True`` OR the entry
     references an analysis_id whose verification ledger contains a
     `severity == "confirmation"` note. Failures raise
     `UnverifiedMemoryPromotionError` BEFORE any SDK call; the platform
-    store is never partially mutated by an unverified batch.
+    store is never partially mutated by an unverified or unsafe batch.
 
     This is the load-bearing safety contract: untrusted recording content
-    cannot reach the platform store without passing through the human
-    ledger.
+    cannot reach the platform store without passing through both the human
+    ledger and the sanitizer.
     """
+    from .sanitizer import (
+        AllowList,
+        UnsafePromotionContentError,
+        assert_safe_for_platform_promotion,
+    )
+
     stores_api = getattr(getattr(client, "beta", None), "memory_stores", None)
     if stores_api is None:
         raise RuntimeError(
@@ -164,7 +178,11 @@ def promote_verified_priors_to_managed_memory(
             "client.beta.memory_stores.memories is not available; cannot promote priors."
         )
 
+    if allow_list is None:
+        allow_list = AllowList.load()
+
     # Validate the whole batch before mutating.
+    cleaned: list[tuple[str, str]] = []
     for prior in verified_priors:
         path = prior.get("path")
         content = prior.get("content")
@@ -179,13 +197,22 @@ def promote_verified_priors_to_managed_memory(
                 "verification ledger. Untrusted recording content cannot "
                 "reach the platform store."
             )
+        try:
+            safe_content = assert_safe_for_platform_promotion(
+                content, allow_list=allow_list
+            )
+        except UnsafePromotionContentError as exc:
+            raise UnsafePromotionContentError(
+                f"refusing to promote {path!r}: {exc}"
+            ) from exc
+        cleaned.append((path, safe_content))
 
     written: list[str] = []
-    for prior in verified_priors:
+    for path, safe_content in cleaned:
         result = memories_api.create(
             memory_store_id=store_id,
-            path=prior["path"],
-            content=prior["content"],
+            path=path,
+            content=safe_content,
         )
         rid = getattr(result, "id", None)
         if rid is not None:

--- a/tests/test_memory_sanitizer.py
+++ b/tests/test_memory_sanitizer.py
@@ -1,0 +1,330 @@
+"""Tests for the platform-promotion sanitizer + atomicity of the gate.
+
+Covers Lucas audit asks #6 (PII / secret detection) and #7 (atomic
+promotion: no partial writes when the sanitizer raises mid-batch).
+
+All Anthropic SDK calls are stubbed; nothing hits the network. No model
+calls anywhere in this file — sanitizer is pure regex.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from black_box.memory import (
+    AllowList,
+    UnsafePromotionContentError,
+    UnverifiedMemoryPromotionError,
+    assert_safe_for_platform_promotion,
+    promote_verified_priors_to_managed_memory,
+    scan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+class _FakeMemoriesAPI:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+
+    def create(self, *, memory_store_id, path, content, **_):
+        rec = {"memory_store_id": memory_store_id, "path": path, "content": content}
+        self.created.append(rec)
+        return SimpleNamespace(
+            id=f"mem_{len(self.created):04d}",
+            memory_store_id=memory_store_id,
+            path=path,
+        )
+
+
+class _FakeMemoryStoresAPI:
+    def __init__(self) -> None:
+        self.memories = _FakeMemoriesAPI()
+
+
+class _FakeBeta:
+    def __init__(self) -> None:
+        self.memory_stores = _FakeMemoryStoresAPI()
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.beta = _FakeBeta()
+
+
+# ---------------------------------------------------------------------------
+# Detector unit tests — positive (catches) + negative (allow-list lets through)
+# ---------------------------------------------------------------------------
+def test_api_key_openai_is_blocked():
+    bad = "leaked: sk-abcdef0123456789abcdefXYZ in prod logs"
+    result = scan(bad)
+    assert any(f.kind == "api_key" for f in result.blocked)
+    with pytest.raises(UnsafePromotionContentError):
+        assert_safe_for_platform_promotion(bad)
+
+
+def test_api_key_github_aws_jwt_hex_all_blocked():
+    samples = [
+        "ghp_abcdefghijklmnopqrstuvwxyz0123",
+        "AKIAABCDEFGHIJKLMNOP",
+        "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.SflKxwRJSMeKKF",
+        "token: deadbeefcafebabe1234567890abcdef00112233",
+    ]
+    for s in samples:
+        with pytest.raises(UnsafePromotionContentError):
+            assert_safe_for_platform_promotion(s)
+
+
+def test_api_key_clean_text_passes():
+    clean = "telemetry shows sensor_timeout in window 12.3-13.4s; no secrets here"
+    cleaned = assert_safe_for_platform_promotion(clean)
+    assert cleaned == clean
+
+
+def test_private_url_blocked_localhost_and_internal():
+    samples = [
+        "see http://localhost:8080/admin",
+        "POST https://10.0.0.4/relay",
+        "https://api.acme.internal/health",
+        "http://control.local",
+        "https://gateway.corp.acme.io/x",
+    ]
+    for s in samples:
+        with pytest.raises(UnsafePromotionContentError):
+            assert_safe_for_platform_promotion(s)
+
+
+def test_private_url_negative_public_url_passes():
+    s = "see https://docs.anthropic.com/en/docs/agents/managed for spec"
+    cleaned = assert_safe_for_platform_promotion(s)
+    assert cleaned == s
+
+
+def test_local_path_is_redacted_not_blocked():
+    s = "extracted from /Users/lucas/Recordings/sanfer_drive_03.bag"
+    result = scan(s)
+    assert result.blocked == []
+    assert any(f.kind == "local_path" for f in result.redacted)
+    assert "[REDACTED:local_path]" in result.cleaned_content
+    assert "/Users/lucas/Recordings" not in result.cleaned_content
+
+
+def test_local_path_windows_redacted():
+    s = r"telemetry from C:\Users\op\bags\drive.bag"
+    result = scan(s)
+    assert any(f.kind == "local_path" for f in result.redacted)
+    assert r"C:\Users\op" not in result.cleaned_content
+
+
+def test_license_plate_argentine_is_redacted():
+    s = "vehicle plate AB 123 CD entered the loading bay"
+    result = scan(s)
+    assert any(f.kind == "license_plate" for f in result.redacted)
+    assert "[REDACTED:license_plate]" in result.cleaned_content
+
+
+def test_license_plate_us_redacted():
+    s = "vehicle plate ABC-1234 was logged"
+    result = scan(s)
+    assert any(f.kind == "license_plate" for f in result.redacted)
+
+
+def test_operator_name_blocked_when_not_in_allowlist():
+    s = "operator John Smith reviewed the run"
+    with pytest.raises(UnsafePromotionContentError):
+        assert_safe_for_platform_promotion(s, allow_list=AllowList.empty())
+
+
+def test_operator_name_passes_when_allowlisted():
+    s = "operator John Smith reviewed the run"
+    al = AllowList(operator_names=("John Smith",))
+    cleaned = assert_safe_for_platform_promotion(s, allow_list=al)
+    assert cleaned == s
+
+
+def test_customer_name_blocked_then_allowed():
+    s = "customer Acme Corp signed the SOW"
+    with pytest.raises(UnsafePromotionContentError):
+        assert_safe_for_platform_promotion(s)
+    al = AllowList(customer_names=("Acme Corp",))
+    assert assert_safe_for_platform_promotion(s, allow_list=al) == s
+
+
+def test_site_name_blocked_then_allowed():
+    s = "site Plant42 telemetry was clean"
+    with pytest.raises(UnsafePromotionContentError):
+        assert_safe_for_platform_promotion(s)
+    al = AllowList(site_names=("Plant42",))
+    assert assert_safe_for_platform_promotion(s, allow_list=al) == s
+
+
+def test_allowlist_load_missing_file_is_empty(tmp_path: Path):
+    al = AllowList.load(tmp_path / "nope.yaml")
+    assert al == AllowList.empty()
+
+
+def test_allowlist_load_yaml_round_trip(tmp_path: Path):
+    p = tmp_path / "al.yaml"
+    p.write_text(
+        "operator_names: [Lucas Ercolano]\n"
+        "customer_names: [Sanfer]\n"
+        "site_names: []\n",
+        encoding="utf-8",
+    )
+    al = AllowList.load(p)
+    assert al.operator_names == ("Lucas Ercolano",)
+    assert al.customer_names == ("Sanfer",)
+    assert al.site_names == ()
+
+
+# ---------------------------------------------------------------------------
+# Integration: promote_verified_priors_to_managed_memory + sanitizer
+# ---------------------------------------------------------------------------
+def test_promote_refuses_batch_with_api_key():
+    client = _FakeClient()
+    batch = [
+        {
+            "path": "/priors/leak.md",
+            "content": "rotate this: sk-abcdef0123456789abcdefXYZQ",
+            "verified": True,
+        },
+    ]
+    with pytest.raises(UnsafePromotionContentError):
+        promote_verified_priors_to_managed_memory(
+            client=client,
+            store_id="memstore_platform",
+            verified_priors=batch,
+            allow_list=AllowList.empty(),
+        )
+    assert client.beta.memory_stores.memories.created == []
+
+
+def test_promote_refuses_batch_with_non_allowlisted_operator():
+    client = _FakeClient()
+    batch = [
+        {
+            "path": "/priors/op.md",
+            "content": "operator Jane Doe drove the rig",
+            "verified": True,
+        },
+    ]
+    with pytest.raises(UnsafePromotionContentError):
+        promote_verified_priors_to_managed_memory(
+            client=client,
+            store_id="memstore_platform",
+            verified_priors=batch,
+            allow_list=AllowList.empty(),
+        )
+    assert client.beta.memory_stores.memories.created == []
+
+
+def test_promote_passes_clean_batch_and_applies_redactions():
+    client = _FakeClient()
+    batch = [
+        {
+            "path": "/priors/clean.md",
+            "content": "sensor_timeout window 12.3-13.4s; refutes operator narrative",
+            "verified": True,
+        },
+        {
+            "path": "/priors/path.md",
+            "content": "extracted from /Users/lucas/Recordings/x.bag",
+            "verified": True,
+        },
+    ]
+    written = promote_verified_priors_to_managed_memory(
+        client=client,
+        store_id="memstore_platform",
+        verified_priors=batch,
+        allow_list=AllowList.empty(),
+    )
+    assert len(written) == 2
+    created = client.beta.memory_stores.memories.created
+    assert created[0]["content"] == batch[0]["content"]
+    assert "[REDACTED:local_path]" in created[1]["content"]
+    assert "/Users/lucas/Recordings" not in created[1]["content"]
+
+
+def test_promote_atomic_no_partial_writes_when_sanitizer_blocks_second_entry():
+    """Audit ask #7 — atomicity: a single blocked entry refuses the whole
+    batch and `memories.create` is never called.
+    """
+    client = _FakeClient()
+    batch = [
+        {
+            "path": "/priors/ok.md",
+            "content": "clean prior content",
+            "verified": True,
+        },
+        {
+            "path": "/priors/leak.md",
+            "content": "leaked key sk-abcdef0123456789abcdefXYZQ",
+            "verified": True,
+        },
+        {
+            "path": "/priors/also_ok.md",
+            "content": "another clean prior",
+            "verified": True,
+        },
+    ]
+    with pytest.raises(UnsafePromotionContentError):
+        promote_verified_priors_to_managed_memory(
+            client=client,
+            store_id="memstore_platform",
+            verified_priors=batch,
+            allow_list=AllowList.empty(),
+        )
+    assert client.beta.memory_stores.memories.created == []
+
+
+def test_promote_verification_gate_runs_before_sanitizer():
+    """Defence-in-depth: an unverified prior is rejected by the human gate
+    before the sanitizer ever runs. Both errors are subclasses of
+    `RuntimeError`; we just check the more specific one fires here.
+    """
+    client = _FakeClient()
+    batch = [
+        {
+            "path": "/priors/unverified.md",
+            "content": "totally clean content",
+        },
+    ]
+    with pytest.raises(UnverifiedMemoryPromotionError):
+        promote_verified_priors_to_managed_memory(
+            client=client,
+            store_id="memstore_platform",
+            verified_priors=batch,
+            allow_list=AllowList.empty(),
+        )
+    assert client.beta.memory_stores.memories.created == []
+
+
+def test_promote_uses_default_allowlist_when_not_passed(monkeypatch, tmp_path: Path):
+    """If `allow_list` is omitted, `AllowList.load()` is consulted. We point
+    it at a tmp YAML so we can exercise the full default path without
+    touching the repo file.
+    """
+    al_path = tmp_path / "al.yaml"
+    al_path.write_text("operator_names: [Lucas Ercolano]\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "black_box.memory.sanitizer._default_allowlist_path",
+        lambda: al_path,
+    )
+
+    client = _FakeClient()
+    batch = [
+        {
+            "path": "/priors/op.md",
+            "content": "operator Lucas Ercolano signed off",
+            "verified": True,
+        },
+    ]
+    written = promote_verified_priors_to_managed_memory(
+        client=client,
+        store_id="memstore_platform",
+        verified_priors=batch,
+    )
+    assert len(written) == 1


### PR DESCRIPTION
Stacks on top of #138 (`feat/p6-managed-memory-stores`). Closes Lucas's audit asks **#6** (PII / secret sanitizer) and **#7** (atomic promotion + concurrency docs).

## Summary

- New pure-Python sanitizer (`src/black_box/memory/sanitizer.py`) wired into `promote_verified_priors_to_managed_memory` BEFORE any `memories.create`. Pipeline is now `verify → sanitize → diff → promote`.
- Closed-by-default operator / customer / site allow-list at `config/sanitizer_allowlist.yaml` — no names land in `bb-platform-priors` until a human edits the YAML.
- Detector classes: `api_key` (sk-/ghp_/AKIA/JWT/long-hex, BLOCK), `private_url` (localhost / RFC1918 / `*.internal` / `*.local` / `*.corp.*`, BLOCK), `local_path` (`/Users/...`, `/home/...`, `C:\\...`, REDACT), `license_plate` (US/EU/AR shapes, REDACT), `operator_name` / `customer_name` / `site_name` (BLOCK unless allow-listed).
- Atomicity guarantee preserved and pinned by a dedicated test: a single blocked entry refuses the whole batch and the SDK is never touched.
- New `docs/MEMORY_PROMOTION_PIPELINE.md` covers the verify→sanitize→diff→promote pipeline, why the platform seed is create-only today, and the `content_sha256` precondition path for future updates.

## Test plan

- [x] `PYTHONPATH=src pytest -q tests/test_memory_sanitizer.py` — 21 / 21 pass.
- [x] `PYTHONPATH=src pytest tests/` — 497 passed, 1 skipped (no regressions vs. parent branch).
- [x] No model calls anywhere in the new code or tests — pure regex + YAML.
- [x] Existing `tests/test_memory_stores.py::test_safety_gate_*` still pass (verification gate runs before sanitizer; both errors exposed).

## Files touched

- `config/sanitizer_allowlist.yaml` (new)
- `docs/MEMORY_PROMOTION_PIPELINE.md` (new)
- `src/black_box/memory/sanitizer.py` (new)
- `src/black_box/memory/__init__.py` (re-exports `AllowList`, `scan`, `assert_safe_for_platform_promotion`, `Finding`, `SanitizerResult`, `UnsafePromotionContentError`)
- `src/black_box/memory/verification.py` (sanitizer pass added inside `promote_verified_priors_to_managed_memory`)
- `tests/test_memory_sanitizer.py` (new, 21 tests covering each detector + integration + atomicity)

## Out of scope

- Did not touch `src/black_box/analysis/managed_agent.py`, `src/black_box/ui/`, `scripts/`, `src/black_box/memory/cli.py`, or `docs/MANAGED_AGENTS_MEMORY.md` (other agents own those).
- No in-place `memories.update` — see "Why platform memories are append-only today" in the new doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)