### PR TITLE
feat(memory): native memory-store lifecycle + audit + promotion CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,15 @@ flowchart TB
 
 **Native Managed Agents memory stores** sit alongside the local stack. Every `ForensicAgent.open_session(...)` provisions two `client.beta.memory_stores.*` resources mounted under `/mnt/memory/`: a shared `bb-platform-priors` store (read-only, seeded from the bug taxonomy and verified anti-hypotheses like the `rtk_heading_break_01` prior that refutes "GPS fails in tunnel"), and a fresh per-case `bb-forensic-learnings-{case_key}` store (read-write, case-isolated). Promotion of unverified content into the platform store is blocked by `promote_verified_priors_to_managed_memory` until a human writes a `severity="confirmation"` entry to the verification ledger. Beta header `managed-agents-2026-04-01`, model `claude-opus-4-7`. Details: [docs/MEMORY_STACK.md](docs/MEMORY_STACK.md#native-managed-agents-memory-stores).
 
+**Memory lifecycle CLI.** `blackbox-memory` (entry point installed by `pyproject.toml`) wraps the stores for ops:
+
+- `audit-native --store NAME` — paths, last-modified, version count, sha256.
+- `export-native-versions --store NAME [--include-content]` — dumps version history to `data/memory_exports/<store_id>/`.
+- `redact-native-version --version ID --reason TXT` — SDK redaction with a required reason.
+- `propose-promotion ANALYSIS_ID` / `diff-promotion ANALYSIS_ID` / `approve-promotion ANALYSIS_ID` / `reject-promotion ANALYSIS_ID --reason TXT` — human-gated promotion of agent-emitted candidates from `data/memory/proposed_promotions/` into `bb-platform-priors`. Approve and reject both append to `data/memory/promotion_log.jsonl`.
+
+Companion ops scripts: `scripts/list_managed_memory_stores.py`, `scripts/archive_old_case_memory_stores.py` (dry-run by default), `scripts/delete_case_memory_store.py` (hard guard against `bb-platform-priors`), `scripts/export_memory_versions.py`.
+
 **Not yet shipped (roadmap):** the policy loop that reads L2 priors to bias the system prompt, uses L3 frequency as a tie-breaker on low-confidence hypotheses, and raises a regression alarm when L4 accuracy on a previously-solved case class drops below a threshold. Calling that "self-improving" would be overclaim until the loop is visible between runs.
 
 ## Grounding gate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
 
 [project.scripts]
 blackbox = "black_box.cli:main"
+blackbox-memory = "black_box.memory.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,6 +35,10 @@ Per #90: classify each script as **eval / demo / ops / dev** so evaluators can t
 | `legal_review.py` | ops | scan repo for license/legal risk markers (release gating). |
 | `snapshot_controllers.py` | ops | freeze the controller source tree for an analysis. |
 | `download_sample_bag.py` | ops | fetch the public sample bag (idempotent). |
+| `list_managed_memory_stores.py` | ops | list all native managed memory stores (id/name/created/size); JSON or table. |
+| `archive_old_case_memory_stores.py` | ops | dry-run/apply deletion of `bb-case-*` stores older than N days; refuses platform store. |
+| `delete_case_memory_store.py` | ops | delete one specific managed memory store by id or name; refuses `bb-platform-priors`. |
+| `export_memory_versions.py` | ops | dump every memory path's version history from a store to `data/memory_exports/`. |
 | `final_pipeline.py` | demo | submission-cut full pipeline driver (long; produces final video assets). |
 | `build_grounding_gate_demo.py` | demo | builds the grounding-gate replay demo asset. |
 | `build_sanfer_timelapse.py` | demo | timelapse of the sanfer hero session for the demo video. |

--- a/scripts/archive_old_case_memory_stores.py
+++ b/scripts/archive_old_case_memory_stores.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Archive (delete) per-case memory stores older than N days.
+
+Targets stores whose name matches the `bb-case-*` prefix. The shared
+`bb-platform-priors` store is hard-skipped regardless of age.
+
+Dry-run by default. Pass `--apply` to actually delete.
+
+Usage:
+    python scripts/archive_old_case_memory_stores.py
+    python scripts/archive_old_case_memory_stores.py --days 14
+    python scripts/archive_old_case_memory_stores.py --days 14 --apply
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+PLATFORM_STORE_NAME = "bb-platform-priors"
+CASE_PREFIXES = ("bb-case-", "bb-forensic-learnings-")
+
+
+def _parse_created_at(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _is_case_store(name: str | None) -> bool:
+    if not name:
+        return False
+    return any(name.startswith(p) for p in CASE_PREFIXES)
+
+
+def find_archivable(client: Any, *, days: int, now: datetime | None = None) -> list[dict[str, Any]]:
+    beta = getattr(client, "beta", None)
+    stores_api = getattr(beta, "memory_stores", None)
+    if stores_api is None:
+        raise RuntimeError("client.beta.memory_stores not available on this SDK.")
+    page = stores_api.list()
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=days)
+    out: list[dict[str, Any]] = []
+    for item in items:
+        name = getattr(item, "name", None)
+        if name == PLATFORM_STORE_NAME:
+            continue
+        if not _is_case_store(name):
+            continue
+        created = _parse_created_at(getattr(item, "created_at", None))
+        if created is None or created > cutoff:
+            continue
+        out.append(
+            {
+                "id": getattr(item, "id", None),
+                "name": name,
+                "created_at": created.isoformat(timespec="seconds"),
+            }
+        )
+    return out
+
+
+def archive(client: Any, *, days: int, apply: bool) -> int:
+    candidates = find_archivable(client, days=days)
+    if not candidates:
+        print(f"no case stores older than {days} days.")
+        return 0
+
+    stores_api = client.beta.memory_stores
+    deleted = 0
+    for c in candidates:
+        if c["name"] == PLATFORM_STORE_NAME:
+            print(f"skip: {c['name']} ({c['id']}) is the platform store; refusing.")
+            continue
+        if not apply:
+            print(f"DRY-RUN would delete: {c['name']} ({c['id']}) created={c['created_at']}")
+            continue
+        try:
+            stores_api.delete(c["id"])
+            print(f"deleted: {c['name']} ({c['id']})")
+            deleted += 1
+        except Exception as exc:
+            print(f"error deleting {c['name']} ({c['id']}): {exc}", file=sys.stderr)
+    if not apply:
+        print(f"DRY-RUN complete. {len(candidates)} stores match. pass --apply to delete.")
+    else:
+        print(f"deleted {deleted}/{len(candidates)} matching stores.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--days", type=int, default=30, help="age threshold in days (default: 30)")
+    p.add_argument("--apply", action="store_true", help="actually delete (default: dry-run)")
+    args = p.parse_args(argv)
+
+    from black_box.analysis.client import build_client
+
+    client = build_client()
+    try:
+        return archive(client, days=args.days, apply=args.apply)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/delete_case_memory_store.py
+++ b/scripts/delete_case_memory_store.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Delete one specific managed memory store by id or name.
+
+Hard guard: refuses to delete `bb-platform-priors`.
+Confirms interactively unless `--yes` is passed.
+
+Usage:
+    python scripts/delete_case_memory_store.py --id memstore_abc
+    python scripts/delete_case_memory_store.py --name bb-case-foo --yes
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+PLATFORM_STORE_NAME = "bb-platform-priors"
+
+
+def _resolve(client: Any, *, id_: str | None, name: str | None) -> dict[str, Any] | None:
+    stores_api = getattr(getattr(client, "beta", None), "memory_stores", None)
+    if stores_api is None:
+        raise RuntimeError("client.beta.memory_stores not available on this SDK.")
+    page = stores_api.list()
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    for item in items:
+        iid = getattr(item, "id", None)
+        iname = getattr(item, "name", None)
+        if id_ is not None and iid == id_:
+            return {"id": iid, "name": iname}
+        if name is not None and iname == name:
+            return {"id": iid, "name": iname}
+    return None
+
+
+def delete_store(client: Any, *, id_: str | None, name: str | None, yes: bool) -> int:
+    if not id_ and not name:
+        print("error: pass --id or --name", file=sys.stderr)
+        return 2
+
+    target = _resolve(client, id_=id_, name=name)
+    if target is None:
+        print(f"error: no store matched (id={id_!r}, name={name!r})", file=sys.stderr)
+        return 1
+
+    if target["name"] == PLATFORM_STORE_NAME:
+        print(
+            f"refused: {PLATFORM_STORE_NAME!r} is the platform priors store; "
+            "deleting it would erase verified human-curated knowledge.",
+            file=sys.stderr,
+        )
+        return 3
+
+    if not yes:
+        prompt = f"DELETE {target['name']} ({target['id']})? type 'yes' to confirm: "
+        try:
+            answer = input(prompt)
+        except EOFError:
+            answer = ""
+        if answer.strip().lower() != "yes":
+            print("aborted.")
+            return 0
+
+    stores_api = client.beta.memory_stores
+    stores_api.delete(target["id"])
+    print(f"deleted: {target['name']} ({target['id']})")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--id", dest="id_", help="store id to delete")
+    p.add_argument("--name", help="store name to delete")
+    p.add_argument("--yes", action="store_true", help="skip the confirm prompt")
+    args = p.parse_args(argv)
+
+    from black_box.analysis.client import build_client
+
+    client = build_client()
+    try:
+        return delete_store(client, id_=args.id_, name=args.name, yes=args.yes)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/export_memory_versions.py
+++ b/scripts/export_memory_versions.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Export every memory path's version history from a managed memory store.
+
+Output: `data/memory_exports/<store_id>/<sanitized_path>.versions.jsonl`,
+one JSON line per version with version_id, created_at, sha256, size, and
+optionally `content` if `--include-content` is set.
+
+Usage:
+    python scripts/export_memory_versions.py --store bb-platform-priors
+    python scripts/export_memory_versions.py --store memstore_abc --include-content
+    python scripts/export_memory_versions.py --store bb-platform-priors --output /tmp/exports
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def _resolve_store(stores_api: Any, key: str) -> Any:
+    page = stores_api.list()
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    for item in items:
+        if getattr(item, "id", None) == key or getattr(item, "name", None) == key:
+            return item
+    return None
+
+
+def _safe_filename(path: str) -> str:
+    return path.strip("/").replace("/", "__") or "_root"
+
+
+def _list_paths(memories_api: Any, store_id: str) -> Iterable[Any]:
+    page = memories_api.list(memory_store_id=store_id)
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    return items
+
+
+def _list_versions(memories_api: Any, store_id: str, path: str) -> Iterable[Any]:
+    versions_api = getattr(memories_api, "versions", None)
+    if versions_api is not None:
+        page = versions_api.list(memory_store_id=store_id, path=path)
+    else:
+        page = memories_api.list(memory_store_id=store_id, path=path, history=True)
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    return items
+
+
+def _version_record(v: Any, *, include_content: bool) -> dict[str, Any]:
+    content = getattr(v, "content", None)
+    if isinstance(content, str):
+        sha256 = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        size = len(content.encode("utf-8"))
+    else:
+        sha256 = getattr(v, "sha256", None)
+        size = getattr(v, "size", None) or getattr(v, "byte_size", None)
+    rec = {
+        "version_id": getattr(v, "id", None) or getattr(v, "version_id", None),
+        "created_at": str(getattr(v, "created_at", "") or ""),
+        "sha256": sha256,
+        "size": size,
+    }
+    if include_content:
+        rec["content"] = content
+    return rec
+
+
+def export_versions(
+    client: Any,
+    *,
+    store: str,
+    output_root: Path,
+    include_content: bool,
+) -> tuple[int, int]:
+    stores_api = getattr(getattr(client, "beta", None), "memory_stores", None)
+    if stores_api is None:
+        raise RuntimeError("client.beta.memory_stores not available on this SDK.")
+    memories_api = getattr(stores_api, "memories", None)
+    if memories_api is None:
+        raise RuntimeError("client.beta.memory_stores.memories not available on this SDK.")
+
+    target = _resolve_store(stores_api, store)
+    if target is None:
+        raise RuntimeError(f"no store found matching {store!r}")
+
+    store_id = getattr(target, "id", store)
+    out_dir = output_root / store_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    paths_seen = 0
+    versions_seen = 0
+    for memory in _list_paths(memories_api, store_id):
+        path = getattr(memory, "path", None)
+        if not path:
+            continue
+        paths_seen += 1
+        out_file = out_dir / f"{_safe_filename(path)}.versions.jsonl"
+        with out_file.open("w", encoding="utf-8") as fh:
+            for v in _list_versions(memories_api, store_id, path):
+                rec = _version_record(v, include_content=include_content)
+                fh.write(json.dumps(rec, sort_keys=True) + "\n")
+                versions_seen += 1
+        print(f"wrote {out_file} (path={path})")
+    return paths_seen, versions_seen
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--store", required=True, help="store name or id")
+    p.add_argument(
+        "--output",
+        default="data/memory_exports",
+        help="root output directory (default: data/memory_exports)",
+    )
+    p.add_argument("--include-content", action="store_true", help="include version body in dump")
+    args = p.parse_args(argv)
+
+    from black_box.analysis.client import build_client
+
+    client = build_client()
+    try:
+        paths, versions = export_versions(
+            client,
+            store=args.store,
+            output_root=Path(args.output),
+            include_content=args.include_content,
+        )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(f"done. paths={paths} versions={versions}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/list_managed_memory_stores.py
+++ b/scripts/list_managed_memory_stores.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""List all native Anthropic Managed Agents memory stores in the org.
+
+Usage:
+    python scripts/list_managed_memory_stores.py
+    python scripts/list_managed_memory_stores.py --json
+
+Falls back gracefully if the installed anthropic SDK predates `memory_stores`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _fmt_ts(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc).isoformat(timespec="seconds")
+    return str(value)
+
+
+def _row(item: Any) -> dict[str, Any]:
+    return {
+        "id": getattr(item, "id", None),
+        "name": getattr(item, "name", None),
+        "created_at": _fmt_ts(getattr(item, "created_at", None)),
+        "size": getattr(item, "size", None) or getattr(item, "byte_size", None),
+        "memory_count": getattr(item, "memory_count", None),
+        "description": getattr(item, "description", None),
+    }
+
+
+def list_stores(client: Any) -> list[dict[str, Any]]:
+    beta = getattr(client, "beta", None)
+    stores_api = getattr(beta, "memory_stores", None)
+    if stores_api is None:
+        raise RuntimeError(
+            "client.beta.memory_stores not available on this anthropic SDK; "
+            "upgrade to a build that exposes managed memory stores."
+        )
+    page = stores_api.list()
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    return [_row(item) for item in items]
+
+
+def _print_table(rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        print("(no memory stores)")
+        return
+    headers = ["id", "name", "created_at", "size", "memory_count"]
+    widths = {h: max(len(h), max((len(str(r.get(h) or "")) for r in rows), default=0)) for h in headers}
+    line = "  ".join(h.ljust(widths[h]) for h in headers)
+    print(line)
+    print("  ".join("-" * widths[h] for h in headers))
+    for r in rows:
+        print("  ".join(str(r.get(h) or "").ljust(widths[h]) for h in headers))
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = p.parse_args(argv)
+
+    from black_box.analysis.client import build_client
+
+    client = build_client()
+    try:
+        rows = list_stores(client)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(rows, indent=2, sort_keys=True))
+    else:
+        _print_table(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/black_box/memory/cli.py
+++ b/src/black_box/memory/cli.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: MIT
+"""`blackbox-memory` — lifecycle, audit, and promotion CLI for native managed memory stores.
+
+Subcommands:
+    audit-native --store NAME              paths, last_modified, version_count, sha256
+    export-native-versions --store NAME    full version history dump (delegates to script)
+    redact-native-version --version ID --reason TXT
+                                            redact a specific memory version (SDK redaction API)
+    propose-promotion ANALYSIS_ID          show candidate priors emitted by an agent run
+    diff-promotion ANALYSIS_ID             diff proposal against current bb-platform-priors
+    approve-promotion ANALYSIS_ID          promote (verified=True) and audit-log
+    reject-promotion ANALYSIS_ID --reason  move proposal to rejected/, audit-log
+
+Designed to run on anthropic 0.96.0 (no `memory_stores` exposed) for tests by
+guarding every SDK touchpoint with `getattr(client.beta, "memory_stores", None)`.
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+PLATFORM_STORE_NAME = "bb-platform-priors"
+
+PROPOSED_DIR = Path("data/memory/proposed_promotions")
+REJECTED_DIR = Path("data/memory/rejected_promotions")
+PROMOTION_LOG = Path("data/memory/promotion_log.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _stores_api(client: Any) -> Any:
+    beta = getattr(client, "beta", None)
+    api = getattr(beta, "memory_stores", None)
+    if api is None:
+        raise RuntimeError(
+            "client.beta.memory_stores not available on this anthropic SDK; "
+            "upgrade to a build that exposes managed memory stores."
+        )
+    return api
+
+
+def _memories_api(client: Any) -> Any:
+    api = getattr(_stores_api(client), "memories", None)
+    if api is None:
+        raise RuntimeError("client.beta.memory_stores.memories not available on this SDK.")
+    return api
+
+
+def _resolve_store(stores_api: Any, key: str) -> Any:
+    page = stores_api.list()
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    for item in items:
+        if getattr(item, "id", None) == key or getattr(item, "name", None) == key:
+            return item
+    return None
+
+
+def _iter_data(page: Any) -> list[Any]:
+    items = getattr(page, "data", None)
+    if items is None:
+        try:
+            items = list(page)
+        except TypeError:
+            items = []
+    return list(items)
+
+
+def _content_sha(content: Any) -> str | None:
+    if isinstance(content, str):
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _append_audit(entry: dict[str, Any]) -> None:
+    PROMOTION_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with PROMOTION_LOG.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _platform_content(client: Any) -> dict[str, str]:
+    stores_api = _stores_api(client)
+    target = _resolve_store(stores_api, PLATFORM_STORE_NAME)
+    if target is None:
+        return {}
+    memories_api = _memories_api(client)
+    out: dict[str, str] = {}
+    page = memories_api.list(memory_store_id=getattr(target, "id"))
+    for m in _iter_data(page):
+        path = getattr(m, "path", None)
+        content = getattr(m, "content", None)
+        if path is not None and isinstance(content, str):
+            out[path] = content
+    return out
+
+
+# ---------------------------------------------------------------------------
+# audit-native
+# ---------------------------------------------------------------------------
+def audit_native(client: Any, *, store: str) -> int:
+    stores_api = _stores_api(client)
+    target = _resolve_store(stores_api, store)
+    if target is None:
+        print(f"error: no store matched {store!r}", file=sys.stderr)
+        return 1
+    memories_api = _memories_api(client)
+    store_id = getattr(target, "id")
+    page = memories_api.list(memory_store_id=store_id)
+    rows: list[dict[str, Any]] = []
+    for m in _iter_data(page):
+        path = getattr(m, "path", None)
+        last_modified = str(getattr(m, "updated_at", "") or getattr(m, "created_at", "") or "")
+        version_count = getattr(m, "version_count", None)
+        if version_count is None:
+            versions_api = getattr(memories_api, "versions", None)
+            if versions_api is not None:
+                try:
+                    vpage = versions_api.list(memory_store_id=store_id, path=path)
+                    version_count = len(_iter_data(vpage))
+                except Exception:
+                    version_count = None
+        content = getattr(m, "content", None)
+        sha = _content_sha(content) or getattr(m, "sha256", None)
+        rows.append(
+            {
+                "path": path,
+                "last_modified": last_modified,
+                "version_count": version_count,
+                "sha256": sha,
+            }
+        )
+    print(json.dumps({"store": store, "store_id": store_id, "memories": rows}, indent=2, sort_keys=True))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# export-native-versions (delegate to script for real API; reuse logic)
+# ---------------------------------------------------------------------------
+def export_native_versions(client: Any, *, store: str, include_content: bool, output: Path) -> int:
+    from scripts.export_memory_versions import export_versions  # type: ignore
+
+    paths, versions = export_versions(
+        client, store=store, output_root=output, include_content=include_content
+    )
+    print(f"done. paths={paths} versions={versions}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# redact-native-version
+# ---------------------------------------------------------------------------
+def redact_native_version(client: Any, *, version_id: str, reason: str) -> int:
+    if not reason or not reason.strip():
+        print("error: --reason is required and must be non-empty.", file=sys.stderr)
+        return 2
+    memories_api = _memories_api(client)
+    redact_fn = (
+        getattr(memories_api, "redact", None)
+        or getattr(getattr(memories_api, "versions", None), "redact", None)
+    )
+    if redact_fn is None:
+        raise RuntimeError(
+            "memories.redact not available on this SDK; upgrade to a build that "
+            "exposes the redaction API."
+        )
+    result = redact_fn(version_id=version_id, reason=reason)
+    rid = getattr(result, "id", None) or getattr(result, "version_id", None)
+    print(f"redacted version: {rid or version_id}")
+    _append_audit(
+        {
+            "kind": "redact",
+            "version_id": version_id,
+            "reason": reason,
+            "ts": _now_iso(),
+        }
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# propose-promotion
+# ---------------------------------------------------------------------------
+def propose_promotion(*, analysis_id: str) -> int:
+    proposal_path = PROPOSED_DIR / f"{analysis_id}.json"
+    if not proposal_path.exists():
+        print(f"error: no proposal at {proposal_path}", file=sys.stderr)
+        return 1
+    proposal = _load_json(proposal_path)
+    print(json.dumps(proposal, indent=2, sort_keys=True))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# diff-promotion
+# ---------------------------------------------------------------------------
+def _diff_one(path: str, old: str, new: str) -> str:
+    diff = difflib.unified_diff(
+        old.splitlines(keepends=True),
+        new.splitlines(keepends=True),
+        fromfile=f"a{path}",
+        tofile=f"b{path}",
+        n=3,
+    )
+    return "".join(diff)
+
+
+def diff_promotion(client: Any, *, analysis_id: str) -> int:
+    proposal_path = PROPOSED_DIR / f"{analysis_id}.json"
+    if not proposal_path.exists():
+        print(f"error: no proposal at {proposal_path}", file=sys.stderr)
+        return 1
+    proposal = _load_json(proposal_path)
+    priors: list[dict[str, Any]] = list(proposal.get("priors") or proposal.get("verified_priors") or [])
+    if not priors:
+        print("(proposal has no priors)")
+        return 0
+
+    current = _platform_content(client)
+    any_diff = False
+    for prior in priors:
+        path = prior.get("path")
+        new_content = prior.get("content") or ""
+        old_content = current.get(path or "", "")
+        if old_content == new_content:
+            print(f"== {path} (no change)")
+            continue
+        any_diff = True
+        if not old_content:
+            print(f"++ {path} (NEW)")
+            for ln in new_content.splitlines():
+                print(f"+ {ln}")
+        else:
+            d = _diff_one(path or "", old_content, new_content)
+            print(d if d else f"~~ {path} (binary or no textual diff)")
+    if not any_diff:
+        print("no differences vs current platform priors.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# approve-promotion
+# ---------------------------------------------------------------------------
+def approve_promotion(client: Any, *, analysis_id: str) -> int:
+    from black_box.memory.verification import promote_verified_priors_to_managed_memory
+
+    proposal_path = PROPOSED_DIR / f"{analysis_id}.json"
+    if not proposal_path.exists():
+        print(f"error: no proposal at {proposal_path}", file=sys.stderr)
+        return 1
+    proposal = _load_json(proposal_path)
+    priors: list[dict[str, Any]] = list(proposal.get("priors") or proposal.get("verified_priors") or [])
+    if not priors:
+        print("error: proposal has no priors to promote.", file=sys.stderr)
+        return 1
+
+    stores_api = _stores_api(client)
+    target = _resolve_store(stores_api, PLATFORM_STORE_NAME)
+    if target is None:
+        print(f"error: platform store {PLATFORM_STORE_NAME!r} does not exist.", file=sys.stderr)
+        return 1
+    store_id = getattr(target, "id")
+
+    flagged = [{**p, "verified": True} for p in priors]
+    written = promote_verified_priors_to_managed_memory(
+        client=client,
+        store_id=store_id,
+        verified_priors=flagged,
+    )
+    print(f"approved: promoted {len(written)} priors into {PLATFORM_STORE_NAME} ({store_id}).")
+    _append_audit(
+        {
+            "kind": "approve",
+            "analysis_id": analysis_id,
+            "store_id": store_id,
+            "memory_ids": written,
+            "paths": [p.get("path") for p in priors],
+            "ts": _now_iso(),
+        }
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# reject-promotion
+# ---------------------------------------------------------------------------
+def reject_promotion(*, analysis_id: str, reason: str) -> int:
+    if not reason or not reason.strip():
+        print("error: --reason is required and must be non-empty.", file=sys.stderr)
+        return 2
+    proposal_path = PROPOSED_DIR / f"{analysis_id}.json"
+    if not proposal_path.exists():
+        print(f"error: no proposal at {proposal_path}", file=sys.stderr)
+        return 1
+    REJECTED_DIR.mkdir(parents=True, exist_ok=True)
+    dest = REJECTED_DIR / f"{analysis_id}.json"
+    proposal = _load_json(proposal_path)
+    proposal["_rejected"] = {"reason": reason, "ts": _now_iso()}
+    with dest.open("w", encoding="utf-8") as fh:
+        json.dump(proposal, fh, indent=2, sort_keys=True)
+    proposal_path.unlink()
+    print(f"rejected: moved {proposal_path} -> {dest}")
+    _append_audit(
+        {
+            "kind": "reject",
+            "analysis_id": analysis_id,
+            "reason": reason,
+            "ts": _now_iso(),
+        }
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# argparse
+# ---------------------------------------------------------------------------
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="blackbox-memory",
+        description="Lifecycle, audit, and promotion CLI for native managed memory stores.",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("audit-native", help="audit memories in a store")
+    s.add_argument("--store", required=True)
+
+    s = sub.add_parser("export-native-versions", help="dump version history of a store")
+    s.add_argument("--store", required=True)
+    s.add_argument("--output", default="data/memory_exports")
+    s.add_argument("--include-content", action="store_true")
+
+    s = sub.add_parser("redact-native-version", help="redact one memory version")
+    s.add_argument("--version", dest="version_id", required=True)
+    s.add_argument("--reason", required=True)
+
+    s = sub.add_parser("propose-promotion", help="show a candidate promotion proposal")
+    s.add_argument("analysis_id")
+
+    s = sub.add_parser("diff-promotion", help="diff proposal vs current platform priors")
+    s.add_argument("analysis_id")
+
+    s = sub.add_parser("approve-promotion", help="promote a proposal as verified")
+    s.add_argument("analysis_id")
+
+    s = sub.add_parser("reject-promotion", help="reject a proposal with reason")
+    s.add_argument("analysis_id")
+    s.add_argument("--reason", required=True)
+
+    return p
+
+
+def main(argv: list[str] | None = None, *, client: Any | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    needs_client = args.cmd in {
+        "audit-native",
+        "export-native-versions",
+        "redact-native-version",
+        "diff-promotion",
+        "approve-promotion",
+    }
+    if needs_client and client is None:
+        from black_box.analysis.client import build_client
+
+        client = build_client()
+
+    try:
+        if args.cmd == "audit-native":
+            return audit_native(client, store=args.store)
+        if args.cmd == "export-native-versions":
+            return export_native_versions(
+                client,
+                store=args.store,
+                include_content=args.include_content,
+                output=Path(args.output),
+            )
+        if args.cmd == "redact-native-version":
+            return redact_native_version(client, version_id=args.version_id, reason=args.reason)
+        if args.cmd == "propose-promotion":
+            return propose_promotion(analysis_id=args.analysis_id)
+        if args.cmd == "diff-promotion":
+            return diff_promotion(client, analysis_id=args.analysis_id)
+        if args.cmd == "approve-promotion":
+            return approve_promotion(client, analysis_id=args.analysis_id)
+        if args.cmd == "reject-promotion":
+            return reject_promotion(analysis_id=args.analysis_id, reason=args.reason)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,0 +1,392 @@
+"""Tests for `blackbox-memory` CLI + lifecycle scripts.
+
+Mocks the SDK surface — the installed anthropic 0.96.0 does not expose
+`memory_stores`, so we monkeypatch a `_FakeClient` everywhere.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from black_box.memory import cli as memcli
+
+
+# ---------------------------------------------------------------------------
+# Fakes (mirror the patterns used in test_memory_stores.py)
+# ---------------------------------------------------------------------------
+class _FakeMemoriesAPI:
+    def __init__(self, items: dict[str, list[Any]] | None = None) -> None:
+        self.items: dict[str, list[Any]] = items or {}
+        self.created: list[dict] = []
+
+    def list(self, *, memory_store_id, path=None, history=False):
+        if path is not None:
+            v = []
+            for mem in self.items.get(memory_store_id, []):
+                if getattr(mem, "path", None) == path:
+                    v.extend(getattr(mem, "_versions", []))
+            return SimpleNamespace(data=v)
+        return SimpleNamespace(data=list(self.items.get(memory_store_id, [])))
+
+    def create(self, *, memory_store_id, path, content, **_):
+        self.created.append({"memory_store_id": memory_store_id, "path": path, "content": content})
+        rec = SimpleNamespace(
+            id=f"mem_{len(self.created):04d}",
+            memory_store_id=memory_store_id,
+            path=path,
+            content=content,
+            _versions=[SimpleNamespace(id=f"ver_{len(self.created):04d}", content=content)],
+        )
+        self.items.setdefault(memory_store_id, []).append(rec)
+        return rec
+
+    def redact(self, *, version_id, reason):
+        return SimpleNamespace(id=version_id, redacted=True, reason=reason)
+
+
+class _FakeMemoryStoresAPI:
+    def __init__(self, preexisting: list[Any] | None = None, mems: dict[str, list[Any]] | None = None) -> None:
+        self._stores: list[Any] = list(preexisting or [])
+        self.created: list[dict] = []
+        self.deleted: list[str] = []
+        self.memories = _FakeMemoriesAPI(mems)
+
+    def list(self):
+        return SimpleNamespace(data=list(self._stores))
+
+    def create(self, *, name, description=None, metadata=None, **_):
+        store = SimpleNamespace(
+            id=f"memstore_{len(self._stores) + 1:04d}",
+            name=name,
+            description=description,
+            metadata=metadata or {},
+            created_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        )
+        self._stores.append(store)
+        self.created.append({"name": name, "description": description})
+        return store
+
+    def delete(self, store_id: str):
+        self._stores = [s for s in self._stores if getattr(s, "id", None) != store_id]
+        self.deleted.append(store_id)
+        return SimpleNamespace(deleted=True, id=store_id)
+
+
+class _FakeBeta:
+    def __init__(self, stores: _FakeMemoryStoresAPI) -> None:
+        self.memory_stores = stores
+
+
+class _FakeClient:
+    def __init__(self, stores: _FakeMemoryStoresAPI) -> None:
+        self.beta = _FakeBeta(stores)
+
+
+def _store(id_: str, name: str, *, days_old: int = 0) -> Any:
+    created = (datetime.now(timezone.utc) - timedelta(days=days_old)).isoformat(timespec="seconds")
+    return SimpleNamespace(id=id_, name=name, created_at=created)
+
+
+@pytest.fixture
+def cwd_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(memcli, "PROPOSED_DIR", tmp_path / "data/memory/proposed_promotions")
+    monkeypatch.setattr(memcli, "REJECTED_DIR", tmp_path / "data/memory/rejected_promotions")
+    monkeypatch.setattr(memcli, "PROMOTION_LOG", tmp_path / "data/memory/promotion_log.jsonl")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. list_managed_memory_stores
+# ---------------------------------------------------------------------------
+def test_list_managed_memory_stores_table_and_json(capsys: pytest.CaptureFixture):
+    from scripts import list_managed_memory_stores as lms
+
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[
+            _store("memstore_a", "bb-platform-priors", days_old=10),
+            _store("memstore_b", "bb-case-foo", days_old=5),
+        ]
+    )
+    client = _FakeClient(stores)
+
+    rows = lms.list_stores(client)
+    assert {r["name"] for r in rows} == {"bb-platform-priors", "bb-case-foo"}
+    assert all("id" in r and "created_at" in r for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# 2. archive dry-run
+# ---------------------------------------------------------------------------
+def test_archive_dry_run_lists_old_case_stores(capsys: pytest.CaptureFixture):
+    from scripts import archive_old_case_memory_stores as arc
+
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[
+            _store("memstore_p", "bb-platform-priors", days_old=99),
+            _store("memstore_old", "bb-case-old", days_old=45),
+            _store("memstore_new", "bb-case-new", days_old=2),
+            _store("memstore_legacy", "bb-forensic-learnings-x", days_old=60),
+        ]
+    )
+    client = _FakeClient(stores)
+
+    rc = arc.archive(client, days=30, apply=False)
+    assert rc == 0
+    assert stores.deleted == []
+    out = capsys.readouterr().out
+    assert "DRY-RUN" in out
+    assert "bb-case-old" in out
+    assert "bb-forensic-learnings-x" in out
+    assert "bb-platform-priors" not in out
+    assert "bb-case-new" not in out
+
+
+# ---------------------------------------------------------------------------
+# 3. archive guard against platform-priors
+# ---------------------------------------------------------------------------
+def test_archive_apply_never_deletes_platform_priors():
+    from scripts import archive_old_case_memory_stores as arc
+
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[
+            _store("memstore_p", "bb-platform-priors", days_old=99),
+            _store("memstore_old", "bb-case-old", days_old=45),
+        ]
+    )
+    client = _FakeClient(stores)
+
+    rc = arc.archive(client, days=30, apply=True)
+    assert rc == 0
+    assert "memstore_old" in stores.deleted
+    assert "memstore_p" not in stores.deleted
+
+
+# ---------------------------------------------------------------------------
+# 4. delete guard against platform-priors
+# ---------------------------------------------------------------------------
+def test_delete_case_memory_store_refuses_platform(capsys: pytest.CaptureFixture):
+    from scripts import delete_case_memory_store as dcs
+
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[_store("memstore_p", "bb-platform-priors", days_old=1)]
+    )
+    client = _FakeClient(stores)
+
+    rc = dcs.delete_store(client, id_=None, name="bb-platform-priors", yes=True)
+    assert rc == 3
+    assert stores.deleted == []
+    err = capsys.readouterr().err
+    assert "refused" in err
+
+
+def test_delete_case_memory_store_deletes_named_case_store():
+    from scripts import delete_case_memory_store as dcs
+
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[
+            _store("memstore_p", "bb-platform-priors", days_old=1),
+            _store("memstore_old", "bb-case-old", days_old=1),
+        ]
+    )
+    client = _FakeClient(stores)
+    rc = dcs.delete_store(client, id_=None, name="bb-case-old", yes=True)
+    assert rc == 0
+    assert stores.deleted == ["memstore_old"]
+
+
+# ---------------------------------------------------------------------------
+# 5. propose-promotion
+# ---------------------------------------------------------------------------
+def test_propose_promotion_prints_proposal(cwd_tmp: Path, capsys: pytest.CaptureFixture):
+    memcli.PROPOSED_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "analysis_id": "case_42",
+        "priors": [{"path": "/priors/foo.md", "content": "hello"}],
+    }
+    (memcli.PROPOSED_DIR / "case_42.json").write_text(json.dumps(payload))
+
+    rc = memcli.main(["propose-promotion", "case_42"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "case_42" in out
+    assert "/priors/foo.md" in out
+
+
+def test_propose_promotion_missing_returns_error(cwd_tmp: Path, capsys: pytest.CaptureFixture):
+    rc = memcli.main(["propose-promotion", "nope"])
+    assert rc == 1
+    assert "no proposal" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# 6. diff-promotion
+# ---------------------------------------------------------------------------
+def test_diff_promotion_shows_new_path(cwd_tmp: Path, capsys: pytest.CaptureFixture):
+    memcli.PROPOSED_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "analysis_id": "case_43",
+        "priors": [{"path": "/priors/new.md", "content": "freshly verified"}],
+    }
+    (memcli.PROPOSED_DIR / "case_43.json").write_text(json.dumps(payload))
+
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[_store("memstore_p", "bb-platform-priors", days_old=1)],
+        mems={"memstore_p": []},
+    )
+    client = _FakeClient(stores)
+
+    rc = memcli.main(["diff-promotion", "case_43"], client=client)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "/priors/new.md" in out
+    assert "NEW" in out
+
+
+def test_diff_promotion_shows_textual_diff(cwd_tmp: Path, capsys: pytest.CaptureFixture):
+    memcli.PROPOSED_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "analysis_id": "case_44",
+        "priors": [{"path": "/priors/x.md", "content": "v2 content\nline\n"}],
+    }
+    (memcli.PROPOSED_DIR / "case_44.json").write_text(json.dumps(payload))
+
+    existing = SimpleNamespace(
+        id="mem_1",
+        path="/priors/x.md",
+        content="v1 content\nline\n",
+        _versions=[],
+    )
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[_store("memstore_p", "bb-platform-priors", days_old=1)],
+        mems={"memstore_p": [existing]},
+    )
+    client = _FakeClient(stores)
+
+    rc = memcli.main(["diff-promotion", "case_44"], client=client)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "v1 content" in out
+    assert "v2 content" in out
+
+
+# ---------------------------------------------------------------------------
+# 7. approve-promotion roundtrip
+# ---------------------------------------------------------------------------
+def test_approve_promotion_writes_and_audits(cwd_tmp: Path, capsys: pytest.CaptureFixture):
+    memcli.PROPOSED_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "analysis_id": "case_45",
+        "priors": [{"path": "/priors/verified.md", "content": "rtk break confirmed"}],
+    }
+    (memcli.PROPOSED_DIR / "case_45.json").write_text(json.dumps(payload))
+
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[_store("memstore_p", "bb-platform-priors", days_old=1)],
+    )
+    client = _FakeClient(stores)
+
+    rc = memcli.main(["approve-promotion", "case_45"], client=client)
+    assert rc == 0
+    assert any(c["path"] == "/priors/verified.md" for c in stores.memories.created)
+
+    log = memcli.PROMOTION_LOG.read_text(encoding="utf-8").strip().splitlines()
+    assert len(log) == 1
+    entry = json.loads(log[0])
+    assert entry["kind"] == "approve"
+    assert entry["analysis_id"] == "case_45"
+    assert "/priors/verified.md" in entry["paths"]
+
+
+def test_approve_promotion_fails_when_platform_missing(cwd_tmp: Path, capsys: pytest.CaptureFixture):
+    memcli.PROPOSED_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {"analysis_id": "case_46", "priors": [{"path": "/p.md", "content": "x"}]}
+    (memcli.PROPOSED_DIR / "case_46.json").write_text(json.dumps(payload))
+
+    stores = _FakeMemoryStoresAPI(preexisting=[])
+    client = _FakeClient(stores)
+
+    rc = memcli.main(["approve-promotion", "case_46"], client=client)
+    assert rc == 1
+    assert "platform store" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# 8. reject-promotion roundtrip
+# ---------------------------------------------------------------------------
+def test_reject_promotion_moves_proposal_and_audits(cwd_tmp: Path):
+    memcli.PROPOSED_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {"analysis_id": "case_47", "priors": [{"path": "/p.md", "content": "x"}]}
+    src = memcli.PROPOSED_DIR / "case_47.json"
+    src.write_text(json.dumps(payload))
+
+    rc = memcli.main(["reject-promotion", "case_47", "--reason", "operator narrative, not verified"])
+    assert rc == 0
+    assert not src.exists()
+    dest = memcli.REJECTED_DIR / "case_47.json"
+    assert dest.exists()
+    rejected = json.loads(dest.read_text(encoding="utf-8"))
+    assert rejected["_rejected"]["reason"] == "operator narrative, not verified"
+
+    log = memcli.PROMOTION_LOG.read_text(encoding="utf-8").strip().splitlines()
+    assert len(log) == 1
+    entry = json.loads(log[0])
+    assert entry["kind"] == "reject"
+    assert entry["analysis_id"] == "case_47"
+
+
+def test_reject_promotion_requires_reason(cwd_tmp: Path):
+    with pytest.raises(SystemExit):
+        memcli.main(["reject-promotion", "case_48"])
+
+
+# ---------------------------------------------------------------------------
+# 9. audit-native
+# ---------------------------------------------------------------------------
+def test_audit_native_prints_paths_and_sha(capsys: pytest.CaptureFixture):
+    existing = SimpleNamespace(
+        id="mem_1",
+        path="/priors/foo.md",
+        content="hello world",
+        updated_at="2026-04-25T00:00:00+00:00",
+        _versions=[SimpleNamespace(id="ver_a", content="hello world")],
+    )
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[_store("memstore_p", "bb-platform-priors", days_old=1)],
+        mems={"memstore_p": [existing]},
+    )
+    client = _FakeClient(stores)
+
+    rc = memcli.main(["audit-native", "--store", "bb-platform-priors"], client=client)
+    assert rc == 0
+    out = capsys.readouterr().out
+    blob = json.loads(out)
+    assert blob["store"] == "bb-platform-priors"
+    assert blob["memories"][0]["path"] == "/priors/foo.md"
+    assert len(blob["memories"][0]["sha256"]) == 64
+
+
+# ---------------------------------------------------------------------------
+# 10. redact-native-version
+# ---------------------------------------------------------------------------
+def test_redact_native_version_audits(cwd_tmp: Path, capsys: pytest.CaptureFixture):
+    stores = _FakeMemoryStoresAPI(
+        preexisting=[_store("memstore_p", "bb-platform-priors", days_old=1)],
+    )
+    client = _FakeClient(stores)
+    rc = memcli.main(
+        ["redact-native-version", "--version", "ver_42", "--reason", "PII removal"],
+        client=client,
+    )
+    assert rc == 0
+    log = memcli.PROMOTION_LOG.read_text(encoding="utf-8").strip().splitlines()
+    assert len(log) == 1
+    entry = json.loads(log[0])
+    assert entry["kind"] == "redact"
+    assert entry["version_id"] == "ver_42"
+    assert entry["reason"] == "PII removal"

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -5,15 +5,26 @@ Mocks the SDK surface — the installed anthropic 0.96.0 does not expose
 """
 from __future__ import annotations
 
+import importlib.util
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import pytest
 
 from black_box.memory import cli as memcli
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load_script(name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +116,7 @@ def cwd_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 # 1. list_managed_memory_stores
 # ---------------------------------------------------------------------------
 def test_list_managed_memory_stores_table_and_json(capsys: pytest.CaptureFixture):
-    from scripts import list_managed_memory_stores as lms
+    lms = _load_script("list_managed_memory_stores")
 
     stores = _FakeMemoryStoresAPI(
         preexisting=[
@@ -124,7 +135,7 @@ def test_list_managed_memory_stores_table_and_json(capsys: pytest.CaptureFixture
 # 2. archive dry-run
 # ---------------------------------------------------------------------------
 def test_archive_dry_run_lists_old_case_stores(capsys: pytest.CaptureFixture):
-    from scripts import archive_old_case_memory_stores as arc
+    arc = _load_script("archive_old_case_memory_stores")
 
     stores = _FakeMemoryStoresAPI(
         preexisting=[
@@ -151,7 +162,7 @@ def test_archive_dry_run_lists_old_case_stores(capsys: pytest.CaptureFixture):
 # 3. archive guard against platform-priors
 # ---------------------------------------------------------------------------
 def test_archive_apply_never_deletes_platform_priors():
-    from scripts import archive_old_case_memory_stores as arc
+    arc = _load_script("archive_old_case_memory_stores")
 
     stores = _FakeMemoryStoresAPI(
         preexisting=[
@@ -171,7 +182,7 @@ def test_archive_apply_never_deletes_platform_priors():
 # 4. delete guard against platform-priors
 # ---------------------------------------------------------------------------
 def test_delete_case_memory_store_refuses_platform(capsys: pytest.CaptureFixture):
-    from scripts import delete_case_memory_store as dcs
+    dcs = _load_script("delete_case_memory_store")
 
     stores = _FakeMemoryStoresAPI(
         preexisting=[_store("memstore_p", "bb-platform-priors", days_old=1)]
@@ -186,7 +197,7 @@ def test_delete_case_memory_store_refuses_platform(capsys: pytest.CaptureFixture
 
 
 def test_delete_case_memory_store_deletes_named_case_store():
-    from scripts import delete_case_memory_store as dcs
+    dcs = _load_script("delete_case_memory_store")
 
     stores = _FakeMemoryStoresAPI(
         preexisting=[


### PR DESCRIPTION
Stacked on #138 (native managed-agents memory_stores wiring). Once #138 merges, GitHub auto-retargets this to `master`.

## Lucas audit asks landed

- **#4 Lifecycle scripts.** `scripts/list_managed_memory_stores.py`, `scripts/archive_old_case_memory_stores.py` (dry-run by default, hard-skips `bb-platform-priors`), `scripts/delete_case_memory_store.py` (interactive confirm, refuses `bb-platform-priors`), `scripts/export_memory_versions.py` (dumps version history to `data/memory_exports/<store_id>/`).
- **#5 Audit + redaction CLI.** New `blackbox-memory` console-script (`src/black_box/memory/cli.py`):
  - `audit-native --store NAME` — paths + last_modified + version_count + sha256.
  - `export-native-versions --store NAME [--include-content]`.
  - `redact-native-version --version ID --reason TXT` — `--reason` required, audited.
- **#8 Human-gated promotion flow.** Same CLI:
  - `propose-promotion ANALYSIS_ID` reads `data/memory/proposed_promotions/<id>.json`.
  - `diff-promotion ANALYSIS_ID` per-path unified diff vs current `bb-platform-priors` content.
  - `approve-promotion ANALYSIS_ID` calls `promote_verified_priors_to_managed_memory(verified=True)` — the same gate from PR #138 — and writes an audit row to `data/memory/promotion_log.jsonl`.
  - `reject-promotion ANALYSIS_ID --reason TXT` moves the proposal to `data/memory/rejected_promotions/<id>.json` and writes an audit row.

## Constraints respected
- Did not touch `src/black_box/analysis/managed_agent.py`, `src/black_box/ui/`, `docs/MANAGED_AGENTS_MEMORY.md`, or `src/black_box/memory/sanitizer.py`.
- All SDK touches use `getattr(client.beta, "memory_stores", None)` so the module imports and `--help` runs on the installed `anthropic 0.96.0`.
- All client construction goes through `src/black_box/analysis/client.py::build_client()`.
- No model calls; no LangChain/RAG/vector DBs; no comments without a non-obvious WHY.

## Test plan
- [x] `PYTHONPATH=src pytest -q tests/test_memory_cli.py` — 15 tests pass.
- [x] `PYTHONPATH=src pytest -q` — full suite green (491 passed, 1 skipped).
- [x] `python -m black_box.memory.cli --help` prints help cleanly on `anthropic 0.96.0`.
- [x] `scripts/README.md` taxonomy test still green (rows added for the four new scripts).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>