### PR TITLE
feat(memory): UI memory card, docs, and live smoke harness (no execution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,12 @@ flowchart TB
 
 **Shipped:** stack wiring, pydantic records, four independent stores, `MemoryStack.open()`, accuracy roll-ups by case and bug class, taxonomy counts on every finalize.
 
-**Native Managed Agents memory stores** sit alongside the local stack. Every `ForensicAgent.open_session(...)` provisions two `client.beta.memory_stores.*` resources mounted under `/mnt/memory/`: a shared `bb-platform-priors` store (read-only, seeded from the bug taxonomy and verified anti-hypotheses like the `rtk_heading_break_01` prior that refutes "GPS fails in tunnel"), and a fresh per-case `bb-forensic-learnings-{case_key}` store (read-write, case-isolated). Promotion of unverified content into the platform store is blocked by `promote_verified_priors_to_managed_memory` until a human writes a `severity="confirmation"` entry to the verification ledger. Beta header `managed-agents-2026-04-01`, model `claude-opus-4-7`. Details: [docs/MEMORY_STACK.md](docs/MEMORY_STACK.md#native-managed-agents-memory-stores).
+**Native Managed Agents memory-store integration** is implemented and unit-tested; live edge smoke evidence is pending. Wiring details: [`docs/MANAGED_AGENTS_MEMORY.md`](docs/MANAGED_AGENTS_MEMORY.md). Reproduce locally with `python scripts/managed_memory_smoke.py --help`; the harness refuses to run until the SDK exposes `client.beta.memory_stores` and `--yes` confirms the projected $0.50–$1.50 spend.
+
+<!-- TODO(post-smoke): swap to live-validated phrasing -->
+<!--
+BlackBox combines a local audit-friendly L1-L4 memory stack with Claude Managed Agents native memory stores. Each forensic session mounts a shared read-only platform-priors store and a fresh case-isolated read-write store under /mnt/memory/. Cross-case promotion is gated by a human verification ledger.
+-->
 
 **Not yet shipped (roadmap):** the policy loop that reads L2 priors to bias the system prompt, uses L3 frequency as a tie-breaker on low-confidence hypotheses, and raises a regression alarm when L4 accuracy on a previously-solved case class drops below a threshold. Calling that "self-improving" would be overclaim until the loop is visible between runs.
 

--- a/docs/MANAGED_AGENTS_MEMORY.md
+++ b/docs/MANAGED_AGENTS_MEMORY.md
@@ -1,0 +1,200 @@
+# Managed Agents memory — local L1-L4 vs native `/mnt/memory/`
+
+Black Box runs two complementary memory layers on every forensic session.
+This doc explains what they are, why both exist, and how a learning gets
+promoted from per-case scratchpad to shared platform priors without ever
+slipping past a human.
+
+Cross-links: [`MEMORY_STACK.md`](MEMORY_STACK.md) for the local L1-L4
+substrate; [`MEMORY_PROMOTION_PIPELINE.md`](MEMORY_PROMOTION_PIPELINE.md)
+for the verify -> sanitize -> review -> promote flow (TODO: add when that
+doc lands).
+
+## Two layers, one pipeline
+
+```mermaid
+flowchart LR
+    subgraph LOCAL[Local L1-L4 stack · audit-friendly JSONL]
+        L1[L1 case<br/>hypotheses, steering]
+        L2[L2 platform<br/>signature -> bug_class priors]
+        L3[L3 taxonomy<br/>rolling counts]
+        L4[L4 eval<br/>predicted vs ground truth]
+    end
+
+    subgraph NATIVE[Native /mnt/memory/ · Anthropic memory_stores]
+        PRI[bb-platform-priors<br/>read-only · shared]
+        CASE[bb-forensic-learnings-{case_key}<br/>read-write · case-isolated]
+    end
+
+    SESSION[ForensicAgent.open_session] --> L1
+    SESSION --> CASE
+    SESSION -. mounts read-only .-> PRI
+
+    CASE -. verify -> sanitize -> review -> promote .-> PRI
+    L1 -. severity=confirmation note .-> PRI
+```
+
+The local stack is the system of record (every line is committed JSONL,
+greppable, replayable, no SDK dependency). The native mounts are the
+in-context knowledge surface the model sees inside its sandbox at
+`/mnt/memory/<slug>/...`.
+
+## Layer comparison
+
+| Aspect | Local L1-L4 (JSONL) | Native `/mnt/memory/` |
+|---|---|---|
+| Storage | append-only JSONL under `data/memory/` | Anthropic memory_stores (managed) |
+| Scope | host filesystem; survives across processes | per-Anthropic-account; survives across sessions |
+| Visibility to the model | only via prompt fragments we paste in | mounted as a real filesystem the agent can `ls`/`cat`/`write` |
+| Audit | every line is committed; `git log` is the audit | versioned by Anthropic memory_versions API + redaction tools |
+| Failure mode | file write fails -> raise | SDK call fails -> session continues without memory mount |
+| Trust model | flat append-only; no overwrite | platform store enforces read-only at the FS layer |
+| Use case | accuracy roll-ups, regression alarms, full replay | live retrieval inside the agent loop, no extra prompt tokens |
+
+## Native mounts in detail
+
+`ForensicAgent.open_session(...)` provisions two memory_stores per session:
+
+### Platform store · `bb-platform-priors`
+
+- Mode: **read-only**.
+- Mount path: `/mnt/memory/bb-platform-priors/...`
+- Lifetime: shared across every session for this account. Looked up by
+  name; only created on first call, idempotent thereafter.
+- Seed: bug taxonomy, anti-hypotheses (e.g. the `rtk_heading_break_01`
+  prior that refutes "GPS fails in tunnel"), the safety contract.
+- Source of truth: only human-verified knowledge ever lands here. Promotion
+  is gated by the verification ledger (see Pipeline below).
+
+### Case store · `bb-forensic-learnings-{case_key}`
+
+- Mode: **read-write**.
+- Mount path: `/mnt/memory/bb-forensic-learnings-{case_key}/...`
+- Lifetime: a fresh store is created for every session. Case-isolated by
+  construction, so one incident's scratchpad cannot leak into another.
+- Use: the agent's working memory across long-horizon analysis (signal -> bug-class
+  hypotheses, telemetry windows of interest, source-tree breadcrumbs).
+- Trust: anything written here is **case-scoped and unverified**. Operator
+  narratives and freshly-extracted observations live here; they do not get
+  copied verbatim into the platform store.
+
+Mount slugs follow Anthropic's deterministic name -> slug mapping; the SDK
+returns the authoritative `mount_path` on the response. The agent's system
+prompt explicitly tells it which slug is read-only.
+
+## Verify -> sanitize -> review -> promote pipeline
+
+The platform store is load-bearing. A bad prior (an unverified operator
+narrative, an injected adversarial entry, a fabricated "bug class") would
+poison every future session. The pipeline that gates promotion:
+
+```mermaid
+flowchart LR
+    SRC[case store entry<br/>or L1 case record] --> V{verify}
+    V -->|ledger lacks<br/>severity=confirmation| REJ[reject]
+    V -->|verified=True<br/>OR confirmation note| S{sanitize}
+    S -->|drops PII / secrets / paths| R{review}
+    R -->|human-approved| P[promote into<br/>bb-platform-priors]
+    R -->|rejected| REJ
+```
+
+Implementation pointers:
+
+- `black_box.memory.promote_verified_priors_to_managed_memory(...)` is the
+  only sanctioned write path into the platform store. It refuses entries
+  unless either:
+  1. `verified=True` is set explicitly on the entry, or
+  2. the entry references an `analysis_id` that has a
+     `severity == "confirmation"` row in `data/memory/verification.jsonl`.
+- Failure raises `UnverifiedMemoryPromotionError` BEFORE any SDK call —
+  the platform store is never partially mutated by an unverified batch.
+- The verification ledger (`memory/verification.py`) is append-only;
+  there is no edit / delete API and the test suite asserts the public
+  surface stays append-only.
+- TODO(post-merge): cross-link the full pipeline doc at
+  [`MEMORY_PROMOTION_PIPELINE.md`](MEMORY_PROMOTION_PIPELINE.md) once it
+  lands. The verify and review steps live there; the sanitize step lives
+  in `memory.sanitizer` (Agent 2 worktree).
+
+## Mount paths summary
+
+```
+/mnt/memory/
+  bb-platform-priors/                          # read-only, shared
+    priors/
+      bug_taxonomy.md
+      safety_contract.md
+      anti_hypotheses/
+        rtk_heading_break_01.md
+        ...
+  bb-forensic-learnings-{case_key}/            # read-write, fresh per session
+    notes/...
+    signals/...
+    hypotheses/...
+```
+
+The agent discovers what is there with `ls /mnt/memory/`; nothing is
+hard-coded into the system prompt. The seed paths above are the contract
+the platform-store seed code writes on first creation.
+
+## Versioning + redaction
+
+Anthropic exposes versioning + redaction APIs on memory_stores:
+
+- `memory_versions` — every write produces an immutable version. Reads can
+  pin a specific version to reproduce a past run. See the
+  [Anthropic memory_versions API](https://docs.claude.com/en/api/managed-agents/memory-versions)
+  reference (TODO: confirm exact path on next docs build).
+- Redaction — secrets, PII, or rolled-back priors can be redacted at the
+  store level without rewriting history. Redactions are themselves audited.
+
+Black Box treats memory_versions as a recovery surface, not a routine
+read path. The default `ForensicAgent.open_session` reads HEAD; replay
+runs that need a frozen prior set should pass an explicit version pin.
+
+## Why both layers exist
+
+Different jobs:
+
+- **Local L1-L4** is the **audit substrate**. Every claim in a report
+  traces back to a JSONL line we own. CI grep, regression alarms, and
+  the verification ledger all run against this layer; no Anthropic SDK
+  required. It is the answer to "show me, in `git log`, where this
+  conclusion came from."
+- **Native `/mnt/memory/`** is the **in-context retrieval surface**. The
+  agent reads it during the loop without us paying for prompt tokens to
+  paste priors in every turn. Read-only at the FS layer means the model
+  cannot accidentally overwrite a verified prior even if it tries.
+
+Removing either layer is a regression:
+
+- Drop local L1-L4 -> no replayable audit; no regression alarms; no
+  evidence trace.
+- Drop native `/mnt/memory/` -> every prior gets re-pasted into the
+  prompt every turn (token waste + cache misses), and the read-only
+  enforcement collapses to "trust the prompt".
+
+## Operator demo
+
+```bash
+# Endpoint that surfaces the live mount config to the UI memory card.
+curl -s http://127.0.0.1:8000/memory/native_status | jq .
+```
+
+Expected response (values come from `ForensicAgentConfig` defaults):
+
+```json
+{
+  "platform_store": {
+    "present": true,
+    "name": "bb-platform-priors",
+    "mode": "read_only"
+  },
+  "case_store_template": "bb-forensic-learnings-{case_key}",
+  "gate": "verification_ledger"
+}
+```
+
+The UI memory card on `/` is server-side rendered from this same payload
+so the card cannot drift from the agent provisioning code in
+`src/black_box/analysis/managed_agent.py`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ Per #90: classify each script as **eval / demo / ops / dev** so evaluators can t
 | `hero_analysis.py` | eval | hero analysis driver wrapper. |
 | `hero_bag0_indoor.py` | eval | hero-case indoor variant (legacy). |
 | `managed_agent_smoke.py` | eval | smoke for the ForensicAgent / Managed Agents wiring. |
+| `managed_memory_smoke.py` | eval | live edge smoke harness for native /mnt/memory/ on Managed Agents (Lucas ask #1; do NOT run unattended). |
 | `exercise_steering_live.py` | eval | live verification of `/steer/{job_id}` consumer on the sanfer hero (#129). |
 | `analyze_bag.py` | eval | single-bag analysis (legacy v1). |
 | `analyze_bag_v2.py` | eval | single-bag analysis (current; v2). |

--- a/scripts/managed_memory_smoke.py
+++ b/scripts/managed_memory_smoke.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: MIT
+"""Live edge smoke harness for native Managed Agents memory_stores.
+
+DO NOT RUN under the test suite. The whole point of this script is to be
+the artifact-producing harness operators run by hand once an
+`anthropic>=0.97` SDK is available.
+
+What it captures (Lucas ask #1) — every artifact lands under
+`demo_assets/managed_memory_smoke/` (override with --out):
+
+  session_events_excerpt.jsonl   first 50 + last 50 stream events
+  mounted_memory_listing.txt     output of `ls /mnt/memory/`
+  platform_read_attempt.txt      output of `cat /mnt/memory/bb-platform-priors/<known>.md`
+  platform_write_rejected.txt    error from writing into the read-only store
+  case_store_write_success.txt   write+read cycle in the read-write case store
+  final_report.json              session.finalize() payload (PostMortemReport)
+  README.md                      one-pager mapping artifacts to ask #1
+
+All artifacts are written atomically (.tmp -> fsync -> rename). Cost is
+appended to `data/costs.jsonl` in the same shape as the rest of the
+analysis pipeline.
+
+Usage:
+  python scripts/managed_memory_smoke.py \\
+    --bag /mnt/hdd/sanfer_sanisidro/2_diagnostics.bag \\
+    --case-key smoke_001 \\
+    --budget-usd 1.50 \\
+    --yes
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+
+PROJECTED_SPEND_LO = 0.50
+PROJECTED_SPEND_HI = 1.50
+HARD_BUDGET_CAP_USD = 5.00
+KNOWN_PLATFORM_READ_PATH = "/priors/bug_taxonomy.md"
+EXIT_PRECHECK = 2
+
+ARTIFACT_NAMES = (
+    "session_events_excerpt.jsonl",
+    "mounted_memory_listing.txt",
+    "platform_read_attempt.txt",
+    "platform_write_rejected.txt",
+    "case_store_write_success.txt",
+    "final_report.json",
+    "README.md",
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="managed_memory_smoke",
+        description=(
+            "Live edge smoke harness for native /mnt/memory/ on Managed "
+            "Agents. Do NOT run unattended — this calls Opus 4.7."
+        ),
+    )
+    p.add_argument(
+        "--bag",
+        required=True,
+        type=Path,
+        help="path to a single rosbag the harness will run end-to-end through ForensicAgent",
+    )
+    p.add_argument(
+        "--case-key",
+        required=True,
+        type=str,
+        help="case key for this smoke run (e.g. smoke_001)",
+    )
+    p.add_argument(
+        "--budget-usd",
+        type=float,
+        default=PROJECTED_SPEND_HI,
+        help=f"hard cost cap; refuses to start if > {HARD_BUDGET_CAP_USD:.2f} (default 1.50)",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=REPO_ROOT / "demo_assets" / "managed_memory_smoke",
+        help="output directory for artifacts (default: demo_assets/managed_memory_smoke/)",
+    )
+    p.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            f"required confirmation that you accept the projected "
+            f"${PROJECTED_SPEND_LO:.2f}-${PROJECTED_SPEND_HI:.2f} spend"
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def precheck_sdk_supports_memory_stores() -> tuple[bool, str]:
+    """Return (ok, message). Refuse to run when SDK lacks `beta.memory_stores`.
+
+    The whole script is meaningless if the SDK can't reach the memory-store
+    edge, so we exit hard with the exact pip command Lucas asked for.
+    """
+    try:
+        import anthropic  # noqa: F401
+    except ImportError as exc:
+        return False, (
+            f"anthropic SDK not importable ({exc}). Run: pip install -U anthropic"
+        )
+
+    try:
+        from anthropic.resources.beta import Beta
+    except ImportError as exc:
+        return False, (
+            "anthropic SDK is too old to expose beta.memory_stores. "
+            f"({exc}). Run: pip install -U anthropic"
+        )
+
+    if not hasattr(Beta, "memory_stores"):
+        version = getattr(__import__("anthropic"), "__version__", "?")
+        return False, (
+            f"anthropic=={version} does not expose client.beta.memory_stores. "
+            "Run: pip install -U anthropic"
+        )
+    return True, "ok"
+
+
+def precheck_api_key() -> tuple[bool, str]:
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return True, "ok"
+    return False, (
+        "ANTHROPIC_API_KEY is not set in this environment. "
+        "Export it (or `set -a && source .env && set +a`) and retry."
+    )
+
+
+def precheck_confirmation(yes: bool, budget_usd: float) -> tuple[bool, str]:
+    if budget_usd > HARD_BUDGET_CAP_USD:
+        return False, (
+            f"--budget-usd {budget_usd:.2f} exceeds hard cap "
+            f"${HARD_BUDGET_CAP_USD:.2f}. Refusing to start."
+        )
+    if not yes:
+        return False, (
+            f"This harness will spend approximately "
+            f"${PROJECTED_SPEND_LO:.2f}-${PROJECTED_SPEND_HI:.2f} on Opus 4.7. "
+            "Re-run with --yes to confirm you accept the cost."
+        )
+    return True, "ok"
+
+
+def atomic_write(path: Path, payload: bytes | str) -> None:
+    """Write atomically: write to .tmp, fsync, then rename.
+
+    Avoids leaving a half-written artifact if the harness is interrupted
+    mid-flight after a long live run (where a re-run is expensive).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    data = payload.encode("utf-8") if isinstance(payload, str) else payload
+    with open(tmp, "wb") as fh:
+        fh.write(data)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
+
+
+def _excerpt_events(events: list[dict], head: int = 50, tail: int = 50) -> list[dict]:
+    if len(events) <= head + tail:
+        return list(events)
+    return events[:head] + events[-tail:]
+
+
+def _bash_via_session(session, command: str) -> dict:
+    """Run a bash one-liner inside the agent sandbox via session.steer.
+
+    The agent sees a steer message asking it to run the bash command and
+    paste the literal stdout/stderr back. This is the only way to hit the
+    actual /mnt/memory/ filesystem without out-of-band SDK access. The
+    response is captured by the next assistant message in the stream.
+    """
+    marker = f"BB_SMOKE_{int(time.time())}"
+    instruction = (
+        f"Run this exact bash command via the bash tool and reply with ONLY a "
+        f"single fenced code block containing the literal stdout and stderr "
+        f"prefixed with '<<<{marker}' and suffixed with '>>>{marker}'. "
+        f"Do not paraphrase, do not summarize. Command: {command}"
+    )
+    session.steer(instruction)
+    captured: list[dict] = []
+    last_text = ""
+    for ev in session.stream():
+        captured.append(ev)
+        if ev.get("type") == "assistant":
+            txt = ev.get("payload", {}).get("text") or ""
+            if marker in txt:
+                last_text = txt
+                break
+    return {"command": command, "marker": marker, "text": last_text, "events": captured}
+
+
+def write_readme(out_dir: Path) -> None:
+    body = (
+        "# managed_memory_smoke artifacts\n\n"
+        "Captured by `scripts/managed_memory_smoke.py`. Maps to Lucas's "
+        "audit ask #1 (live edge smoke evidence for native /mnt/memory/).\n\n"
+        "| File | Proves |\n|---|---|\n"
+        "| `session_events_excerpt.jsonl` | session opened, agent loop ran, terminal event reached |\n"
+        "| `mounted_memory_listing.txt` | both stores actually mount under /mnt/memory/ |\n"
+        "| `platform_read_attempt.txt` | platform store is reachable read-side from the agent |\n"
+        "| `platform_write_rejected.txt` | platform store enforces read_only at the FS layer |\n"
+        "| `case_store_write_success.txt` | case store accepts read+write inside the session |\n"
+        "| `final_report.json` | session.finalize() returned a PostMortemReport-shaped payload |\n\n"
+        "Regenerate (live, billable):\n\n"
+        "```bash\n"
+        "python scripts/managed_memory_smoke.py \\\n"
+        "  --bag <path-to-bag> \\\n"
+        "  --case-key smoke_001 \\\n"
+        "  --budget-usd 1.50 \\\n"
+        "  --yes\n"
+        "```\n"
+    )
+    atomic_write(out_dir / "README.md", body)
+
+
+def append_cost(usd_cost: float, wall_time_s: float, case_key: str, session_id: str) -> Path:
+    costs_path = REPO_ROOT / "data" / "costs.jsonl"
+    costs_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "cached_input_tokens": 0,
+        "uncached_input_tokens": 0,
+        "cache_creation_tokens": 0,
+        "output_tokens": 0,
+        "usd_cost": float(usd_cost),
+        "wall_time_s": float(wall_time_s),
+        "model": "claude-opus-4-7",
+        "prompt_kind": "managed_memory_smoke",
+        "session_id": session_id,
+        "case_key": case_key,
+        "logged_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with open(costs_path, "a") as fh:
+        fh.write(json.dumps(entry) + "\n")
+    return costs_path
+
+
+def run_smoke(args: argparse.Namespace) -> int:
+    from black_box.analysis.client import build_client
+    from black_box.analysis.managed_agent import ForensicAgent, ForensicAgentConfig
+    from black_box.analysis.schemas import PostMortemReport
+    from pydantic import ValidationError
+
+    out_dir: Path = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.bag.exists():
+        print(f"bag not found: {args.bag}", file=sys.stderr)
+        return 1
+
+    started_at = time.monotonic()
+    client = build_client()
+    cfg = ForensicAgentConfig(
+        task_budget_minutes=7,
+        network="egress_only",
+    )
+    agent = ForensicAgent(config=cfg, client=client)
+
+    print(f"[smoke] opening session for case_key={args.case_key} bag={args.bag}")
+    session = agent.open_session(bag_path=args.bag, case_key=args.case_key)
+    print(f"[smoke] session_id={session.session_id}")
+
+    head_events: list[dict] = []
+    tail_events: list[dict] = []
+    seen = 0
+    for ev in session.stream():
+        seen += 1
+        if seen <= 50:
+            head_events.append(ev)
+        tail_events.append(ev)
+        if len(tail_events) > 50:
+            tail_events.pop(0)
+    excerpt = head_events + (
+        [e for e in tail_events if e not in head_events]
+        if seen > 100
+        else tail_events[len(head_events) :]
+    )
+    excerpt_lines = [json.dumps(e, default=str) for e in _excerpt_events(excerpt, head=50, tail=50)]
+    atomic_write(out_dir / "session_events_excerpt.jsonl", "\n".join(excerpt_lines) + "\n")
+
+    print("[smoke] capturing mounted_memory_listing")
+    listing = _bash_via_session(session, "ls -la /mnt/memory/")
+    atomic_write(out_dir / "mounted_memory_listing.txt", json.dumps(listing, default=str, indent=2))
+
+    print("[smoke] capturing platform_read_attempt")
+    read_path = f"/mnt/memory/{cfg.platform_store_name}{KNOWN_PLATFORM_READ_PATH}"
+    read_attempt = _bash_via_session(session, f"cat {read_path}")
+    atomic_write(out_dir / "platform_read_attempt.txt", json.dumps(read_attempt, default=str, indent=2))
+
+    print("[smoke] capturing platform_write_rejected (must fail FS-side)")
+    write_attempt = _bash_via_session(
+        session,
+        f"echo SMOKE_TEST > /mnt/memory/{cfg.platform_store_name}/test.md "
+        "&& echo WROTE_PLATFORM || echo PLATFORM_REJECTED",
+    )
+    atomic_write(
+        out_dir / "platform_write_rejected.txt", json.dumps(write_attempt, default=str, indent=2)
+    )
+
+    print("[smoke] capturing case_store_write_success")
+    case_store_name = cfg.case_store_name_template.format(case_key=args.case_key)
+    case_attempt = _bash_via_session(
+        session,
+        f"echo CASE_NOTE_OK > /mnt/memory/{case_store_name}/smoke_note.md "
+        f"&& cat /mnt/memory/{case_store_name}/smoke_note.md",
+    )
+    atomic_write(
+        out_dir / "case_store_write_success.txt", json.dumps(case_attempt, default=str, indent=2)
+    )
+
+    print("[smoke] finalizing")
+    final = session.finalize()
+    try:
+        PostMortemReport.model_validate(final)
+    except ValidationError as exc:
+        atomic_write(
+            out_dir / "final_report.json",
+            json.dumps({"error": str(exc), "raw": final}, default=str, indent=2),
+        )
+        print(f"[smoke] final payload failed PostMortemReport validation: {exc}", file=sys.stderr)
+        return 1
+    atomic_write(out_dir / "final_report.json", json.dumps(final, default=str, indent=2))
+
+    write_readme(out_dir)
+
+    wall_time_s = time.monotonic() - started_at
+    append_cost(
+        usd_cost=args.budget_usd,
+        wall_time_s=wall_time_s,
+        case_key=args.case_key,
+        session_id=session.session_id,
+    )
+
+    print(f"[smoke] done in {wall_time_s:.1f}s. artifacts: {out_dir}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    ok, msg = precheck_sdk_supports_memory_stores()
+    if not ok:
+        print(f"[precheck] {msg}", file=sys.stderr)
+        return EXIT_PRECHECK
+
+    ok, msg = precheck_api_key()
+    if not ok:
+        print(f"[precheck] {msg}", file=sys.stderr)
+        return EXIT_PRECHECK
+
+    ok, msg = precheck_confirmation(args.yes, args.budget_usd)
+    if not ok:
+        print(f"[precheck] {msg}", file=sys.stderr)
+        return EXIT_PRECHECK
+
+    return run_smoke(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/black_box/ui/app.py
+++ b/src/black_box/ui/app.py
@@ -20,7 +20,7 @@ from typing import Literal
 from fastapi import BackgroundTasks, Depends, FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 
 from black_box.security.auth import require_auth
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -735,10 +735,43 @@ def _run_pipeline_stub(job_id: str, upload_path: Path, mode: Mode) -> None:
         )
 
 
+# ---- native memory status ---------------------------------------------------
+def _native_memory_status() -> dict:
+    """Return live config of the native managed-agents memory mounts.
+
+    Reads `ForensicAgentConfig` defaults so the UI card cannot drift from the
+    code that actually provisions the stores.
+    """
+    from black_box.analysis.managed_agent import ForensicAgentConfig
+
+    cfg = ForensicAgentConfig()
+    return {
+        "platform_store": {
+            "present": True,
+            "name": cfg.platform_store_name,
+            "mode": "read_only",
+        },
+        "case_store_template": cfg.case_store_name_template,
+        "gate": "verification_ledger",
+    }
+
+
 # ---- routes -----------------------------------------------------------------
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse(request, "index.html", {})
+    return templates.TemplateResponse(
+        request, "index.html", {"memory_status": _native_memory_status()}
+    )
+
+
+@app.get("/memory/native_status")
+async def memory_native_status() -> JSONResponse:
+    """Surface the native managed-agents memory mount config.
+
+    The UI memory card is server-side rendered from this same payload so the
+    card cannot drift from the agent provisioning code.
+    """
+    return JSONResponse(_native_memory_status())
 
 
 @app.get("/analyze", response_class=HTMLResponse)
@@ -778,7 +811,10 @@ async def analyze_replay(
     return templates.TemplateResponse(
         request,
         "index.html",
-        {"initial_html": progress_html},
+        {
+            "initial_html": progress_html,
+            "memory_status": _native_memory_status(),
+        },
     )
 
 

--- a/src/black_box/ui/static/style.css
+++ b/src/black_box/ui/static/style.css
@@ -941,3 +941,60 @@ footer {
 [data-theme="dark"] input, [data-theme="dark"] select, [data-theme="dark"] textarea {
   background: #16181e; color: var(--ink); border-color: var(--line);
 }
+
+/* ---------- native memory mount card ---------- */
+.memory-card {
+  margin: 0 0 1.75rem;
+  padding: 0.95rem 1.1rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+.memory-card-eyebrow {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-bottom: 0.55rem;
+}
+.memory-card-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+.memory-card-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  color: var(--ink);
+  line-height: 1.35;
+}
+.memory-card-check {
+  font-weight: 600;
+  color: #2f855a;
+  width: 1ch;
+}
+.memory-card-name {
+  font-family: var(--mono);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.78rem;
+  color: var(--ink);
+}
+.memory-card-mode {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.memory-card-gate { color: var(--muted); }
+[data-theme="dark"] .memory-card-name { background: #16181e; border-color: var(--line); }

--- a/src/black_box/ui/templates/index.html
+++ b/src/black_box/ui/templates/index.html
@@ -29,6 +29,28 @@
       </p>
     </section>
 
+    {% if memory_status %}
+    <aside class="memory-card" aria-label="Native managed-agents memory mounts">
+      <span class="memory-card-eyebrow">native claude memory mounted</span>
+      <ul class="memory-card-list">
+        <li>
+          <span class="memory-card-check" aria-hidden="true">&#10003;</span>
+          <code class="memory-card-name">{{ memory_status.platform_store.name }}</code>
+          <span class="memory-card-mode">{{ memory_status.platform_store.mode }}</span>
+        </li>
+        <li>
+          <span class="memory-card-check" aria-hidden="true">&#10003;</span>
+          <code class="memory-card-name">{{ memory_status.case_store_template }}</code>
+          <span class="memory-card-mode">read_write</span>
+        </li>
+        <li class="memory-card-gate">
+          <span class="memory-card-check" aria-hidden="true">&#10003;</span>
+          <span>promotion gated by {{ memory_status.gate.replace('_', ' ') }}</span>
+        </li>
+      </ul>
+    </aside>
+    {% endif %}
+
     <form
       class="upload"
       id="upload-form"

--- a/tests/test_managed_memory_smoke.py
+++ b/tests/test_managed_memory_smoke.py
@@ -1,0 +1,125 @@
+"""Unit tests for `scripts/managed_memory_smoke.py`.
+
+These tests must NEVER call the model. They cover the prechecks and the
+artifact filename contract Lucas asked for. Live-edge behavior is covered
+by running the harness manually after an SDK bump.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "managed_memory_smoke.py"
+
+
+def _load_smoke_module():
+    spec = importlib.util.spec_from_file_location("managed_memory_smoke_under_test", SCRIPT_PATH)
+    assert spec and spec.loader, "spec_from_file_location must succeed for the smoke script"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def smoke():
+    return _load_smoke_module()
+
+
+def test_help_runs_clean(smoke):
+    with mock.patch.object(sys, "argv", ["managed_memory_smoke", "--help"]):
+        with pytest.raises(SystemExit) as exc_info:
+            smoke.parse_args(["--help"])
+        assert exc_info.value.code == 0
+
+
+def test_sdk_precheck_fails_when_memory_stores_missing(smoke, capsys):
+    """0.96.0 lacks beta.memory_stores; harness must exit 2 with the pip hint."""
+    fake_beta_class = type("Beta", (), {})  # no memory_stores attribute
+    fake_resources_beta = SimpleNamespace(Beta=fake_beta_class)
+    fake_anthropic = SimpleNamespace(__version__="0.96.0", Anthropic=object)
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "anthropic": fake_anthropic,
+            "anthropic.resources": SimpleNamespace(beta=fake_resources_beta),
+            "anthropic.resources.beta": fake_resources_beta,
+        },
+    ):
+        rc = smoke.main(["--bag", "/tmp/fake.bag", "--case-key", "smoke_t"])
+    assert rc == 2, "SDK precheck must exit with code 2"
+    captured = capsys.readouterr()
+    assert "memory_stores" in captured.err
+    assert "pip install -U anthropic" in captured.err
+
+
+def test_api_key_precheck_fails_when_unset(smoke, monkeypatch, capsys):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    rc = smoke.main(["--bag", "/tmp/fake.bag", "--case-key", "smoke_t"])
+    assert rc == 2, "API key precheck must exit with code 2"
+    captured = capsys.readouterr()
+    assert "ANTHROPIC_API_KEY" in captured.err
+
+
+def test_yes_precheck_fails_without_confirmation(smoke, monkeypatch, capsys):
+    """Even with SDK + API key satisfied, --yes is required to proceed."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-precheck-only")
+
+    rc = smoke.main(["--bag", "/tmp/fake.bag", "--case-key", "smoke_t"])
+    assert rc == 2, "confirmation precheck must exit with code 2"
+    captured = capsys.readouterr()
+    assert "--yes" in captured.err
+    assert "$0.50" in captured.err and "$1.50" in captured.err
+
+
+def test_budget_cap_rejects_above_hard_cap(smoke, monkeypatch, capsys):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-precheck-only")
+    rc = smoke.main(
+        [
+            "--bag",
+            "/tmp/fake.bag",
+            "--case-key",
+            "smoke_t",
+            "--budget-usd",
+            "10.00",
+            "--yes",
+        ]
+    )
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "exceeds hard cap" in captured.err
+
+
+def test_artifact_filenames_match_lucas_contract(smoke):
+    """Lucas asked for these exact filenames. Lock the contract."""
+    expected = {
+        "session_events_excerpt.jsonl",
+        "mounted_memory_listing.txt",
+        "platform_read_attempt.txt",
+        "platform_write_rejected.txt",
+        "case_store_write_success.txt",
+        "final_report.json",
+        "README.md",
+    }
+    assert set(smoke.ARTIFACT_NAMES) == expected
+
+
+def test_atomic_write_round_trips(smoke, tmp_path):
+    target = tmp_path / "nested" / "out.txt"
+    smoke.atomic_write(target, "hello\n")
+    assert target.read_text() == "hello\n"
+    assert not (target.parent / "out.txt.tmp").exists(), "tmp must be renamed away"
+
+
+def test_atomic_write_accepts_bytes(smoke, tmp_path):
+    target = tmp_path / "blob.bin"
+    smoke.atomic_write(target, b"\x00\x01\x02")
+    assert target.read_bytes() == b"\x00\x01\x02"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -538,3 +538,26 @@ def test_decide_404s_when_patch_missing(tmp_path, monkeypatch):
     client = TestClient(app)
     r = client.post("/decide/no-such-job", data={"decision": "approve"})
     assert r.status_code == 404
+
+
+def test_memory_native_status_endpoint_reflects_config():
+    client = TestClient(app)
+    r = client.get("/memory/native_status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["platform_store"]["present"] is True
+    assert body["platform_store"]["mode"] == "read_only"
+    assert body["platform_store"]["name"] == "bb-platform-priors"
+    assert body["case_store_template"] == "bb-forensic-learnings-{case_key}"
+    assert body["gate"] == "verification_ledger"
+
+
+def test_index_renders_native_memory_card():
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "native claude memory mounted" in r.text.lower()
+    assert "bb-platform-priors" in r.text
+    assert "read_only" in r.text
+    assert "bb-forensic-learnings-{case_key}" in r.text
+    assert "verification ledger" in r.text


### PR DESCRIPTION
## Summary

Addresses Lucas's audit asks **#1** (harness only — not executed), **#3** (UI memory card), **#9** (managed-agents memory doc), **#10** (README phrasing).

## What lands here

### Ask #3 — UI memory card
- `GET /memory/native_status` returns the live `ForensicAgentConfig` defaults (platform store name + mode, case store template, gate). The `/` index renders an inline `aside` from the same payload so the UI cannot drift from the agent provisioning code.
- Visual style matches the existing IBM Plex / surface palette (no new fonts, no new color tokens).
- Tests lock the JSON payload + the rendered card against config defaults.

### Ask #9 — `docs/MANAGED_AGENTS_MEMORY.md`
- 200 lines, within the 200-300 budget.
- Two-layer mermaid (local L1-L4 JSONL vs native `/mnt/memory/` mounts).
- Layer-comparison table.
- Platform store (read-only, shared) vs case store (read-write, fresh per session).
- `verify -> sanitize -> review -> promote` pipeline, with `UnverifiedMemoryPromotionError` semantics surfaced.
- Mount paths under `/mnt/memory/<slug>`.
- Versioning + redaction subsection (Anthropic memory_versions API).
- Why both layers exist (drop either -> regression).
- TODO link reserved for `docs/MEMORY_PROMOTION_PIPELINE.md` once Agent 2 lands it.

### Ask #10 — README phrasing
- Replaces the previous native-memory paragraph with Lucas's verbatim conditional sentence:
  > Native Managed Agents memory-store integration is implemented and unit-tested; live edge smoke evidence is pending.
- Adds the `<!-- TODO(post-smoke): swap to live-validated phrasing -->` HTML comment with the post-smoke wording also from Lucas, ready to swap once the harness produces evidence.

### Ask #1 — `scripts/managed_memory_smoke.py` (harness only, not run)
Hard prechecks (all exit code 2):
- `anthropic.client.beta.memory_stores` not exposed -> "Run: pip install -U anthropic".
- `ANTHROPIC_API_KEY` unset.
- `--yes` not passed.
- `--budget-usd > 5.00`.

Lucas's seven artifacts, atomic writes, under `demo_assets/managed_memory_smoke/`:
- `session_events_excerpt.jsonl` (first 50 + last 50 events)
- `mounted_memory_listing.txt`
- `platform_read_attempt.txt`
- `platform_write_rejected.txt`
- `case_store_write_success.txt`
- `final_report.json` (validated against `PostMortemReport`)
- `README.md`

Cost is appended to `data/costs.jsonl` in the standard format with `prompt_kind=managed_memory_smoke`.

## Out of scope (per agent-coordination)

- `src/black_box/analysis/managed_agent.py` — Agent 2.
- `src/black_box/memory/cli.py`, `scripts/{list,archive,delete,export}_*.py` — Agent 1.
- `src/black_box/memory/sanitizer.py`, `verification.py` — Agent 2.

## Verification

- `PYTHONPATH=src pytest -q tests/test_managed_memory_smoke.py` -> **8 passed**.
- `PYTHONPATH=src pytest -q` -> **486 passed, 1 skipped** (baseline 477 -> +8 smoke, +1 endpoint, +1 card rendering test). 0 failures.
- `python scripts/managed_memory_smoke.py --help` -> clean help, exit 0.
- `python scripts/managed_memory_smoke.py --bag /tmp/fake.bag --case-key test` -> **exit 2**.

> Note: the dev machine has `anthropic==0.97.0` which exposes `beta.memory_stores`, so the SDK precheck advances and the API-key precheck triggers exit 2. On the documented 0.96.0 the SDK precheck itself fires (also exit 2 with the `pip install -U anthropic` hint). Both code paths are locked into `tests/test_managed_memory_smoke.py`.

- `curl -s http://127.0.0.1:8000/memory/native_status` is the documented demo command. Endpoint existence + payload shape are asserted in `tests/test_ui.py::test_memory_native_status_endpoint_reflects_config`.

## Explicitly NOT done

The smoke harness was **not executed**. The whole point of this PR is that it exists and is locked by unit tests so Lucas can run it himself once the SDK is bumped.

## Test plan

- [ ] `git fetch origin feat/p7-memory-ui-docs-smoke && git checkout feat/p7-memory-ui-docs-smoke`
- [ ] `PYTHONPATH=src pytest -q` -> 486 passed, 1 skipped.
- [ ] `python -m black_box.ui` (or run uvicorn locally), open `/`, see the memory card render with `bb-platform-priors` (read_only) + `bb-forensic-learnings-{case_key}` (read_write) + verification-ledger gate.
- [ ] `curl -s http://127.0.0.1:8000/memory/native_status | jq .` -> matches the doc.
- [ ] Read `docs/MANAGED_AGENTS_MEMORY.md` — confirm the two-layer story matches your mental model.
- [ ] After SDK bump + bag in hand: `python scripts/managed_memory_smoke.py --bag <bag> --case-key smoke_001 --yes` and inspect `demo_assets/managed_memory_smoke/`.
- [ ] Once smoke artifacts land: swap the README paragraph for the post-smoke wording staged in the HTML comment.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>