### PR TITLE
demo: silent 3-min cut assembled from editor raw footage pack

### DIFF
--- a/demo_assets/editor_raw_footage_pack/assembled/README.md
+++ b/demo_assets/editor_raw_footage_pack/assembled/README.md
@@ -1,0 +1,40 @@
+# Combined silent cut — v1
+
+Assembled from the 20 raw clips in `../clips/` per the manifest's `suggested_beat`
+fields. Silent on purpose — VO (ElevenLabs) is muxed downstream.
+
+**Output:** `blackbox_demo_combined_silent_v1.mp4` — 1920x1080, 30fps, h264, ~2:43, ~53MB.
+
+**Build:** `bash build_combined.sh` (re-runs ffmpeg over `../clips/` → `/tmp/bb_combined/`).
+
+## Cut order
+
+| # | Beat | Source clip | Trim |
+|---|------|-------------|------|
+|  1 | Hook: real robot footage         | `13_sanfer_real_camera_broll.mp4`        | 10.0s |
+|  2 | Operator-facing intake           | `01_intake_upload_ui.mp4`                | 10.0s |
+|  3 | Live analysis running            | `02_live_analysis_ui.mp4`                | 14.0s |
+|  4 | Managed agent stream             | `03_managed_agent_stream_ui.mp4`         | 12.0s |
+|  5 | Verdict reveal                   | `04_report_overview_ui.mp4`              | 13.0s |
+|  6 | Operator vs BlackBox refutation  | `09_operator_refutation_report.mp4`      | 11.0s |
+|  7 | RTK root-cause evidence          | `10_rtk_root_cause_charts.mp4`           | 13.0s |
+|  8 | Scoped patch / human review      | `06_patch_diff_ui.mp4`                   | 12.0s |
+|  9 | Opus 4.7 model delta             | `17_opus47_delta_doc_scroll.mp4`         | 14.0s |
+| 10 | 4.6 vs 4.7 vision detail         | `20_vision_ab_artifact.mp4`              |  8.0s |
+| 11 | Breadth: cases archive           | `07_cases_archive_ui.mp4`                | 12.0s |
+| 12 | Second car run                   | `16_other_car_run_broll.mp4`             |  9.0s |
+| 13 | Robotic boat case                | `15_boat_report_broll.mp4`               |  9.0s |
+| 14 | Grounding gate (refuses to invent) | `08_grounding_gate_ui.mp4`             | 10.0s |
+| 15 | Delta panel close                | `19_opus47_delta_panel_real_capture.mp4` |  6.5s |
+
+Total target: 163.5s.
+
+## Skipped (overlap with picks)
+
+- `05_report_exhibits_ui.mp4` — covered by 04
+- `11_sanfer_pdf_scroll.mp4` — covered by 04 + 10
+- `12_telemetry_files_broll.mp4` — covered by 13 + 16
+- `14_multicam_composite_real.mp4` — covered by 13
+- `18_opus47_delta_artifacts_folder.mp4` — covered by 17 + 19
+
+Easy to swap any in by editing the `SLOTS` array in `build_combined.sh`.

--- a/demo_assets/editor_raw_footage_pack/assembled/build_combined.sh
+++ b/demo_assets/editor_raw_footage_pack/assembled/build_combined.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Assemble a ~3-min silent demo from Lucas's editor raw footage pack.
+set -euo pipefail
+CLIPS="/tmp/bb_editor_pack/demo_assets/editor_raw_footage_pack/clips"
+TMP="/tmp/bb_combined/work"; rm -rf "$TMP"; mkdir -p "$TMP"
+OUT_DIR="/tmp/bb_combined"
+OUT="$OUT_DIR/blackbox_demo_combined_silent.mp4"
+
+# Each entry: source_clip target_duration_seconds
+# Total target ~ 172s
+declare -a SLOTS=(
+  "13_sanfer_real_camera_broll.mp4 10.0"        # 1. hook: real robot footage
+  "01_intake_upload_ui.mp4         10.0"        # 2. operator intake
+  "02_live_analysis_ui.mp4         14.0"        # 3. analysis running
+  "03_managed_agent_stream_ui.mp4  12.0"        # 4. managed agent
+  "04_report_overview_ui.mp4       13.0"        # 5. verdict reveal
+  "09_operator_refutation_report.mp4 11.0"      # 6. operator vs BB refutation
+  "10_rtk_root_cause_charts.mp4    13.0"        # 7. root-cause evidence
+  "06_patch_diff_ui.mp4            12.0"        # 8. scoped patch
+  "17_opus47_delta_doc_scroll.mp4  14.0"        # 9. model delta
+  "20_vision_ab_artifact.mp4       8.0"         # 10. vision A/B
+  "07_cases_archive_ui.mp4         12.0"        # 11. breadth
+  "16_other_car_run_broll.mp4      9.0"         # 12. second car
+  "15_boat_report_broll.mp4        9.0"         # 13. boat case
+  "08_grounding_gate_ui.mp4        10.0"        # 14. refuses to invent
+  "19_opus47_delta_panel_real_capture.mp4 6.5"  # 15. close
+)
+
+norm() {
+  local src="$1" dst="$2" dur="$3"
+  ffmpeg -y -hide_banner -loglevel error -i "$src" -an \
+    -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2:color=#0a0c10,fps=30,format=yuv420p" \
+    -t "$dur" -c:v libx264 -preset veryfast -crf 18 -movflags +faststart "$dst"
+}
+
+i=1
+for entry in "${SLOTS[@]}"; do
+  read -r name dur <<<"$entry"
+  printf "[%02d/%d] %-40s -> %4ss\n" "$i" "${#SLOTS[@]}" "$name" "$dur"
+  norm "$CLIPS/$name" "$TMP/$(printf '%02d' $i).mp4" "$dur"
+  i=$((i+1))
+done
+
+LIST="$TMP/list.txt"; : > "$LIST"
+for f in "$TMP"/*.mp4; do
+  [[ "$f" == "$LIST" ]] && continue
+  echo "file '$f'" >> "$LIST"
+done
+
+echo "[concat]"
+ffmpeg -y -hide_banner -loglevel error -f concat -safe 0 -i "$LIST" \
+  -c:v libx264 -preset veryfast -crf 18 -pix_fmt yuv420p -movflags +faststart "$OUT"
+
+dur=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$OUT")
+size=$(du -h "$OUT" | cut -f1)
+printf "\nOK -> %s\n  duration: %ss\n  size:     %s\n" "$OUT" "$dur" "$size"


### PR DESCRIPTION
## Summary
- Assembled `blackbox_demo_combined_silent_v1.mp4` (2:43, 1080p30, 53MB) from the 20 raw clips in `demo_assets/editor_raw_footage_pack/clips/`.
- 15 clips picked, 5 redundant ones skipped — order matches the manifest's `suggested_beat` fields.
- Silent on purpose: ElevenLabs VO is muxed downstream.
- Deterministic build script (`build_combined.sh`) so the cut is reproducible from the same source clips.

Cut order, skipped clips, and trim durations are documented in `demo_assets/editor_raw_footage_pack/assembled/README.md`.

## Heads-up
- `02_live_analysis_ui` shows up partly unstyled at t≈30s — looks like a mid-render or stripped-stylesheet capture. Worth a quick look before shipping; easy to swap or re-record.

## Test plan
- [ ] `open demo_assets/editor_raw_footage_pack/assembled/blackbox_demo_combined_silent_v1.mp4` and skim
- [ ] Confirm the beat order tracks the planned VO script
- [ ] Decide whether to re-record clip `02` or trim around the unstyled stretch

🤖 Generated with [Claude Code](https://claude.com/claude-code)